### PR TITLE
fix model selection using reordered list

### DIFF
--- a/src/utils/providers/openrouter_provider.py
+++ b/src/utils/providers/openrouter_provider.py
@@ -59,12 +59,16 @@ class OpenRouterProvider(Provider):
         models = self.fetch_models()
         if not models:
             return None
-        
+        excluded_providers = ["nousresearch"]
+        excluded_models = []
         filtered = []
         for model in models:
             model_id = model.get("id", "")
             pricing = model.get("pricing", {})
-            
+            if model_id in excluded_models:
+                continue
+            if any(f"{provider}/" in model_id for provider in excluded_providers):
+                continue
             # Skip unwanted models
             if (not pricing or 
                 model_id.startswith("openrouter/") or


### PR DESCRIPTION
- pick the right model from the reordered list
- we also have 2 lists with excluded providers and excluded models. Currently we only exclude nousresearch since they do not like our privacy settings on openrouter. We should add any providers or models we find that do not work well on our system