### PR TITLE
Use OpenAI client for report summary generation

### DIFF
--- a/src/run_agent.py
+++ b/src/run_agent.py
@@ -75,12 +75,12 @@ async def main(model_name, feedback_model_name, dataset, tags, val_metric, root_
         provider=OpenAIProvider(openai_client=client)
     )
 
-    await run_agentomics(config=config, default_model=model, feedback_model=feedback_model)
+    await run_agentomics(config=config, default_model=model, feedback_model=feedback_model, openai_client=client)
 
     if(wandb_logged_in):
         wandb.finish()
 
-async def run_agentomics(config: Config, default_model, feedback_model):
+async def run_agentomics(config: Config, default_model, feedback_model, openai_client):
     all_feedbacks = []
     feedback = None
     print(f"Starting training loop with {config.iterations} iterations")
@@ -160,7 +160,7 @@ async def run_agentomics(config: Config, default_model, feedback_model):
                 )
         finally:
             add_metrics_to_report(config, run_index)
-            await add_summary_to_report(config, run_index)
+            await add_summary_to_report(config, run_index, openai_client)
             log_files(config, iteration=run_index)
         
     print("\nRunning final test evaluation...")

--- a/src/utils/report_logger.py
+++ b/src/utils/report_logger.py
@@ -8,11 +8,7 @@ def wrap_text(text, width=100):
     return '\n'.join(textwrap.fill(line, width) for line in str(text).split('\n'))
 
 
-async def generate_summary(config, report_content):
-    client = AsyncOpenAI(
-        base_url='https://openrouter.ai/api/v1',
-        api_key=openrouter_api_key
-    )
+async def generate_summary(config, report_content, client: AsyncOpenAI):
     
     response = await client.chat.completions.create(
         model=config.model_name,
@@ -25,7 +21,7 @@ async def generate_summary(config, report_content):
     return response.choices[0].message.content.strip()
 
 
-async def add_summary_to_report(config, iteration):
+async def add_summary_to_report(config, iteration, client: AsyncOpenAI):
     report_dir = config.reports_dir / config.agent_id
     report_dir.mkdir(parents=True, exist_ok=True)
     report_file = report_dir / f"run_report_iter_{iteration}.txt"
@@ -33,7 +29,7 @@ async def add_summary_to_report(config, iteration):
     with open(report_file, 'r') as f:
         content = f.read()
     
-    summary = await generate_summary(config, content)
+    summary = await generate_summary(config, content, client)
     wrapped_summary = wrap_text(summary, 100)
     
     with open(report_file, 'w') as f:


### PR DESCRIPTION
Inject the existing OpenAI client into report_logger for summary generation, replacing env-based key access and fixing the NameError. Pass the client through run_agent to add_summary_to_report