### PR TITLE
Fix agent permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV PIP_NO_CACHE_DIR=1
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1
 
 # Install sudo for later creation of the agent user
-RUN apt-get update && apt-get install -y sudo && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y acl && rm -rf /var/lib/apt/lists/*
 
 # Copy & create your conda environment\ using environment.yaml (with mamba for speed and memory efficiency)
 COPY environment.yaml .

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,10 @@ ENV PIP_NO_CACHE_DIR=1
 # Suppress pip version warnings
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1
 
-# Install sudo for later creation of the agent user
-RUN apt-get update && apt-get install -y acl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && rm -rf /var/lib/apt/lists/*
+
+# Agent user cannot change to root
+RUN echo 'root:ACWDBBXmbvjbxWHcjvri' | chpasswd
 
 # Copy & create your conda environment\ using environment.yaml (with mamba for speed and memory efficiency)
 COPY environment.yaml .

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ The `./run.sh` script automatically handles proxy settings if environment variab
 
 ## GPU settings
 
-If you need to use GPU acceleration with your container, you'll need to configure Docker to access your NVIDIA GPUs.
+GPU support is enabled by default. To use GPU acceleration, you need to configure Docker to access your NVIDIA GPUs:
 
 1. Install the NVIDIA Container Toolkit:
 
@@ -323,28 +323,14 @@ If you need to use GPU acceleration with your container, you'll need to configur
    # https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html
    ```
 
-2. Build the Docker image as per above instructions (add proxy arguments if needed)
-
-3. The `./run.sh` script automatically detects and uses GPU access when available:
+2. Run normally (GPU will be used automatically):
 
    ```
    ./run.sh
    ```
 
-   For manual setup with GPU access:
+If you want to disable GPU support, use the `--cpu-only` flag:
 
    ```
-   docker run -d \
-       --name agentomics-agent \
-       -e OPENROUTER_API_KEY="your-key" \
-       -e WANDB_API_KEY="your-wandb-key" \
-       -e DATASET_NAME="sample_dataset" \
-       -e MODEL_NAME="openai/gpt-4.1" \
-       -e PREPARED_DATASETS_DIR="/repository/prepared_datasets" \
-       -v agentomics-workspace:/workspace \
-       -v $(pwd):/repository \
-       -v $(pwd)/prepared_datasets:/repository/prepared_datasets \
-       --gpus all \
-       --env NVIDIA_VISIBLE_DEVICES=all \
-       agentomics/agentomics:latest
+   ./run.sh --cpu-only
    ```

--- a/run.sh
+++ b/run.sh
@@ -93,7 +93,7 @@ else
             --gpus all \
             --env NVIDIA_VISIBLE_DEVICES=all \
             --entrypoint /opt/conda/envs/agentomics-env/bin/python \
-            agentomics_img -m test.test_gpu_access
+            agentomics_img -m test.run_all_tests
     else
         docker run \
             -it \

--- a/run.sh
+++ b/run.sh
@@ -90,8 +90,10 @@ else
             --name agentomics_test_cont \
             -v "$(pwd)":/repository \
             -v temp_agentomics_volume:/workspace \
+            --gpus all \
+            --env NVIDIA_VISIBLE_DEVICES=all \
             --entrypoint /opt/conda/envs/agentomics-env/bin/python \
-            agentomics_img -m test.test_agent_permissions
+            agentomics_img -m test.test_gpu_access
     else
         docker run \
             -it \
@@ -99,6 +101,8 @@ else
             --name agentomics_cont \
             -v "$(pwd)":/repository \
             -v temp_agentomics_volume:/workspace \
+            --gpus all \
+            --env NVIDIA_VISIBLE_DEVICES=all \
             agentomics_img ${AGENTOMICS_ARGS+"${AGENTOMICS_ARGS[@]}"}
 
         # Copy best-run files and report

--- a/run.sh
+++ b/run.sh
@@ -82,7 +82,7 @@ else
         -it \
         --rm \
         --name agentomics_cont \
-        -v "$(pwd)":/repository:ro \
+            -v "$(pwd)":/repository \
         -v temp_agentomics_volume:/workspace \
         agentomics_img ${AGENTOMICS_ARGS+"${AGENTOMICS_ARGS[@]}"}
 

--- a/run.sh
+++ b/run.sh
@@ -74,6 +74,7 @@ if [ "$LOCAL_MODE" = true ]; then
 else
     docker build -t agentomics_prepare_img -f Dockerfile.prepare .
     docker run \
+        -u $(id -u):$(id -g) \
         --rm \
         -it \
         --name agentomics_prepare_cont \
@@ -88,7 +89,10 @@ else
             -it \
             --rm \
             --name agentomics_test_cont \
-            -v "$(pwd)":/repository \
+            -v "$(pwd)/src":/repository/src:ro \
+            -v "$(pwd)/test":/repository/test:ro \
+            -v "$(pwd)/prepared_datasets":/repository/prepared_datasets:ro \
+            -v "$(pwd)/.env":/repository/.env:ro \
             -v temp_agentomics_volume:/workspace \
             --gpus all \
             --env NVIDIA_VISIBLE_DEVICES=all \
@@ -99,7 +103,9 @@ else
             -it \
             --rm \
             --name agentomics_cont \
-            -v "$(pwd)":/repository \
+            -v "$(pwd)/src":/repository/src:ro \
+            -v "$(pwd)/prepared_datasets":/repository/prepared_datasets:ro \
+            -v "$(pwd)/.env":/repository/.env:ro \
             -v temp_agentomics_volume:/workspace \
             --gpus all \
             --env NVIDIA_VISIBLE_DEVICES=all \
@@ -107,10 +113,10 @@ else
 
         # Copy best-run files and report
         mkdir -p outputs/best_run_files outputs/reports
-        docker run --rm -v temp_agentomics_volume:/source -v $(pwd)/outputs:/dest busybox cp -r /source/snapshots/. /dest/best_run_files/
+        docker run --rm -u $(id -u):$(id -g) -v temp_agentomics_volume:/source -v $(pwd)/outputs:/dest busybox cp -r /source/snapshots/. /dest/best_run_files/
 
         # Copy reports from all iterations
-        docker run --rm -v temp_agentomics_volume:/source -v $(pwd)/outputs:/dest busybox cp -r /source/reports/. /dest/reports/
+        docker run --rm -u $(id -u):$(id -g) -v temp_agentomics_volume:/source -v $(pwd)/outputs:/dest busybox cp -r /source/reports/. /dest/reports/
     fi
 
     docker volume rm temp_agentomics_volume

--- a/src/agents/architecture.py
+++ b/src/agents/architecture.py
@@ -14,12 +14,9 @@ from agents.steps.data_exploration import DataExploration, get_data_exploration_
 from agents.steps.model_training import ModelTraining, get_model_training_prompt
 from utils.config import Config
 from utils.report_logger import save_step_output
-from tools.setup_tools import create_tools
 from run_logging.evaluate_log_run import run_inference_and_log
 
-def create_agents(config: Config, model):
-    tools = create_tools(config)
-
+def create_agents(config: Config, model, tools):
     text_output_agent = Agent( # this is data exploration, representation, architecture reasoning agent
         model=model,
         system_prompt=get_system_prompt(config),
@@ -139,8 +136,8 @@ async def run_architecture(text_output_agent: Agent, inference_agent: Agent, spl
     return _messages
 
 @weave.op(call_display_name=lambda call: f"Iteration {call.inputs.get('iteration', 0) + 1}")
-async def run_iteration(config: Config, model, iteration, feedback):
-    agents_dict = create_agents(config=config, model=model)
+async def run_iteration(config: Config, model, iteration, feedback, tools):
+    agents_dict = create_agents(config=config, model=model, tools=tools)
 
     if iteration == 0:
         base_prompt = get_user_prompt(config)

--- a/src/run_agent.py
+++ b/src/run_agent.py
@@ -20,6 +20,7 @@ from utils.metrics import get_classification_metrics_names, get_regression_metri
 from utils.report_logger import add_metrics_to_report, add_summary_to_report, add_final_test_metrics_to_best_report, rename_and_snapshot_best_iteration_report
 from utils.providers.provider import Provider, get_provider_and_api_key
 from feedback.feedback_agent import get_feedback, aggregate_feedback
+from tools.setup_tools import create_tools
 
 
 async def main(model_name, feedback_model_name, dataset, tags, val_metric, root_privileges, 
@@ -56,13 +57,15 @@ async def main(model_name, feedback_model_name, dataset, tags, val_metric, root_
         wandb.finish()
 
 async def run_agentomics(config: Config, default_model, feedback_model):
+    tools = create_tools(config)
+    
     all_feedbacks = []
     feedback = None
     print(f"Starting training loop with {config.iterations} iterations")
     for run_index in range(config.iterations):
         print(f"\n=== ITERATION {run_index + 1} / {config.iterations} ===")
         try:
-            current_run_messages = await run_iteration(config=config, model=default_model, iteration=run_index, feedback=feedback)
+            current_run_messages = await run_iteration(config=config, model=default_model, iteration=run_index, feedback=feedback, tools=tools)
         except Exception as e:
             log_serial_metrics(prefix='validation', metrics=None, iteration=run_index, task_type=config.task_type)
             log_serial_metrics(prefix='train', metrics=None, iteration=run_index, task_type=config.task_type)

--- a/src/run_agent_interactive.py
+++ b/src/run_agent_interactive.py
@@ -7,7 +7,7 @@ from rich.panel import Panel
 import json
 import dotenv
 
-from utils.dataset_utils import get_all_datasets_info
+from utils.dataset_utils import get_all_prepared_datasets_info
 from utils.datasets_interactive_utils import interactive_dataset_selection, print_datasets_table
 from utils.metrics_interactive_utils import display_metrics_table, interactive_metric_selection
 from utils.providers.provider import Provider, get_provider_and_api_key
@@ -68,7 +68,7 @@ def main():
     # Handle list-only modes (these don't require interactivity)
     if args.list_datasets:
         console.print("Available Datasets", style="cyan")
-        datasets = get_all_datasets_info(paths["datasets_dir"], paths["prepared_datasets_dir"])
+        datasets = get_all_prepared_datasets_info(paths["prepared_datasets_dir"])
         print_datasets_table(datasets)
         return 0
     
@@ -95,7 +95,7 @@ def main():
     # Go to interactive selection if dataset/model/val_metric not provided
     print_welcome()
     if not dataset:
-        datasets = get_all_datasets_info(paths["datasets_dir"], paths["prepared_datasets_dir"])
+        datasets = get_all_prepared_datasets_info(paths["prepared_datasets_dir"])
         dataset = interactive_dataset_selection(datasets)
         if not dataset:
             console.print("No dataset selected", style="red")

--- a/src/tools/setup_tools.py
+++ b/src/tools/setup_tools.py
@@ -1,6 +1,6 @@
-from tools.bash_tool import create_bash_tool
-from tools.write_python_tool import create_write_python_tool
-from tools.run_python_tool import create_run_python_tool
+from .bash_tool import create_bash_tool
+from .write_python_tool import create_write_python_tool
+from .run_python_tool import create_run_python_tool
 import weave
 
 def create_tools(config):

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional
-from utils.dataset_utils import get_task_type_from_prepared_dataset
+from .dataset_utils import get_task_type_from_prepared_dataset
 
 @dataclass
 class Config:

--- a/src/utils/create_user.py
+++ b/src/utils/create_user.py
@@ -2,15 +2,6 @@ import subprocess
 import sys
 from hrid import HRID
 
-def _change_repository_permissions(agent_id):
-    """Change to read-only agent access for repository with specific restrictions."""
-    subprocess.run(["setfacl", "-R", "-m", f"u:{agent_id}:r-X", "/repository"], check=True)
-
-    subprocess.run(["setfacl", "-m", f"u:{agent_id}:---", "/repository/.env"], check=True)
-
-    subprocess.run(["setfacl", "-R", "-m", f"u:{agent_id}:---", "/repository/datasets"], check=True)
-    subprocess.run(["setfacl", "-R", "-m", f"u:{agent_id}:---", "/repository/prepared_datasets"], check=True)
-
 def create_new_user_and_rundir(config):
     run_id = "_".join(HRID().generate().replace("-", "_").replace(" ","_").split("_")[:-1])[:32]
     run_dir = config.runs_dir / run_id
@@ -21,7 +12,6 @@ def create_new_user_and_rundir(config):
             ["useradd", "-d", run_dir, "-m", "-U", run_id],
             check=True
         )
-        _change_repository_permissions(run_id)
     else:
         run_dir.mkdir(parents=True, exist_ok=True)
     

--- a/src/utils/create_user.py
+++ b/src/utils/create_user.py
@@ -2,6 +2,15 @@ import subprocess
 import sys
 from hrid import HRID
 
+def _change_repository_permissions(agent_id):
+    """Change to read-only agent access for repository with specific restrictions."""
+    subprocess.run(["setfacl", "-R", "-m", f"u:{agent_id}:r-X", "/repository"], check=True)
+
+    subprocess.run(["setfacl", "-m", f"u:{agent_id}:---", "/repository/.env"], check=True)
+
+    subprocess.run(["setfacl", "-R", "-m", f"u:{agent_id}:---", "/repository/datasets"], check=True)
+    subprocess.run(["setfacl", "-R", "-m", f"u:{agent_id}:---", "/repository/prepared_datasets"], check=True)
+
 def create_new_user_and_rundir(config):
     run_id = "_".join(HRID().generate().replace("-", "_").replace(" ","_").split("_")[:-1])[:32]
     run_dir = config.runs_dir / run_id
@@ -9,13 +18,10 @@ def create_new_user_and_rundir(config):
 
     if config.root_privileges:
         subprocess.run(
-            ["sudo", "useradd", "-d", run_dir, "-m", "-p", "1234", run_id],
+            ["useradd", "-d", run_dir, "-m", "-U", run_id],
             check=True
         )
-        subprocess.run(
-            ["sudo", "chmod", "o-rwx", run_dir],
-            check=True
-        )
+        _change_repository_permissions(run_id)
     else:
         run_dir.mkdir(parents=True, exist_ok=True)
     

--- a/src/utils/dataset_utils.py
+++ b/src/utils/dataset_utils.py
@@ -5,6 +5,7 @@ import shutil
 import pandas as pd
 from pathlib import Path
 from typing import List, Dict
+import subprocess
 
 def count_csv_rows(csv_file: str) -> int:
     """
@@ -281,3 +282,4 @@ def setup_nonsensitive_dataset_files_for_agent(prepared_datasets_dir: Path, agen
             #TODO make it read-only simlink 
             #TODO check raw data -> prepared data is not a symlink but a hard copy!
             shutil.copy2(source_file, target_file)
+            subprocess.run(["setfacl", "-b", str(target_file)], check=True) # give access to the agent user

--- a/src/utils/datasets_interactive_utils.py
+++ b/src/utils/datasets_interactive_utils.py
@@ -221,10 +221,9 @@ def interactive_dataset_selection(datasets: List[Dict]) -> Optional[str]:
     
     console.print("Selecting dataset interactively...", style="cyan")
     print_datasets_table(datasets)
-    prepared_datasets = [d for d in datasets if d['is_prepared']]
-    prepared_datasets_table_indicies = [i+1 for i,d in enumerate(datasets) if d['is_prepared']]
+    prepared_datasets_table_indicies = [i+1 for i,d in enumerate(datasets)]
 
-    if not prepared_datasets:
+    if not datasets:
         console.print("[red]No prepared datasets available for selection[/red]")
         return None
     

--- a/test/run_all_tests.py
+++ b/test/run_all_tests.py
@@ -1,0 +1,11 @@
+import unittest
+import sys
+
+if __name__ == "__main__":
+    print("="*20, "Running all tests", "="*20)
+
+    loader = unittest.TestLoader()
+    suite = loader.discover('test', pattern="test_*.py")
+    runner = unittest.TextTestRunner(verbosity=2)
+    result = runner.run(suite)
+    sys.exit(0 if result.wasSuccessful() else 1)

--- a/test/test_agent_permissions.py
+++ b/test/test_agent_permissions.py
@@ -1,0 +1,212 @@
+import unittest
+from pathlib import Path
+
+from src.tools.bash_tool import create_bash_tool
+from src.tools.write_python_tool import create_write_python_tool
+from src.tools.run_python_tool import create_run_python_tool
+from src.utils.create_user import create_new_user_and_rundir
+from src.utils.config import Config
+from src.utils.workspace_setup import ensure_workspace_folders
+
+
+class TestAgentPermissions(unittest.TestCase):
+    """Test suite for agent isolation and security."""
+    
+    @classmethod
+    def setUpClass(cls):
+        """Set up a test agent and tools for testing."""
+        
+        cls.config = Config(
+            model_name="openai/gpt-3.5-turbo",
+            feedback_model_name="openai/gpt-3.5-turbo",
+            dataset="AGO2_CLASH_Hejret",
+            tags=[],
+            val_metric="ACC",
+            root_privileges=True,
+            workspace_dir=Path("/workspace").resolve(),
+            prepared_datasets_dir=Path('../repository/prepared_datasets').resolve(),
+            agent_dataset_dir=Path('../workspace/datasets').resolve(),
+            iterations=5,
+            user_prompt="Create the best possible machine learning model that will generalize to new unseen data."
+        )
+        
+        ensure_workspace_folders(cls.config)
+        cls.agent_id = create_new_user_and_rundir(cls.config)
+        cls.config.agent_id = cls.agent_id
+        print(f"Created test agent: {cls.agent_id}")
+        
+        print("Setting up tools for testing (including conda env creation, might take a moment)\n")
+        
+        cls.bash_tool = create_bash_tool(
+            agent_id=cls.agent_id,
+            runs_dir=cls.config.runs_dir,
+            timeout=120,
+            max_retries=cls.config.max_tool_retries,
+            autoconda=True,
+            proxy=cls.config.use_proxy
+        )
+        
+        cls.write_python_tool = create_write_python_tool(
+            agent_id=cls.agent_id,
+            runs_dir=cls.config.runs_dir,
+            max_retries=cls.config.max_tool_retries
+        )
+        
+        cls.run_python_tool = create_run_python_tool(
+            agent_id=cls.agent_id,
+            runs_dir=cls.config.runs_dir,
+            timeout=cls.config.run_python_tool_timeout,
+            proxy=cls.config.use_proxy,
+            max_retries=cls.config.max_tool_retries
+        )
+
+    def test_agent_user_context(self):
+        """Test that agent tools run as the correct user and group (not root)."""
+        
+        result = self.bash_tool.function("whoami")
+        self.assertNotIn("Command failed", result, "'whoami' command should succeed")
+        self.assertEqual(result.strip(), self.agent_id, f"The bash tool command should be run as {self.agent_id}, not {result.strip()}")
+        
+        result = self.bash_tool.function("id")
+        self.assertNotIn("Command failed", result, "'id' command should succeed")
+        self.assertIn(self.agent_id, result, f"User ID should contain agent name {self.agent_id}")
+        self.assertNotIn("uid=0", result, "Should not run as root (uid=0)")
+        self.assertNotIn("gid=0", result, "Should not run as root group (gid=0)")
+
+        result = self.bash_tool.function("sudo whoami 2>&1")
+        result = self.bash_tool.function("sudo whoami 2>&1")
+        cannot_sudo = "Command failed" in result or "not allowed" in result or "not found" in result or "not in the sudoers file" in result
+        self.assertTrue(cannot_sudo, f"Agent should not have sudo access. Got: {result}")
+
+    def test_agent_directory_access(self):
+        """Test that agent can access only its own work directory."""
+
+        result = self.bash_tool.function(f"ls -la {self.config.runs_dir}/{self.agent_id}/")
+        self.assertNotIn("Permission denied", result, "Agent should access its own directory")
+        self.assertNotIn("Command failed", result, "ls command should succeed")
+
+        result = self.bash_tool.function(f"touch {self.config.runs_dir}/{self.agent_id}/test_file.txt")
+        self.assertNotIn("Permission denied", result, "Agent should create files in its directory")
+        self.assertNotIn("Command failed", result, "touch command should succeed")
+    
+    def test_cross_agent_isolation(self):
+        """Test that workspace contains only the current agent's directory."""
+        
+        result = self.bash_tool.function(f"ls -1 {self.config.runs_dir}/")
+        self.assertNotIn("Command failed", result, "Should be able to list runs directory")
+        directories = [d.strip() for d in result.strip().split('\n') if d.strip()]
+
+        self.assertEqual(len(directories), 1, f"Expected exactly 1 directory, found {len(directories)}: {directories}")
+        self.assertEqual(directories[0], self.agent_id, f"Expected only {self.agent_id} directory, found: {directories}")
+        
+        result = self.bash_tool.function(f"touch {self.config.runs_dir}/root_access_test.txt 2>&1")
+        self.assertIn("Permission denied", result, "Agent should not write to runs root directory")
+
+    def test_protection_test_dataset(self):
+        """Test that agent cannot access test datasets."""
+        
+        result = self.bash_tool.function(f"touch {self.config.agent_dataset_dir}/test_write.txt 2>&1")
+        self.assertTrue("Permission denied" or "Command failed" in result, "Agent should not write to datasets directory")
+        
+        result = self.bash_tool.function(f"head -5 {self.config.agent_dataset_dir}/{self.config.dataset}/test.csv 2>&1")
+        self.assertTrue(
+            "Permission denied" in result or "Command failed" in result or "No such file" in result,
+            "Agent should not read test data content"
+        )
+
+    def test_dataset_access_permissions(self):
+        """Test agent's dataset access from workspace."""
+        
+        result = self.bash_tool.function(f"ls -la {self.config.agent_dataset_dir}/")
+        self.assertNotIn("Permission denied", result, "Agent should access its dataset directory")
+        self.assertNotIn("Command failed", result, "ls command should succeed")
+
+        result = self.bash_tool.function(f"head -5 {self.config.agent_dataset_dir}/train.csv 2>&1")
+        self.assertNotIn("Permission denied", result, "Agent should read its dataset content")
+        self.assertNotIn("Command failed", result, "head command should succeed")
+
+    def test_api_key_protection(self):
+        """Test that agent cannot access API keys."""
+        
+        # Check if agent can see environment variables with API keys
+        env_result = self.bash_tool.function("env | grep -i 'api\\|key' 2>&1")
+        self.assertIn("Command failed", env_result, f"Agent should not see any API/key environment variables. Found: {env_result}")
+        
+        # Check .env file access
+        env_file_result = self.bash_tool.function("cat /repository/.env 2>&1")
+        self.assertTrue(
+            "Permission denied" in env_file_result or "No such file" in env_file_result,
+            f"Should not access .env file. Got: {env_file_result}"
+        )
+    
+    def test_conda_environment_isolation(self):
+        """Test that conda environment is set up and isolated."""
+        which_python = self.bash_tool.function("which python")
+        self.assertNotIn("Command failed", which_python, "'which python' should succeed")
+        self.assertIn(f"{self.config.runs_dir}/{self.agent_id}/.conda/envs/{self.agent_id}_env/bin/python", which_python.strip(),
+                      "Python should be from the agent's conda environment")
+        
+        install_result = self.bash_tool.function("conda install numpy -y 2>&1")
+        self.assertNotIn("Command failed", install_result, "Conda install should succeed")
+        self.assertNotIn("Permission denied", install_result, "Conda install should not have permission issues")
+        
+        python_result = self.bash_tool.function("python -c 'import numpy; print(f\"NumPy version: {numpy.__version__}\")' 2>&1")
+        self.assertNotIn("Command failed", python_result, "Python command should succeed")
+        self.assertIn("NumPy version:", python_result, "Should successfully import numpy")
+
+    def test_agent_python_tools_security(self):
+        """Test that Python tools see proper workspace isolation."""
+        disruptive_code = f"""
+import os
+try:
+    # Check that workspace contains only current agent directory
+    run_dirs = os.listdir("{self.config.runs_dir}")
+    print(f"Found directories: {{run_dirs}}")
+    
+    if len(run_dirs) == 1 and run_dirs[0] == "{self.agent_id}":
+        print("Good: Workspace properly isolated - only current agent directory exists")
+    else:
+        print(f"SECURITY_ISSUE: Expected only [{self.agent_id}], found: {{run_dirs}}")
+    
+    # Test that agent can access its own directory
+    agent_dir = "{self.config.runs_dir}/{self.agent_id}"
+    if os.path.exists(agent_dir) and os.access(agent_dir, os.R_OK | os.W_OK):
+        print("Good: Agent can access its own directory")
+    else:
+        print("ISSUE: Agent cannot access its own directory")
+        
+    # Test that agent cannot write to runs root
+    try:
+        test_file = "{self.config.runs_dir}/unauthorized_file.txt"
+        with open(test_file, 'w') as f:
+            f.write("test")
+        print("SECURITY_BREACH: Can write to runs root directory")
+    except PermissionError:
+        print("Good: Cannot write to runs root directory")
+        
+except Exception as e:
+    print(f"Error during security test: {{e}}")
+    """
+
+        test_file_path = self.config.runs_dir / self.config.agent_id / "security_test.py"
+        write_result = self.write_python_tool.function(
+            file_path=test_file_path,
+            code=disruptive_code
+        )
+        self.assertNotIn("Command failed", write_result, "Should be able to write test file")
+
+        run_result = self.run_python_tool.function(python_file_path=test_file_path)
+        self.assertNotIn("SECURITY_BREACH", run_result, f"Agent performed disruptive action: {run_result}")
+        self.assertIn("Good:", run_result, "Should show security restrictions are working")
+
+def run_isolation_tests():
+    loader = unittest.TestLoader()
+    suite = loader.loadTestsFromTestCase(TestAgentPermissions)
+    
+    runner = unittest.TextTestRunner(verbosity=2, stream=None)
+    result = runner.run(suite)
+    
+    return result.wasSuccessful()
+
+if __name__ == "__main__":
+    run_isolation_tests()

--- a/test/test_gpu_access.py
+++ b/test/test_gpu_access.py
@@ -1,0 +1,128 @@
+import unittest
+from pathlib import Path
+
+from src.tools.bash_tool import create_bash_tool
+from src.tools.write_python_tool import create_write_python_tool
+from src.tools.run_python_tool import create_run_python_tool
+from src.utils.create_user import create_new_user_and_rundir
+from src.utils.config import Config
+from src.utils.workspace_setup import ensure_workspace_folders
+
+class TestGpuAccess(unittest.TestCase):
+    """Test suite for GPU agent access"""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.config = Config(
+            model_name="openai/gpt-3.5-turbo",
+            feedback_model_name="openai/gpt-3.5-turbo",
+            dataset="AGO2_CLASH_Hejret",
+            tags=[],
+            val_metric="ACC",
+            root_privileges=True,
+            workspace_dir=Path("/workspace").resolve(),
+            prepared_datasets_dir=Path('../repository/prepared_datasets').resolve(),
+            agent_dataset_dir=Path('../workspace/datasets').resolve(),
+            iterations=5,
+            user_prompt="Create the best possible machine learning model that will generalize to new unseen data."
+        )
+        
+        ensure_workspace_folders(cls.config)
+        cls.agent_id = create_new_user_and_rundir(cls.config)
+        cls.config.agent_id = cls.agent_id
+        print(f"Created test agent: {cls.agent_id}")
+        
+        print("Setting up tools for testing (including conda env creation, might take a moment)\n")
+        
+        cls.bash_tool = create_bash_tool(
+            agent_id=cls.agent_id,
+            runs_dir=cls.config.runs_dir,
+            timeout=10*60,
+            max_retries=cls.config.max_tool_retries,
+            autoconda=True,
+            proxy=cls.config.use_proxy
+        )
+        
+        cls.write_python_tool = create_write_python_tool(
+            agent_id=cls.agent_id,
+            runs_dir=cls.config.runs_dir,
+            max_retries=cls.config.max_tool_retries
+        )
+        
+        cls.run_python_tool = create_run_python_tool(
+            agent_id=cls.agent_id,
+            runs_dir=cls.config.runs_dir,
+            timeout=cls.config.run_python_tool_timeout,
+            proxy=cls.config.use_proxy,
+            max_retries=cls.config.max_tool_retries
+        )
+
+    def test_gpu_access_bash(self):
+        """Test if the agent can access the GPU using bash tool."""
+
+        result = self.bash_tool.function("nvidia-smi")
+        self.assertIn("NVIDIA-SMI", result, "GPU access failed in bash tool")
+
+        gpu_list_result = self.bash_tool.function("nvidia-smi -L") #should show at least one GPU
+        self.assertIn("GPU 0:", gpu_list_result, "No GPU devices found")
+
+    def test_gpu_pytorch_python(self):
+        """Test if the agent can access the GPU using python tool (PyTorch)."""
+
+        print("Installing PyTorch with CUDA support, might take a while...")
+        install_result = self.bash_tool.function("pip install torch")
+        self.assertNotIn("ERROR", install_result, "Failed to install PyTorch through pip")
+        
+        code = (
+            "import torch\n"
+            "if torch.cuda.is_available():\n"
+            "    print('CUDA is available')\n"
+            "    print(f'GPU count: {torch.cuda.device_count()}')\n"
+            "    print(f'Current GPU: {torch.cuda.current_device()}')\n"
+            "    print(f'GPU Name: {torch.cuda.get_device_name(torch.cuda.current_device())}')\n"
+            "else:\n"
+            "    print('CUDA is not available')\n"
+        )
+        
+        file_path = self.config.runs_dir / self.config.agent_id / "test_pytorch.py"
+        write_result = self.write_python_tool.function(file_path=file_path, code=code)
+        self.assertNotIn("Command failed", write_result, "Should be able to write test file")
+
+        run_result = self.run_python_tool.function(python_file_path=file_path)
+        self.assertIn("CUDA is available", run_result, "GPU access failed in python tool")
+        self.assertIn("GPU Name:", run_result, "Failed to retrieve GPU name in python tool")
+
+    def test_gpu_tensorflow_python(self):
+        """Test if the agent can access the GPU using python tool (Tensorflow)."""
+
+        print("Installing tensorflow with CUDA support, might take a while...")
+        install_result = self.bash_tool.function("pip install tensorflow[and-cuda]") #without [and-cuda] would not detect GPU
+        self.assertNotIn("ERROR", install_result, "Failed to install tensorflow through pip")
+
+        code = (
+          "import tensorflow as tf\n"
+          "gpus = tf.config.list_physical_devices('GPU')\n"
+          "print(f'GPU devices found: {len(gpus)}')\n"
+          "if not gpus:\n"
+          "    print('No GPU devices found for TensorFlow')\n"
+      )
+        
+        file_path = self.config.runs_dir / self.config.agent_id / "test_tensorflow.py"
+        write_result = self.write_python_tool.function(file_path=file_path, code=code)
+        self.assertNotIn("Command failed", write_result, "Should be able to write TensorFlow test file")
+
+        run_result = self.run_python_tool.function(python_file_path=file_path)
+        print(run_result)
+        self.assertNotIn("GPU devices found: 0", run_result, "No GPU devices found for TensorFlow")
+
+def run_gpu_tests():
+    loader = unittest.TestLoader()
+    suite = loader.loadTestsFromTestCase(TestGpuAccess)
+
+    runner = unittest.TextTestRunner(verbosity=2, stream=None)
+    result = runner.run(suite)
+
+    return result.wasSuccessful()
+
+if __name__ == "__main__":
+    run_gpu_tests()

--- a/test/utils_test.py
+++ b/test/utils_test.py
@@ -1,0 +1,89 @@
+import unittest
+from pathlib import Path
+
+from src.tools.bash_tool import create_bash_tool
+from src.tools.write_python_tool import create_write_python_tool
+from src.tools.run_python_tool import create_run_python_tool
+from src.utils.create_user import create_new_user_and_rundir
+from src.utils.config import Config
+from src.utils.workspace_setup import ensure_workspace_folders
+from src.utils.dataset_utils import setup_nonsensitive_dataset_files_for_agent
+
+_shared_test_resources = None
+
+def get_shared_test_resources():
+    global _shared_test_resources
+
+    if _shared_test_resources is None:
+        config = Config(
+              model_name="openai/gpt-3.5-turbo",
+              feedback_model_name="openai/gpt-3.5-turbo",
+              dataset="AGO2_CLASH_Hejret",
+              tags=[],
+              val_metric="ACC",
+              root_privileges=True,
+              workspace_dir=Path("/workspace").resolve(),
+              prepared_datasets_dir=Path('../repository/prepared_datasets').resolve(),
+              agent_dataset_dir=Path('../workspace/datasets').resolve(),
+              iterations=5,
+              user_prompt="Create the best possible machine learning model that will generalize to new unseen data."
+          )
+
+        setup_nonsensitive_dataset_files_for_agent(
+            prepared_datasets_dir=config.prepared_dataset_dir.parent,
+            agent_datasets_dir=config.agent_dataset_dir.parent,
+            dataset_name=config.dataset,
+        )
+        ensure_workspace_folders(config)
+        agent_id = create_new_user_and_rundir(config)
+        config.agent_id = agent_id
+        print(f"Created shared test agent: {agent_id}")
+
+        print("Setting up tools for testing (including conda env creation, might take a moment)\n")
+
+        bash_tool = create_bash_tool(
+            agent_id=agent_id,
+            runs_dir=config.runs_dir,
+            timeout=10*60,
+            max_retries=config.max_tool_retries,
+            autoconda=True,
+            proxy=config.use_proxy
+        )
+
+        write_python_tool = create_write_python_tool(
+            agent_id=agent_id,
+            runs_dir=config.runs_dir,
+            max_retries=config.max_tool_retries
+        )
+
+        run_python_tool = create_run_python_tool(
+            agent_id=agent_id,
+            runs_dir=config.runs_dir,
+            timeout=config.run_python_tool_timeout,
+            proxy=config.use_proxy,
+            max_retries=config.max_tool_retries
+        )
+
+        _shared_test_resources = {
+            'config': config,
+            'agent_id': agent_id,
+            'bash_tool': bash_tool,
+            'write_python_tool': write_python_tool,
+            'run_python_tool': run_python_tool
+        }
+
+    return _shared_test_resources
+
+
+class BaseAgentTest(unittest.TestCase):
+    """Base test class with common setup for agent tests"""
+
+    @classmethod
+    def setUpClass(cls):
+        resources = get_shared_test_resources()
+
+        cls.config = resources['config']
+        cls.agent_id = resources['agent_id']
+        cls.bash_tool = resources['bash_tool']
+        cls.write_python_tool = resources['write_python_tool']
+        cls.run_python_tool = resources['run_python_tool']

--- a/test/utils_test.py
+++ b/test/utils_test.py
@@ -2,9 +2,7 @@ import unittest
 from pathlib import Path
 import dotenv
 
-from src.tools.bash_tool import create_bash_tool
-from src.tools.write_python_tool import create_write_python_tool
-from src.tools.run_python_tool import create_run_python_tool
+from src.tools.setup_tools import create_tools
 from src.utils.create_user import create_new_user_and_rundir
 from src.utils.config import Config
 from src.utils.workspace_setup import ensure_workspace_folders
@@ -44,28 +42,7 @@ def get_shared_test_resources():
 
         print("Setting up tools for testing (including conda env creation, might take a moment)\n")
 
-        bash_tool = create_bash_tool(
-            agent_id=agent_id,
-            runs_dir=config.runs_dir,
-            timeout=10*60,
-            max_retries=config.max_tool_retries,
-            autoconda=True,
-            proxy=config.use_proxy
-        )
-
-        write_python_tool = create_write_python_tool(
-            agent_id=agent_id,
-            runs_dir=config.runs_dir,
-            max_retries=config.max_tool_retries
-        )
-
-        run_python_tool = create_run_python_tool(
-            agent_id=agent_id,
-            runs_dir=config.runs_dir,
-            timeout=config.run_python_tool_timeout,
-            proxy=config.use_proxy,
-            max_retries=config.max_tool_retries
-        )
+        bash_tool, write_python_tool, run_python_tool = create_tools(config)
 
         _shared_test_resources = {
             'config': config,

--- a/test/utils_test.py
+++ b/test/utils_test.py
@@ -1,5 +1,6 @@
 import unittest
 from pathlib import Path
+import dotenv
 
 from src.tools.bash_tool import create_bash_tool
 from src.tools.write_python_tool import create_write_python_tool
@@ -28,6 +29,8 @@ def get_shared_test_resources():
               iterations=5,
               user_prompt="Create the best possible machine learning model that will generalize to new unseen data."
           )
+        
+        dotenv.load_dotenv()
 
         setup_nonsensitive_dataset_files_for_agent(
             prepared_datasets_dir=config.prepared_dataset_dir.parent,


### PR DESCRIPTION
This PR will:
- Change the user permissions to hide: the datasets folders (both /repository/datasets and repository/prepared_datasets), the .env file containing the keys;
- Limit the bash tool to use the agent user, and not root (and hide the api_keys env vars);
- Add test scripts for checking the permissions;
- Refactor tools instantiation to be reused between iterations;
- Fix container gpu access in run.sh;
- Add tests for gpu visibility in container;