### PR TITLE
feat: implement step-level snapshotting and workflow forking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,8 @@ ENV HF_HOME=/cache/foundation_models
 COPY foundation_models/ /foundation_models/
 COPY src/utils/foundation_models_utils.py /repository/src/utils/foundation_models_utils.py
 COPY src/utils/download_foundation_models.py /repository/src/utils/download_foundation_models.py
-#RUN LD_PRELOAD=$(find /opt/conda/envs/agentomics-env/lib/python3.12/site-packages/scikit_learn.libs -name "libgomp*.so*" | head -1) \
-#    /opt/conda/envs/agentomics-env/bin/python /repository/src/utils/download_foundation_models.py || echo "Warning: Foundation models download failed. Continuing without them."
+RUN LD_PRELOAD=$(find /opt/conda/envs/agentomics-env/lib/python3.12/site-packages/scikit_learn.libs -name "libgomp*.so*" | head -1) \
+    /opt/conda/envs/agentomics-env/bin/python /repository/src/utils/download_foundation_models.py || echo "Warning: Foundation models download failed. Continuing without them."
 
 # Setup agent start environment
 ENV START_ENV_PKG=/opt/agent_start_env.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,14 +21,14 @@ RUN mamba env create -f environment.yaml \
 RUN conda init bash \
     && echo "conda activate agentomics-env" >> /root/.bashrc
 
-# Pre-download foundation models
+# Pre-download foundation models (optional - continues build if this fails)
 RUN mkdir -p /foundation_models /cache/foundation_models
 ENV HF_HOME=/cache/foundation_models
 COPY foundation_models/ /foundation_models/
 COPY src/utils/foundation_models_utils.py /repository/src/utils/foundation_models_utils.py
 COPY src/utils/download_foundation_models.py /repository/src/utils/download_foundation_models.py
-RUN LD_PRELOAD=$(find /opt/conda/envs/agentomics-env/lib/python3.12/site-packages/scikit_learn.libs -name "libgomp*.so*" | head -1) \
-    /opt/conda/envs/agentomics-env/bin/python /repository/src/utils/download_foundation_models.py
+#RUN LD_PRELOAD=$(find /opt/conda/envs/agentomics-env/lib/python3.12/site-packages/scikit_learn.libs -name "libgomp*.so*" | head -1) \
+#    /opt/conda/envs/agentomics-env/bin/python /repository/src/utils/download_foundation_models.py || echo "Warning: Foundation models download failed. Continuing without them."
 
 # Setup agent start environment
 ENV START_ENV_PKG=/opt/agent_start_env.tar.gz

--- a/README.md
+++ b/README.md
@@ -5,12 +5,14 @@
 🤖 **Autonomous AI agent for supervised machine learning model development on omics data**
 
 Given a raw dataset, Agentomics-ML autonomously generates
+
 - A trained model, ready to run inference on new data
 - A report summarizing the model development process and evaluation metrics
 
 <!-- **⏱️ Typical timing:** 30-120 minutes depending on dataset size and complexity -->
 
 Agentomics-ML works like a ML engineer
+
 - Explores data before designing a model
 - Conciders domain information
 - Chooses proper data representation
@@ -19,12 +21,13 @@ Agentomics-ML works like a ML engineer
 - Produces working scripts, including their conda environments
 
 Currently Agentomics-ML supports
+
 - Any LLM, including local models
 - Any classification or regression dataset in a csv format
 - Secure runs using docker containers and volumes, constraining the agent to read-only access to the Agentomics-ML folder and code execution only inside a docker container
 
-
 📖 [Preprint](https://arxiv.org/abs/2506.05542) | 🚀 [Quick Start](#quick-start) | [Website](https://agentomicsml.com/)
+
 ## Download
 
 ```
@@ -42,18 +45,21 @@ cd Agentomics-ML
 ```bash
 # 1. Set your API key (see the PROVIDERS readme section for more API key options)
 export OPENROUTER_API_KEY="your-key-here"
-# OR create a .env file (see .env.example) 
+# OR create a .env file (see .env.example)
 
 # 2. Run the agent and select one of the sample datasets
 ./run.sh
 ```
 
 ## Run outputs
-After the run is finished, the `outputs` folder contains 
+
+After the run is finished, the `outputs` folder contains
+
 - Generated files (training script, inference script, model files, ...)
 - Final report (Summary of the model, train/valid/test metrics, ...)
 
 ## Run on your own dataset
+
 Create a folder inside `Agentomics-ML/datasets` and drop your files there
 
 - add `train.csv` - Contains your training data. This will be used by the agent for training and validation
@@ -61,7 +67,7 @@ Create a folder inside `Agentomics-ML/datasets` and drop your files there
 - (OPTIONAL) add `test.csv` - Contains your testing data. This will be hidden from the agent, and used to add test set metrics to the final report.
 - (OPTIONAL) add `dataset_description.md` - Data description and domain information for the agent. See the sample datasets for examples.
 
-The csv files must contain a column for the classification or regression labels named exactly either `class` or `target`. 
+The csv files must contain a column for the classification or regression labels named exactly either `class` or `target`.
 
 **Note:** If you don't provide a `validation.csv`, the agent will automatically create a train/validation split from your `train.csv` during its first iteration.
 
@@ -72,13 +78,14 @@ After you've added your dataset folder and files, run agentomics:
 ```bash
 # 1. Set your API key (see the PROVIDERS readme section for more API key options)
 export OPENROUTER_API_KEY="your-key-here"
-# OR create a .env file (see .env.example) 
+# OR create a .env file (see .env.example)
 
 # 2. Run the agent and select your dataset
 ./run.sh
 ```
 
 ## Predictions
+
 When getting predictions on new data, make sure the data file has the same column names as your training data (except the class/target column).
 
 The output will be a csv file containing a single columns called 'predictions' in the same order as your data.
@@ -94,12 +101,16 @@ Optionally pass `--cpu-only` flag if you wish to only run the inference with CPU
 If you wish to run the inference locally and not inside a docker container, use the `--local` flag.
 
 To customize or directly access the inference code, use artifacts in the `outputs/<run_name>/best_run_files` folder.
+
 - `.conda` folder contains the conda environment with packages necessary for the inference
 - `inference.py` contains the inference code, and might depend on other artifacts in the folder (like `model.joblib`, tokenizer files, etc..)
 
 # Advanced run parameters
+
 ## Providers
+
 We support various providers out-of-the-box. Below is a list of providers, with the specific environment variables names we check for. Those should be provided in the `.env` file, or exported.
+
 - OpenRouter (OPENROUTER_API_KEY)
 - OpenAI (OPENAI_API_KEY)
 - Anthropic (ANTHROPIC_API_KEY)
@@ -107,11 +118,13 @@ We support various providers out-of-the-box. Below is a list of providers, with 
 If you wish to use other providers, add them to the `src/utils/providers/configured_providers.yaml` configuration. For those, we won't support a "nice" interactive model selection, and you will need to provide the `--model` parameter explicitly.
 
 ### Local LLM (Ollama)
+
 We support Ollama for running with local models
 
 If youre running agentomics in docker mode (recommended), additional steps are needed:
 
-- Run `systemctl edit ollama.service`  and add the following lines to allow Ollama to listen the requests coming from the container: 
+- Run `systemctl edit ollama.service` and add the following lines to allow Ollama to listen the requests coming from the container:
+
   ```
   [Service]
   Environment="OLLAMA_HOST=172.17.0.1:11434"
@@ -122,14 +135,16 @@ If youre running agentomics in docker mode (recommended), additional steps are n
   systemctl daemon-reload
   systemctl restart ollama.service
   ```
--  Add the `--ollama` flag when executing the `./run.sh` script.
+- Add the `--ollama` flag when executing the `./run.sh` script.
 
-If youre running agentomics in local mode (unsafe), `OLLAMA_BASE_URL` environment variable needs to be provided (either in the `.env` file or exported, typically `BASE_OLLAMA_URL=http://localhost:11434/v1`). 
+If youre running agentomics in local mode (unsafe), `OLLAMA_BASE_URL` environment variable needs to be provided (either in the `.env` file or exported, typically `BASE_OLLAMA_URL=http://localhost:11434/v1`).
 
 ## Explicit parameters
+
 Running `./run.sh` with no parameters will prompt you to select them interactively.
 
 You can also supply them directly to skip the interactive selection
+
 ```
 .run.sh \
   --model gpt-5-nano \ # provider-specific
@@ -137,18 +152,222 @@ You can also supply them directly to skip the interactive selection
   --iterations 5 \
   --val-metric ACC \
 ```
+
 Run `./run.sh --help` for more information.
 
 ## Custom user prompt
-The default prompt: 
+
+The default prompt:
 `Create the best possible machine learning model that will generalize to new unseen data.`
 
 You can overwrite it with your own user prompt for the agent by passing the `--user-prompt` argument.
+
 ```
 /run.sh --user-prompt "Only create simple ML models like logistic regression and shallow decision trees"
 ```
 
+## Forking from Previous Runs
+
+**Fork from any step in a previous run to try different approaches!**
+
+Agentomics-ML supports forking from specific steps in previous runs, allowing you to:
+
+- Resume from a specific point in the pipeline
+- Try different approaches after a particular step
+- Save time by reusing work from earlier steps
+- Experiment with variations without starting from scratch
+
+### How Forking Works
+
+When you fork from a step:
+
+1. The agent restores the **exact workspace state** from after that step completed
+2. It loads the **conversation history** and outputs from all previous steps
+3. It continues execution from the next step (or re-executes the forked step if desired)
+4. All work is done in a new run with a unique ID
+
+Forking is powered by:
+
+- **Content-addressed storage**: Files are deduplicated automatically, saving disk space
+- **Copy-on-write** (when supported): Instant, zero-copy file restoration on APFS/BTRFS/XFS
+- **Step snapshots**: After each step completes, workspace and outputs are automatically saved
+
+### Available Fork Points
+
+You can fork from any of these steps:
+
+- `data_exploration` - After initial data analysis
+- `data_split` - After train/validation split
+- `data_representation` - After feature engineering/encoding
+- `model_architecture` - After model design
+- `model_training` - After model training
+- `model_inference` - After inference script creation
+- `prediction_exploration` - After prediction analysis
+
+### Basic Forking
+
+Fork from the latest iteration of a previous run:
+
+```bash
+./run.sh \
+  --fork-from-run melodic_recipe_grind \
+  --fork-from-step model_architecture \
+  --model gpt-4o \
+  --dataset breast_cancer \
+  --iterations 5 \
+  --val-metric ACC
+```
+
+This will:
+
+- Skip steps 0-3 (data_exploration through model_architecture)
+- Start fresh from step 4 (model_training)
+- Use the workspace state from after model_architecture completed
+
+### Fork from Specific Iteration
+
+Or fork from a specific iteration number:
+
+```bash
+./run.sh \
+  --fork-from-run melodic_recipe_grind \
+  --fork-from-step data_representation \
+  --fork-from-iteration 2 \
+  --model gpt-4o \
+  --dataset breast_cancer \
+  --iterations 5 \
+  --val-metric ACC
+```
+
+### Custom Fork ID
+
+By default, forked runs get an auto-generated ID like `melodic_recipe_grind_fork_model_training_iter2_20250112_143022` (includes iteration if specified) or `melodic_recipe_grind_fork_model_training_20250112_143022` (uses latest iteration).
+
+You can specify a custom ID:
+
+```bash
+./run.sh \
+  --fork-from-run melodic_recipe_grind \
+  --fork-from-step model_architecture \
+  --agent-id my_custom_fork_experiment \
+  --model gpt-4o \
+  --dataset breast_cancer \
+  --iterations 5 \
+  --val-metric ACC
+```
+
+### Example Use Cases
+
+**Try a different model architecture:**
+
+```bash
+# Original run used a neural network
+# Fork after data_representation to try XGBoost instead
+./run.sh \
+  --fork-from-run original_run_id \
+  --fork-from-step data_representation \
+  --user-prompt "Use XGBoost with careful hyperparameter tuning" \
+  --model gpt-4o \
+  --dataset breast_cancer \
+  --iterations 3 \
+  --val-metric ACC
+```
+
+**Fix data representation issues:**
+
+```bash
+# Fork from data_split to redo representation with different encoding
+./run.sh \
+  --fork-from-run original_run_id \
+  --fork-from-step data_split \
+  --user-prompt "Use target encoding instead of one-hot for categorical features" \
+  --model gpt-4o \
+  --dataset breast_cancer \
+  --iterations 5 \
+  --val-metric ACC
+```
+
+**Continue after timeout:**
+
+```bash
+# Original run timed out during training
+# Fork from model_architecture to continue where it left off
+./run.sh \
+  --fork-from-run timed_out_run_id \
+  --fork-from-step model_architecture \
+  --model gpt-4o \
+  --dataset breast_cancer \
+  --iterations 3 \
+  --val-metric ACC
+```
+
+**Fork from a fork (experiment with variations):**
+
+```bash
+# Original run: melodic_recipe_grind
+# First fork: melodic_recipe_grind_fork_model_training_iter2_20250112_143022
+# Now fork from the first fork to try a different approach
+
+./run.sh \
+  --fork-from-run melodic_recipe_grind_fork_model_training_iter2_20250112_143022 \
+  --fork-from-step model_architecture \
+  --user-prompt "Try ensemble methods combining the previous model with a gradient boosting classifier" \
+  --model gpt-4o \
+  --dataset breast_cancer \
+  --iterations 3 \
+  --val-metric ACC
+```
+
+This creates a fork-of-fork with ID like: `melodic_recipe_grind_fork_model_training_iter2_20250112_143022_fork_model_architecture_iter1_20250113_150000`
+
+**Note:** Fork IDs can get long with deep fork chains. The system automatically truncates if needed to stay within filesystem limits (255 characters on macOS/Linux).
+
+### How Snapshots Are Stored
+
+Snapshots are stored in the `.agentomics_storage` directory using a git-like content-addressed system:
+
+```
+workspace/
+  .agentomics_storage/
+    objects/          # Deduplicated file contents (by SHA-256 hash)
+      a1/
+        23f4d5e6...   # Actual file content
+      b7/
+        89c2e1f3...
+    snapshots/        # Lightweight manifests (just path→hash mappings)
+      melodic_recipe_grind/
+        iteration_0/
+          00_data_exploration.json
+          01_data_split.json
+          02_data_representation.json
+          ...
+      iteration_1/
+          ...
+```
+
+**Benefits:**
+
+- **Space efficient**: Identical files are stored only once
+- **Fast**: Only changed files are stored after each step
+- **Portable**: Copy the entire `.agentomics_storage` directory to share runs
+
+### Storage Statistics
+
+Check how much space your snapshots use:
+
+```python
+from utils.content_store import ContentAddressedStore
+from pathlib import Path
+
+store = ContentAddressedStore(Path("workspace"))
+stats = store.get_storage_stats()
+print(f"Total objects: {stats['total_objects']}")
+print(f"Total size: {stats['total_size_mb']:.2f} MB")
+print(f"Total snapshots: {stats['total_snapshots']}")
+```
+
 ## Local mode (no-docker)
+
 <div style="border:2px solid red; background:#ee2400; padding:10px; border-radius:6px;">
   <strong>⚠️ Warning:</strong> Only run local mode inside a secure environment (like your own docker container with read-only mounts or google colab)! The agent tools can exectute arbitrary bash commands!
 </div>
@@ -158,9 +377,13 @@ If you can't create your own docker container, you can run in local mode with si
 `./run.sh --local`
 
 ## Running scripts separately
+
 If you want to have more fine-grained control over the agent runs, follow these steps:
+
 ### Dataset preparation
+
 To prepare datasets (using data from the Agentomics-ML/datasets directory) for the agent, run:
+
 ```
 conda env create -f environment_prepare.yaml
 conda activate agentomics-prepare-env
@@ -170,7 +393,9 @@ python src/prepare_datasets.py
 Run `python src/prepare_datasets.py --help` for info on more fine-grained control of dataset preparation (e.g. explicitly specifying classification/regression task, explicit positive/negative class, etc..)
 
 ### Agent run
+
 To run the agent run:
+
 ```
 conda env create -f environment.yaml
 conda activate agentomics-env
@@ -178,6 +403,7 @@ python src/run_agent_interactive.py
 ```
 
 To run the agent with more logging options and pre-specifying arguments
+
 ```
 conda env create -f environment.yaml
 conda activate agentomics-env
@@ -185,8 +411,9 @@ python src/run_agent.py --model <model> --dataset <dataset> --val-metric <val_me
 ```
 
 ## Logging
+
 We support logging to W&B, including agent traces, metrics of various model iterations, and generated files.
-To enable logging, specify WANDB_* keys in your `.env` file (see `.env.example`)
+To enable logging, specify WANDB\_\* keys in your `.env` file (see `.env.example`)
 
 # Developer information
 
@@ -249,8 +476,6 @@ docker buildx build \
   -t myusername/agentomics-prepare:latest \
   --push .
 ```
-
-
 
 **With version tags:**
 
@@ -382,6 +607,6 @@ GPU support is enabled by default. To use GPU acceleration, you need to configur
 
 If you want to disable GPU support, use the `--cpu-only` flag:
 
-   ```
-   ./run.sh --cpu-only
-   ```
+```
+./run.sh --cpu-only
+```

--- a/run.sh
+++ b/run.sh
@@ -15,10 +15,13 @@ NOCOLOR='\033[0m'
 AGENTOMICS_ARGS=()
 LOCAL_MODE=false
 TEST_MODE=false
-CPU_ONLY=false
+CPU_ONLY=true
 OLLAMA=false
 USE_PROVISIONING_KEY=false
 SPEND_LIMIT=10
+FORK_FROM_RUN=""
+FORK_FROM_STEP=""
+FORK_FROM_ITERATION=""
 
 show_help() {
     cat << EOF
@@ -27,14 +30,17 @@ Usage: ./run.sh [OPTIONS]
 Orchestrates the Agentomics training and evaluation process. By default, it runs in Docker containers.
 Use --local to run with a local Conda environment.
 
-Required Arguments (for non-interactive runs):
+Required Arguments (for non-fork runs):
   --model <name>      The LLM model name (e.g., 'openai/gpt-4').
-  --dataset <name>    The short identifier for the prepared dataset (e.g., 'breast_cancer').
+  --dataset <name>    The dataset identifier (e.g., 'breast_cancer').
+                      Auto-detected when forking.
   --iterations <N>    Number of iterations to run the agent (e.g., 5).
   --timeout <int>   Amount of seconds the agent is allowed to run for. This or --iterations will dictate the duration, whichever will expire first. 
   --split-allowed-iterations <N>    Number of initial iterations that are allowed to (re)split the data into train/validation (e.g., 1).
   --val-metric <name> The metric to optimize (e.g., 'ACC').
+                      Auto-detected when forking.
   --user-prompt <str> The main prompt/goal for the agent.
+                      Auto-inherited from source when forking.
                       (Default: "Create the best possible machine learning model that will generalize to new unseen data.")
 
 Operational Flags:
@@ -47,6 +53,15 @@ Operational Flags:
   --spend-limit <N>   Only applies when --use-provisioning-key is passed. Spend limit for a temporary key (default: 10).
   --tags              (Optional) Space separated tags for Weights and Biases logging.
   -h, --help          Show this help message and exit.
+
+Forking Flags (Resume from a previous run):
+  --fork-from-run <run_id>      The run ID to fork from (e.g., 'melodic_recipe_grind').
+  --fork-from-step <step_name>  The step to fork from. Options: 
+                                  data_exploration, data_split, data_representation,
+                                  model_architecture, model_training, model_inference,
+                                  prediction_exploration
+  --fork-from-iteration <N>     (Optional) Specific iteration to fork from. If omitted, 
+                                uses the latest iteration.
 
 Listing Flags (Run the script with only one of these):
   --list-models       List models available via the configured provider and exit.
@@ -145,6 +160,21 @@ while [[ $# -gt 0 ]]; do
             CPU_ONLY=true
             shift
             ;;
+        --fork-from-run)
+            FORK_FROM_RUN="$2"
+            AGENTOMICS_ARGS+=(--fork-from-run "$2")
+            shift 2
+            ;;
+        --fork-from-step)
+            FORK_FROM_STEP="$2"
+            AGENTOMICS_ARGS+=(--fork-from-step "$2")
+            shift 2
+            ;;
+        --fork-from-iteration)
+            FORK_FROM_ITERATION="$2"
+            AGENTOMICS_ARGS+=(--fork-from-iteration "$2")
+            shift 2
+            ;;
         *)
           # Catch unrecognized arguments
           if [[ "$1" == -* ]]; then
@@ -156,6 +186,28 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+# Validate fork arguments
+if [ -n "$FORK_FROM_RUN" ] || [ -n "$FORK_FROM_STEP" ]; then
+    if [ -z "$FORK_FROM_RUN" ] || [ -z "$FORK_FROM_STEP" ]; then
+        echo -e "${RED}Error: Both --fork-from-run and --fork-from-step must be specified together.${NOCOLOR}" >&2
+        exit 1
+    fi
+    
+    # Validate step name against predefined list
+    VALID_STEPS=("data_exploration" "data_split" "data_representation" "model_architecture" "model_training" "model_inference" "prediction_exploration")
+    if [[ ! " ${VALID_STEPS[@]} " =~ " ${FORK_FROM_STEP} " ]]; then
+        echo -e "${RED}Error: Invalid step name '${FORK_FROM_STEP}'.${NOCOLOR}" >&2
+        echo "Valid steps are: ${VALID_STEPS[*]}" >&2
+        exit 1
+    fi
+    
+    if [ -z "$FORK_FROM_ITERATION" ]; then
+        echo "Fork mode enabled: forking from run '$FORK_FROM_RUN' at step '$FORK_FROM_STEP' (latest iteration)"
+    else
+        echo "Fork mode enabled: forking from run '$FORK_FROM_RUN' at step '$FORK_FROM_STEP' (iteration $FORK_FROM_ITERATION)"
+    fi
+fi
 
 if [ "$LOCAL_MODE" = true ]; then
     echo -e "${RED}Running in local mode - this is only recommended if you run in a non-vulnerable environment!${NOCOLOR}"
@@ -175,27 +227,142 @@ if [ "$LOCAL_MODE" = true ]; then
     eval "$(conda shell.bash hook)"
     conda activate agentomics-env
 
-    AGENT_ID=$(python src/utils/create_user.py)
+    # Generate AGENT_ID
+    if [ -n "$FORK_FROM_RUN" ]; then
+        # Generate fork-based ID: source_run_fork_step_[iterN]_timestamp
+        # Using _fork_ instead of _forked_from_ to save space (8 chars per fork)
+        TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+        if [ -n "$FORK_FROM_ITERATION" ]; then
+            AGENT_ID="${FORK_FROM_RUN}_fork_${FORK_FROM_STEP}_iter${FORK_FROM_ITERATION}_${TIMESTAMP}"
+        else
+            AGENT_ID="${FORK_FROM_RUN}_fork_${FORK_FROM_STEP}_${TIMESTAMP}"
+        fi
+        # Safety check: truncate if exceeds 240 chars (leaving room for path prefixes)
+        if [ ${#AGENT_ID} -gt 240 ]; then
+            AGENT_ID="${AGENT_ID:0:240}"
+            echo "[WARNING] Fork ID truncated to 240 chars to avoid filesystem limits"
+        fi
+        echo "Generated fork agent ID: $AGENT_ID"
+    else
+        AGENT_ID=$(python src/utils/create_user.py)
+        echo "Generated new agent ID: $AGENT_ID"
+    fi
     export AGENT_ID
+    
+    # If forking, copy source run data into the workspace
+    if [ -n "$FORK_FROM_RUN" ]; then
+        echo "Copying source run data for forking..."
+        
+        # Check if source run exists in outputs
+        if [ ! -d "outputs/${FORK_FROM_RUN}" ]; then
+            echo -e "${RED}Error: Source run '${FORK_FROM_RUN}' not found in outputs/${NOCOLOR}"
+            echo "Make sure the source run exists before trying to fork from it."
+            exit 1
+        fi
+        
+        # Check for required files
+        if [ ! -d "outputs/${FORK_FROM_RUN}/storage/.agentomics_storage" ]; then
+            echo -e "${RED}Error: Content storage not found for run '${FORK_FROM_RUN}'${NOCOLOR}"
+            echo "This run needs to be re-run with the updated system to support forking."
+            exit 1
+        fi
+        
+        # Copy .agentomics_storage (contains everything: snapshots, objects, configs)
+        if [ -d "outputs/${FORK_FROM_RUN}/storage/.agentomics_storage" ]; then
+            cp -r outputs/${FORK_FROM_RUN}/storage/.agentomics_storage ../workspace/
+            echo "  Copied content-addressed storage (including config)"
+        fi
+    fi
+    
     timeout $TIME_LIMIT_SECS python src/run_agent_interactive.py ${AGENTOMICS_ARGS+"${AGENTOMICS_ARGS[@]}"}
     if [ $? -eq 124 ]; then
         echo "Timed out after $TIME_LIMIT_SECS"
     fi
+    
+    # Function to copy local outputs (runs even on failure)
+    copy_local_outputs() {
+        local exit_code=$1
+        
+        if [ $exit_code -eq 0 ]; then
+            # SUCCESS: Copy everything
+            echo "Copying outputs from local workspace..."
+            
+            mkdir -p outputs/${AGENT_ID}/best_run_files outputs/${AGENT_ID}/reports outputs/${AGENT_ID}/storage
+            
+            # Copy content-addressed storage (now created with correct permissions by Python)
+            echo "Copying content-addressed storage..."
+            if [ -d "../workspace/.agentomics_storage" ]; then
+                cp -r ../workspace/.agentomics_storage outputs/${AGENT_ID}/storage/
+            fi
+            
+            # Copy all output files
+            if [ -d "../workspace/snapshots/${AGENT_ID}" ]; then
+                cp -r ../workspace/snapshots/${AGENT_ID}/. outputs/${AGENT_ID}/best_run_files/
+            fi
+            
+            if [ -d "../workspace/reports/${AGENT_ID}" ]; then
+                cp -r ../workspace/reports/${AGENT_ID}/. outputs/${AGENT_ID}/reports/
+            fi
+            
+            echo -e "${GREEN}Run finished successfully. Outputs can be found in outputs/${AGENT_ID}${NOCOLOR}"
+        else
+            # FAILURE: Only copy .agentomics_storage (sufficient for forking)
+            echo "Run failed. Copying step snapshots for recovery..."
+            
+            mkdir -p outputs/${AGENT_ID}/storage
+            
+            if [ -d "../workspace/.agentomics_storage" ]; then
+                # Copy .agentomics_storage (now created with correct permissions by Python)
+                cp -r ../workspace/.agentomics_storage outputs/${AGENT_ID}/storage/
+                echo "Snapshots saved to outputs/${AGENT_ID}/storage/"
+            else
+                echo "Warning: No snapshots found"
+            fi
+            
+            echo -e "${RED}Run failed with exit code ${exit_code}${NOCOLOR}"
+            echo -e "Step snapshots saved to outputs/${AGENT_ID}/storage/"
+            echo -e "You can fork from any completed step using: --fork-from-run ${AGENT_ID} --fork-from-step <step_name>"
+        fi
+    }
+    
+    # Set up trap to ensure outputs are copied even on failure
+    trap 'copy_local_outputs $?' EXIT
+    
     export PYTHONPATH=./src
     python src/run_logging/evaluate_log_test.py --workspace-dir ../workspace
-
-    mkdir -p outputs/${AGENT_ID}/best_run_files outputs/${AGENT_ID}/reports
-    cp -r ../workspace/snapshots/${AGENT_ID}/. outputs/${AGENT_ID}/best_run_files/
-    cp -r ../workspace/reports/${AGENT_ID}/. outputs/${AGENT_ID}/reports/
+    
+    # If we get here, run succeeded
+    trap - EXIT  # Disable trap
+    copy_local_outputs 0
 else
     echo "Building the run image"
-    docker build --progress=quiet -t agentomics_img -f Dockerfile .
+    docker build -t agentomics_img -f Dockerfile .
     echo "Build done"
-    AGENT_ID=$(docker run --rm -u $(id -u):$(id -g) -v "$(pwd)":/repository:ro --entrypoint \
-               /opt/conda/envs/agentomics-env/bin/python agentomics_img /repository/src/utils/create_user.py)
+    
+    # Generate AGENT_ID
+    if [ -n "$FORK_FROM_RUN" ]; then
+        # Generate fork-based ID: source_run_fork_step_[iterN]_timestamp
+        # Using _fork_ instead of _forked_from_ to save space (8 chars per fork)
+        TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+        if [ -n "$FORK_FROM_ITERATION" ]; then
+            AGENT_ID="${FORK_FROM_RUN}_fork_${FORK_FROM_STEP}_iter${FORK_FROM_ITERATION}_${TIMESTAMP}"
+        else
+            AGENT_ID="${FORK_FROM_RUN}_fork_${FORK_FROM_STEP}_${TIMESTAMP}"
+        fi
+        # Safety check: truncate if exceeds 240 chars (leaving room for path prefixes)
+        if [ ${#AGENT_ID} -gt 240 ]; then
+            AGENT_ID="${AGENT_ID:0:240}"
+            echo "[WARNING] Fork ID truncated to 240 chars to avoid filesystem limits"
+        fi
+        echo "Generated fork agent ID: $AGENT_ID"
+    else
+        AGENT_ID=$(docker run --rm -u $(id -u):$(id -g) -v "$(pwd)":/repository:ro --entrypoint \
+                   /opt/conda/envs/agentomics-env/bin/python agentomics_img /repository/src/utils/create_user.py)
+        echo "Generated new agent ID: $AGENT_ID"
+    fi
 
     echo "Building the data preparation image"
-    docker build --progress=quiet -t agentomics_prepare_img -f Dockerfile.prepare .
+    docker build -t agentomics_prepare_img -f Dockerfile.prepare .
     echo "Build done"
     docker run \
         -u $(id -u):$(id -g) \
@@ -225,6 +392,32 @@ else
     if [ "$CPU_ONLY" = false ]; then
         GPU_FLAGS+=(--gpus all)
         GPU_FLAGS+=(--env NVIDIA_VISIBLE_DEVICES=all)
+    fi
+
+    # If forking, copy source run data into the volume
+    if [ -n "$FORK_FROM_RUN" ]; then
+        echo "Copying source run data for forking..."
+        
+        # Check if source run exists in outputs
+        if [ ! -d "outputs/${FORK_FROM_RUN}" ]; then
+            echo -e "${RED}Error: Source run '${FORK_FROM_RUN}' not found in outputs/${NOCOLOR}"
+            echo "Make sure the source run exists before trying to fork from it."
+            exit 1
+        fi
+        
+        # Copy the content-addressed storage (includes objects, snapshots, and configs)
+        if [ ! -d "outputs/${FORK_FROM_RUN}/storage/.agentomics_storage" ]; then
+            echo -e "${RED}Error: Content storage not found for run '${FORK_FROM_RUN}'${NOCOLOR}"
+            echo "This run needs to be re-run with the updated system to support forking."
+            exit 1
+        fi
+        
+        # Copy .agentomics_storage (contains everything: snapshots, objects, configs)
+        docker run --rm \
+            -v "$(pwd)/outputs/${FORK_FROM_RUN}/storage":/source:ro \
+            -v temp_agentomics_volume_${AGENT_ID}:/dest \
+            busybox cp -r /source/.agentomics_storage /dest/
+        echo "  Copied content-addressed storage (including config)"
     fi
     OLLAMA_FLAGS=()
     if [ "$OLLAMA" = true ]; then
@@ -263,6 +456,78 @@ else
             --entrypoint /opt/conda/envs/agentomics-env/bin/python \
             agentomics_img -m test.run_all_tests
     else
+        # Function to copy files from volume (runs even on failure)
+        copy_outputs_from_volume() {
+            local exit_code=$1
+            
+            if [ $exit_code -eq 0 ]; then
+                # SUCCESS: Copy everything
+                echo "Copying outputs from Docker volume..."
+                
+                mkdir -p outputs/${AGENT_ID}/best_run_files outputs/${AGENT_ID}/reports outputs/${AGENT_ID}/run_files outputs/${AGENT_ID}/extras outputs/${AGENT_ID}/storage
+
+                # Copy content-addressed storage
+                echo "Copying content-addressed storage..."
+                docker run --rm -u $(id -u):$(id -g) \
+                    -v temp_agentomics_volume_${AGENT_ID}:/source \
+                    -v $(pwd)/outputs/${AGENT_ID}:/dest \
+                    busybox sh -c "if [ -d /source/.agentomics_storage ]; then cp -r /source/.agentomics_storage /dest/storage/; fi"
+
+                # Copy all output files (with existence checks)
+                docker run --rm -v temp_agentomics_volume_${AGENT_ID}:/workspace busybox sh -c "
+                    [ -d /workspace/snapshots/${AGENT_ID} ] && chmod -R a+rX /workspace/snapshots/${AGENT_ID}/ || true
+                    [ -d /workspace/runs/${AGENT_ID} ] && chmod -R a+rX /workspace/runs/${AGENT_ID}/ || true
+                "
+
+                docker run --rm -u $(id -u):$(id -g) -v temp_agentomics_volume_${AGENT_ID}:/source -v $(pwd)/outputs/${AGENT_ID}:/dest busybox sh -c "
+                    [ -d /source/snapshots/${AGENT_ID} ] && cp -r /source/snapshots/${AGENT_ID}/. /dest/best_run_files/ || echo 'No snapshots directory'
+                "
+
+                docker run --rm -u $(id -u):$(id -g) -v temp_agentomics_volume_${AGENT_ID}:/source -v $(pwd)/outputs/${AGENT_ID}:/dest busybox sh -c "
+                    [ -d /source/runs/${AGENT_ID} ] && cp -r /source/runs/${AGENT_ID}/. /dest/run_files/ || echo 'No runs directory'
+                "
+
+                docker run --rm -u $(id -u):$(id -g) -v temp_agentomics_volume_${AGENT_ID}:/source -v $(pwd)/outputs/${AGENT_ID}:/dest busybox sh -c "
+                    [ -d /source/reports/${AGENT_ID} ] && cp -r /source/reports/${AGENT_ID}/. /dest/reports/ || echo 'No reports directory'
+                "
+
+                docker run --rm -u $(id -u):$(id -g) -v temp_agentomics_volume_${AGENT_ID}:/source -v $(pwd)/outputs/${AGENT_ID}:/dest busybox sh -c "
+                    [ -d /source/extras ] && cp -r /source/extras/. /dest/extras/ || echo 'No extras directory'
+                "
+                
+                # If we used a provisioning key, log costs and clean up the temporary key
+                if [ "$USE_PROVISIONING_KEY" = true ]; then
+                    echo "Logging costs and cleaning up temporary API key"
+                    CONFIG_PATH="outputs/${AGENT_ID}/best_run_files/config.json"
+                    PYTHONPATH="$(pwd)/src" conda run -n agentomics-env python src/utils/api_keys_utils.py cleanup-and-log --config-path "$CONFIG_PATH" --api-key-hash "$TEMP_API_KEY_HASH"
+                fi
+
+                echo -e "${GREEN}Run finished successfully. Outputs can be found in outputs/${AGENT_ID}${NOCOLOR}"
+                echo -e "${GREEN}To run inference on new data, use ./inference.sh --agent-dir outputs/${AGENT_ID} --input <path_to_input_csv> --output <path_to_output_csv>${NOCOLOR}"
+            else
+                # FAILURE: Only copy .agentomics_storage (sufficient for forking)
+                echo "Run failed. Copying step snapshots for recovery..."
+                
+                mkdir -p outputs/${AGENT_ID}/storage
+
+                docker run --rm -u $(id -u):$(id -g) \
+                    -v temp_agentomics_volume_${AGENT_ID}:/source \
+                    -v $(pwd)/outputs/${AGENT_ID}:/dest \
+                    busybox sh -c "if [ -d /source/.agentomics_storage ]; then cp -r /source/.agentomics_storage /dest/storage/; echo 'Snapshots saved to outputs/${AGENT_ID}/storage/'; else echo 'Warning: No snapshots found'; fi"
+                
+                echo -e "${RED}Run failed with exit code ${exit_code}${NOCOLOR}"
+                echo -e "Step snapshots saved to outputs/${AGENT_ID}/storage/"
+                echo -e "You can fork from any completed step using: --fork-from-run ${AGENT_ID} --fork-from-step <step_name>"
+            fi
+            
+            # Clean up volume
+            docker volume rm temp_agentomics_volume_${AGENT_ID} 2>/dev/null || true
+        }
+
+        # Set up trap to ensure outputs are copied even on failure
+        trap 'copy_outputs_from_volume $?' EXIT
+
+        # Run the main agent
         docker run \
             --rm \
             -it \
@@ -292,30 +557,10 @@ else
             -v temp_agentomics_volume_${AGENT_ID}:/workspace \
             --entrypoint /opt/conda/envs/agentomics-env/bin/python \
             agentomics_img src/run_logging/evaluate_log_test.py
-
-        mkdir -p outputs/${AGENT_ID}/best_run_files outputs/${AGENT_ID}/reports outputs/${AGENT_ID}/run_files outputs/${AGENT_ID}/extras
-
-        docker run --rm -v temp_agentomics_volume_${AGENT_ID}:/workspace busybox chmod -R a+rX /workspace/snapshots/${AGENT_ID}/ /workspace/runs/${AGENT_ID}/
-
-        # Copy run files and report
-        docker run --rm -u $(id -u):$(id -g) -v temp_agentomics_volume_${AGENT_ID}:/source -v $(pwd)/outputs/${AGENT_ID}:/dest busybox cp -r /source/snapshots/${AGENT_ID}/. /dest/best_run_files/
-
-        docker run --rm -u $(id -u):$(id -g) -v temp_agentomics_volume_${AGENT_ID}:/source -v $(pwd)/outputs/${AGENT_ID}:/dest busybox cp -r /source/runs/${AGENT_ID}/. /dest/run_files/
-
-        docker run --rm -u $(id -u):$(id -g) -v temp_agentomics_volume_${AGENT_ID}:/source -v $(pwd)/outputs/${AGENT_ID}:/dest busybox cp -r /source/reports/${AGENT_ID}/. /dest/reports/
-
-        docker run --rm -u $(id -u):$(id -g) -v temp_agentomics_volume_${AGENT_ID}:/source -v $(pwd)/outputs/${AGENT_ID}:/dest busybox cp -r /source/extras/. /dest/extras/
-
-        if [ "$USE_PROVISIONING_KEY" = true ]; then
-            echo "Logging costs and cleaning up temporary API key"
-            CONFIG_PATH="outputs/${AGENT_ID}/best_run_files/config.json"
-            PYTHONPATH="$(pwd)/src" conda run -n agentomics-env python src/utils/api_keys_utils.py cleanup-and-log --config-path "$CONFIG_PATH" --api-key-hash "$TEMP_API_KEY_HASH"
-        fi
-
-        echo -e "${GREEN}Run finished. Report and files can be found in outputs/${AGENT_ID}${NOCOLOR}"
-        echo -e "${GREEN}To run inference on new data, use ./inference.sh --agent-dir outputs/${AGENT_ID} --input <path_to_input_csv> --output <path_to_output_csv>${NOCOLOR}"
+        
+        # If we get here, both runs succeeded
+        trap - EXIT  # Disable trap
+        copy_outputs_from_volume 0
 
     fi
-
-    docker volume rm temp_agentomics_volume_${AGENT_ID}
 fi

--- a/src/agents/architecture.py
+++ b/src/agents/architecture.py
@@ -20,7 +20,9 @@ from agents.steps.model_training import ModelTraining, get_model_training_prompt
 from agents.steps.prediction_exploration import PredictionExploration, get_prediction_exploration_prompt
 from utils.config import Config
 from utils.report_logger import save_step_output
+from utils.step_snapshots import StepRegistry
 from run_logging.evaluate_log_run import run_inference_and_log
+from utils.step_snapshots import snapshotable_step, RunManager, step_execution_context
 
 def create_agents(config: Config, model, tools):
     data_exploration_agent = Agent(
@@ -287,124 +289,280 @@ def get_new_rundir_files(config, since_timestamp, ignore_iter_folders=True):
             new_files.append(element.name)
     return new_files
 
-async def run_architecture_compressed(data_exploration_agent: Agent, data_representation_agent: Agent, model_architecture_agent: Agent, inference_agent: Agent, split_dataset_agent: Agent, training_agent: Agent, prediction_exploration_agent: Agent, config: Config, base_prompt: str, iteration: int, last_split_strategy: str):
-    persistent_messages = []
-    structured_outputs = []
-    ctx_replacer_msg = "\nSummarized outputs from your previous steps are in previous messages."
 
+# ============================================================================
+# DECORATED STEP FUNCTIONS (for snapshotting and forking)
+# ============================================================================
+
+@snapshotable_step("data_exploration")
+async def run_data_exploration_step(agent, config, base_prompt, iteration):
+    """Step 0: Data exploration - analyze dataset and understand structure"""
     data_exploration_deps = {'start_time': datetime.datetime.now()}
-    messages_data_exploration, data_exploration_output = await run_agent(
-        agent=data_exploration_agent,
-        user_prompt=base_prompt + get_data_exploration_prompt(iteration), #base prompt has feedback (if non-0 iter) and user prompt
+    messages, output = await run_agent(
+        agent=agent,
+        user_prompt=base_prompt + get_data_exploration_prompt(iteration),
         max_steps=config.max_steps,
         message_history=None,
         deps=data_exploration_deps,
     )
-    replace_message_result_with_validated_files(messages_data_exploration, config, since_timestamp=data_exploration_deps['start_time'])
-    persistent_messages+=get_sytem_and_user_prompt_messages(messages_data_exploration, to_remove=get_data_exploration_prompt(iteration))
-    persistent_messages+=get_final_result_messages(messages_data_exploration)
-    structured_outputs.append(data_exploration_output)
-    
+    replace_message_result_with_validated_files(messages, config, since_timestamp=data_exploration_deps['start_time'])
+    return messages, output
+
+
+@snapshotable_step("data_split")
+async def run_data_split_step(agent, config, iteration, last_split_strategy, message_history):
+    """Step 1: Data split - split data into train/validation sets"""
+    ctx_replacer_msg = "\nSummarized outputs from your previous steps are in previous messages."
     split_allowed_iterations = config.split_allowed_iterations
-    data_split_step = None
+
     if not config.explicit_valid_set_provided and iteration < split_allowed_iterations:
+        # Check if we're forking (to include user prompt override)
+        from utils.step_snapshots import StepRegistry
+        run_manager = StepRegistry._run_manager
+        is_fork = run_manager is not None and run_manager.resume_from is not None
+        config._is_fork = is_fork
         data_split_deps = {'start_time': datetime.datetime.now()}
-        messages_split, data_split = await run_agent(
-            agent=split_dataset_agent,
-            user_prompt=get_data_split_prompt(config=config, iteration=iteration, last_split_strategy=last_split_strategy)+ctx_replacer_msg,
+        messages, output = await run_agent(
+            agent=agent,
+            user_prompt=get_data_split_prompt(config=config, iteration=iteration, last_split_strategy=last_split_strategy) + ctx_replacer_msg,
             max_steps=config.max_steps,
-            message_history=persistent_messages,
+            message_history=message_history,
             deps=data_split_deps,
         )
-        replace_message_result_with_validated_files(messages_split, config, since_timestamp=data_split_deps['start_time'])
-        persistent_messages+=get_final_result_messages(messages_split)
-        data_split_step=data_split
-        structured_outputs.append(data_split)
+        replace_message_result_with_validated_files(messages, config, since_timestamp=data_split_deps['start_time'])
+        return messages, output
     else:
-        assert last_split_strategy is not None, f'Agent didnt have a chance to split data, provide a non-0 allowed split iterations (currently {config.split_allowed_iterations})'
-        manual_data_split_step = DataSplit(
-            train_path = str(config.runs_dir / config.agent_id / 'train.csv'),
-            val_path = str(config.runs_dir / config.agent_id / 'validation.csv'),
-            splitting_strategy = last_split_strategy,
+        assert last_split_strategy is not None, f'Agent didnt have a chance to split data'
+        manual_data_split = DataSplit(
+            train_path=str(config.runs_dir / config.agent_id / 'train.csv'),
+            val_path=str(config.runs_dir / config.agent_id / 'validation.csv'),
+            splitting_strategy=last_split_strategy,
             files_created=[],
         )
-        persistent_messages+=fabricate_final_result_messages(manual_data_split_step, model_name=config.model_name)
-        data_split_step=manual_data_split_step
-        structured_outputs.append(manual_data_split_step)
+        messages = fabricate_final_result_messages(manual_data_split, model_name=config.model_name)
+        return messages, manual_data_split
 
+
+@snapshotable_step("data_representation")
+async def run_data_representation_step(agent, config, message_history):
+    """Step 2: Data representation - define transformations and encodings"""
+    ctx_replacer_msg = "\nSummarized outputs from your previous steps are in previous messages."
     representation_deps = {'start_time': datetime.datetime.now()}
-    messages_representation, data_representation = await run_agent(
-        agent=data_representation_agent,
-        user_prompt=get_data_representation_prompt()+ctx_replacer_msg,
+    # Check if we're forking (to include user prompt override)
+    run_manager = StepRegistry._run_manager
+    is_fork = run_manager is not None and run_manager.resume_from is not None
+    messages, output = await run_agent(
+        agent=agent,
+        user_prompt=get_data_representation_prompt(config.user_prompt, is_fork=is_fork) + ctx_replacer_msg,
         max_steps=config.max_steps,
-        message_history=persistent_messages,
+        message_history=message_history,
         deps=representation_deps,
     )
-    replace_message_result_with_validated_files(messages_representation, config, since_timestamp=representation_deps['start_time'])
-    persistent_messages+=get_final_result_messages(messages_representation)
-    structured_outputs.append(data_representation)
+    replace_message_result_with_validated_files(messages, config, since_timestamp=representation_deps['start_time'])
+    return messages, output
 
+
+@snapshotable_step("model_architecture")
+async def run_model_architecture_step(agent, config, message_history):
+    """Step 3: Model architecture - choose model and hyperparameters"""
+    ctx_replacer_msg = "\nSummarized outputs from your previous steps are in previous messages."
     arch_deps = {'start_time': datetime.datetime.now()}
-    messages_architecture, model_architecture = await run_agent(
-        agent=model_architecture_agent,
-        user_prompt=get_model_architecture_prompt()+ctx_replacer_msg,
+    # Check if we're forking (to include user prompt override)
+    run_manager = StepRegistry._run_manager
+    is_fork = run_manager is not None and run_manager.resume_from is not None
+    messages, output = await run_agent(
+        agent=agent,
+        user_prompt=get_model_architecture_prompt(config.user_prompt, is_fork=is_fork) + ctx_replacer_msg,
         max_steps=config.max_steps,
-        message_history=persistent_messages,
+        message_history=message_history,
         deps=arch_deps,
     )
-    replace_message_result_with_validated_files(messages_architecture, config, since_timestamp=arch_deps['start_time'])
-    persistent_messages+=get_final_result_messages(messages_architecture)
-    structured_outputs.append(model_architecture)
+    replace_message_result_with_validated_files(messages, config, since_timestamp=arch_deps['start_time'])
+    return messages, output
 
-    training_deps = {'start_time': datetime.datetime.now(), 'train_csv_path':data_split_step.train_path, 'validation_csv_path':data_split_step.val_path, 'run_dir': config.runs_dir / config.agent_id}
-    messages_training, model_training = await run_agent(
-        agent=training_agent, 
-        user_prompt=get_model_training_prompt(config)+ctx_replacer_msg, 
+@snapshotable_step("model_training")
+async def run_model_training_step(agent, config, message_history):
+    """Step 4: Model training - train the model"""
+    ctx_replacer_msg = "\nSummarized outputs from your previous steps are in previous messages."
+    run_dir = config.runs_dir / config.agent_id
+    # Determine train and validation paths based on whether explicit validation set was provided
+    if config.explicit_valid_set_provided:
+        train_csv_path = config.agent_dataset_dir / "train.csv"
+        validation_csv_path = config.agent_dataset_dir / "validation.csv"
+    else:
+        train_csv_path = run_dir / "train.csv"
+        validation_csv_path = run_dir / "validation.csv"
+    
+    training_deps = {
+        'start_time': datetime.datetime.now(),
+        'run_dir': run_dir,
+        'train_csv_path': train_csv_path,
+        'validation_csv_path': validation_csv_path,
+    }
+    # Check if we're forking (to include user prompt override)
+    run_manager = StepRegistry._run_manager
+    is_fork = run_manager is not None and run_manager.resume_from is not None
+    messages, output = await run_agent(
+        agent=agent,
+        user_prompt=get_model_training_prompt(config.user_prompt, is_fork=is_fork) + ctx_replacer_msg,
         max_steps=config.max_steps,
-        message_history=persistent_messages,
+        message_history=message_history,
         deps=training_deps,
     )
-    replace_message_result_with_validated_files(messages_training, config, since_timestamp=training_deps['start_time'])
-    persistent_messages+=get_final_result_messages(messages_training)
-    structured_outputs.append(model_training)
+    replace_message_result_with_validated_files(messages, config, since_timestamp=training_deps['start_time'])
+    return messages, output
 
+
+@snapshotable_step("model_inference")
+async def run_model_inference_step(agent, config, model_training_output, message_history):
+    """Step 5: Model inference - create inference script"""
+    ctx_replacer_msg = "\nSummarized outputs from your previous steps are in previous messages."
     inference_deps = {'start_time': datetime.datetime.now()}
-    messages_inference, model_inference = await run_agent(
-        agent=inference_agent, 
-        user_prompt=get_model_inference_prompt(config, training_artifacts_dir=model_training.path_to_artifacts_dir)+ctx_replacer_msg, 
+    # Check if we're forking (to include user prompt override)
+    run_manager = StepRegistry._run_manager
+    is_fork = run_manager is not None and run_manager.resume_from is not None
+    # Mark config as fork for prompt functions that check config._is_fork
+    config._is_fork = is_fork
+
+    training_artifacts_dir = model_training_output.path_to_artifacts_dir
+
+    messages, output = await run_agent(
+        agent=agent,
+        user_prompt=get_model_inference_prompt(config, training_artifacts_dir=training_artifacts_dir) + ctx_replacer_msg,
         max_steps=config.max_steps,
-        message_history=persistent_messages,
+        message_history=message_history,
         deps=inference_deps,
     )
-    replace_message_result_with_validated_files(messages_inference, config, since_timestamp=inference_deps['start_time'])
-    persistent_messages+=get_final_result_messages(messages_inference)
-    structured_outputs.append(model_inference)
+    replace_message_result_with_validated_files(messages, config, since_timestamp=inference_deps['start_time'])
+    return messages, output
 
+
+@snapshotable_step("prediction_exploration")
+async def run_prediction_exploration_step(agent, config, iteration, model_inference_output, message_history):
+    """Step 6: Prediction exploration - analyze model predictions"""
+    ctx_replacer_msg = "\nSummarized outputs from your previous steps are in previous messages."
+    
     if not config.explicit_valid_set_provided:
         val_path = config.runs_dir / config.agent_id / 'validation.csv'
     else:
         val_path = config.agent_dataset_dir / config.dataset / "validation.csv"
-
+    
+    # Check if we're forking (to include user prompt override)
+    run_manager = StepRegistry._run_manager
+    is_fork = run_manager is not None and run_manager.resume_from is not None
     prediction_deps = {'iteration': iteration, 'start_time': datetime.datetime.now()}
-    prediction_messages, prediction_exploration = await run_agent(
-        agent=prediction_exploration_agent,
-        user_prompt=get_prediction_exploration_prompt(validation_path=val_path,inference_path=model_inference.path_to_inference_file)+ctx_replacer_msg,
+    messages, output = await run_agent(
+        agent=agent,
+        user_prompt=get_prediction_exploration_prompt(validation_path=val_path, inference_path=model_inference_output.path_to_inference_file, user_prompt=config.user_prompt, is_fork=is_fork) + ctx_replacer_msg,
         max_steps=config.max_steps,
-        message_history=persistent_messages,
+        message_history=message_history,
         deps=prediction_deps,
     )
-    replace_message_result_with_validated_files(prediction_messages, config, since_timestamp=prediction_deps['start_time'])
-    persistent_messages+=get_final_result_messages(prediction_messages) #not used
-    structured_outputs.append(prediction_exploration)
+    replace_message_result_with_validated_files(messages, config, since_timestamp=prediction_deps['start_time'])
+    return messages, output
 
+
+# ============================================================================
+# ORCHESTRATION FUNCTION
+# ============================================================================
+
+async def run_architecture_compressed(data_exploration_agent: Agent, data_representation_agent: Agent, model_architecture_agent: Agent, inference_agent: Agent, split_dataset_agent: Agent, training_agent: Agent, prediction_exploration_agent: Agent, config: Config, base_prompt: str, iteration: int, last_split_strategy: str, run_manager: RunManager = None):
+    """
+    Orchestrate all steps with automatic snapshotting.
+    
+    The decorated step functions handle snapshotting and forking automatically.
+    Orchestration handles state accumulation (persistent_messages, structured_outputs).
+    """
+    persistent_messages = []
+    structured_outputs = []
+    
+    # Use context manager to enable step tracking
+    async with step_execution_context(config, iteration, run_manager):
+        
+        # Step 0: Data Exploration
+        messages, output = await run_data_exploration_step(
+            data_exploration_agent, config, base_prompt, iteration
+        )
+        # Accumulate state
+        persistent_messages += get_sytem_and_user_prompt_messages(messages, to_remove=get_data_exploration_prompt(iteration))
+        persistent_messages += get_final_result_messages(messages)
+        structured_outputs.append(output)
+        
+        # Step 1: Data Split
+        messages, output = await run_data_split_step(
+            split_dataset_agent, config, iteration, last_split_strategy,
+            persistent_messages
+        )
+        # Accumulate state
+        persistent_messages += get_final_result_messages(messages)
+        structured_outputs.append(output)
+        
+        # Step 2: Data Representation
+        messages, output = await run_data_representation_step(
+            data_representation_agent, config, persistent_messages
+        )
+        # Accumulate state
+        persistent_messages += get_final_result_messages(messages)
+        structured_outputs.append(output)
+        
+        # Step 3: Model Architecture
+        messages, output = await run_model_architecture_step(
+            model_architecture_agent, config, persistent_messages
+        )
+        # Accumulate state
+        persistent_messages += get_final_result_messages(messages)
+        structured_outputs.append(output)
+        
+        # Step 4: Model Training
+        messages, training_output = await run_model_training_step(
+            training_agent, config, persistent_messages
+        )
+        # Accumulate state
+        persistent_messages += get_final_result_messages(messages)
+        structured_outputs.append(training_output)
+        
+        # Step 5: Model Inference
+        messages, model_inference_output = await run_model_inference_step(
+            inference_agent, config, training_output, persistent_messages
+        )
+        # Accumulate state
+        persistent_messages += get_final_result_messages(messages)
+        structured_outputs.append(model_inference_output)
+        
+        # Step 6: Prediction Exploration
+        messages, output = await run_prediction_exploration_step(
+            prediction_exploration_agent, config, iteration, model_inference_output,
+            persistent_messages
+        )
+        # Accumulate state
+        persistent_messages += get_final_result_messages(messages)
+        structured_outputs.append(output)
+    
+    # Save all outputs
     for structured_output in structured_outputs:
         save_step_output(config, type(structured_output).__name__, structured_output, iteration)
-
+    
     return structured_outputs
 
 @weave.op(call_display_name=lambda call: f"Iteration {call.inputs.get('iteration', 0)}")
-async def run_iteration(config: Config, model, iteration, feedback, tools, last_split_strategy):
+async def run_iteration(config: Config, model, iteration, feedback, tools, last_split_strategy, 
+                       resume_from: tuple = None):
+    """
+    Run a single iteration.
+    
+    Args:
+        resume_from: Optional tuple of (run_id, step_name, iteration) or 
+                     (run_id, step_name, iteration, source_user_prompt) to fork from
+    """
     agents_dict = create_agents(config=config, model=model, tools=tools)
+    
+    # Initialize RunManager (handles forking if resume_from is set)
+    # Extract source_user_prompt if provided
+    source_user_prompt = None
+    if resume_from and len(resume_from) == 4:
+        source_user_prompt = resume_from[3]
+    
+    run_manager = RunManager(config, resume_from=resume_from, source_user_prompt=source_user_prompt)
 
     if iteration == 0:
         base_prompt = get_iteration_0_prompt(config)
@@ -423,5 +581,6 @@ async def run_iteration(config: Config, model, iteration, feedback, tools, last_
         base_prompt=base_prompt,
         iteration=iteration,
         last_split_strategy=last_split_strategy,
+        run_manager=run_manager,
     )
     return structured_outputs

--- a/src/agents/steps/data_representation.py
+++ b/src/agents/steps/data_representation.py
@@ -14,5 +14,11 @@ class DataRepresentation(BaseModel):
         """
     )
 
-def get_data_representation_prompt():
-    return "Your next task: define the data representation."
+def get_data_representation_prompt(user_prompt: str = None, is_fork: bool = False):
+    base_prompt = "Your next task: define the data representation."
+    
+    # Include user prompt if provided
+    if user_prompt:
+        return f"{base_prompt}\n\nUser instructions: {user_prompt}"
+    
+    return base_prompt

--- a/src/agents/steps/data_split.py
+++ b/src/agents/steps/data_split.py
@@ -29,6 +29,8 @@ def get_data_split_prompt(config, iteration, last_split_strategy="Split does not
         extra_info = ""
     
     train_csv_path = config.agent_dataset_dir / "train.csv"
+    # Include user prompt if provided
+    user_instructions = f"\n\nUser instructions: {config.user_prompt}" if config.user_prompt else ""
     return f"""
         Your next task: Split the training dataset ({train_csv_path}) into training and validation sets:
         Ensure the validation split is representative of new unseen data, since it will be used for optimizing choices like architecture, hyperparameters, and training strategies.
@@ -36,5 +38,5 @@ def get_data_split_prompt(config, iteration, last_split_strategy="Split does not
         - Save 'train.csv' and 'validation.csv' in {config.runs_dir / config.agent_id}.
         Return the absolute paths to these files.
 
-        {extra_info}
+        {extra_info}{user_instructions}
         """

--- a/src/agents/steps/model_architecture.py
+++ b/src/agents/steps/model_architecture.py
@@ -19,6 +19,17 @@ class ModelArchitecture(BaseModel):
         """
     )
 
-def get_model_architecture_prompt():
-    return """Your next task: choose the model architecture and hyperparameters.
+
+def get_model_architecture_prompt(user_prompt: str = None, is_fork: bool = False):
     """
+    Prompt for choosing model architecture and hyperparameters.
+
+    If a custom user prompt is provided (either from the CLI or inherited
+    when forking), append it as explicit user instructions.
+    """
+    base_prompt = "Your next task: choose the model architecture and hyperparameters."
+    
+    if user_prompt:
+        return f"{base_prompt}\n\nUser instructions: {user_prompt}"
+    
+    return base_prompt

--- a/src/agents/steps/model_inference.py
+++ b/src/agents/steps/model_inference.py
@@ -45,6 +45,8 @@ def get_model_inference_prompt(config, training_artifacts_dir):
     
     #TODO "Except the target column" - use target/class/numeric_label?
     #TODO validate the script uses the artifacts-dir stuff and has not hard-coded paths
+    # Include user prompt if provided
+    user_instructions = f"\n\nUser instructions: {config.user_prompt}" if getattr(config, "user_prompt", None) else ""
     return f"""
     Your next task: create inference.py file.
     If your model can be accelerated by GPU, implement the code to use GPU.
@@ -54,7 +56,7 @@ def get_model_inference_prompt(config, training_artifacts_dir):
     --input (an input file path). This file is of the same format as your training data (except the target column)
     --output (the output file path). {output_file_description}
     --artifacts-dir (the folder that contains training artifacts from the training step that are needed to run inference (for example model weights, tokenizers, etc..). The following dir should be used as a default: '{training_artifacts_dir}'. If a different path is provided, your script must adapt to the new source. You can assume the artifact files will always have the same name. 
-    The script must not accept any other parameters.
+    The script must not accept any other parameters.{user_instructions}
     """
 
 def lock_inference_file(path_to_inference_file):

--- a/src/agents/steps/model_training.py
+++ b/src/agents/steps/model_training.py
@@ -1,6 +1,7 @@
 import subprocess
 import traceback
 import shutil
+import warnings
 
 from pydantic import BaseModel, Field
 from pydantic.json_schema import SkipJsonSchema
@@ -29,22 +30,6 @@ class ModelTraining(BaseModel):
         List of files created during model training step. Populated programmatically.
         """
     )
-
-def get_model_training_prompt(config):
-    return f"""
-    Your next task: implement training code and train your model.
-    Training guidelines:
-    - Train until validation performance stops improving, and output the best checkpoint.
-    - Save all artifacts needed for inference (model file, tokenizers, etc...).
-    - If you failed to implement your intended model, when you call the final_output tool, put into unresolved issues what went wrong.
-    {"If your model can be accelerated by GPU, implement the code to use GPU." if config.check_gpu_availability() else ""}
-
-    The train script should take the following parameters
-    --train-data (a path to the training data csv)
-    --validation-data (a path to the validation data csv. For example for the purposes of early-stopping. If the training script doesn't need validation data, still include the argument for compatibility and don't use it.)
-    --artifacts-dir (path to a directory that will be populated by the training script with artifacts needed to use the trained model for predictions (e.g. produced model weights, produced tokenizers, ...). This directory should not contain any other external sources like imported scripts, conda packages, foundation models, etc..)
-    The script must not accept any other parameters.
-    """
 
 def retrain_and_check(config, train_data_path, valid_data_path, train_script_path, model_file_name):
     run_dir = config.runs_dir / config.agent_id
@@ -80,10 +65,17 @@ def retrain_and_check(config, train_data_path, valid_data_path, train_script_pat
         # Check if model file was created
         expected_model_path = temp_artifacts_dir / model_file_name
         if not expected_model_path.exists():
-            error_msg = f"Training script validation failed: After running the training script, model file '{model_file_name}' was not created in the specified artifacts folder. "
+            # List all files that were actually created
+            created_files = list(temp_artifacts_dir.iterdir())
+            created_files_names = [f.name for f in created_files]
+            error_msg = f"Training script validation failed: After running the training script, model file '{model_file_name}' was not created in the specified artifacts folder ({temp_artifacts_dir}). "
             error_msg += f"Return code: {training_out.returncode}. "
-            error_msg += f"Stderr: {training_out.stderr}"
-            error_msg += f"Stdout: {training_out.stdout}"
+            if created_files_names:
+                error_msg += f"Files found in artifacts folder: {created_files_names}. "
+            else:
+                error_msg += f"No files were created in the artifacts folder. "
+            error_msg += f"Stderr: {training_out.stderr.decode() if isinstance(training_out.stderr, bytes) else training_out.stderr} "
+            error_msg += f"Stdout: {training_out.stdout.decode() if isinstance(training_out.stdout, bytes) else training_out.stdout}"
             raise ModelRetry(error_msg)
         print('TRAINING REPRODUCIBILITY OK')
 
@@ -113,9 +105,20 @@ def get_dataset_subset(data_path, target_col, task_type):
 
     if task_type == 'classification':
         # For classification: balance samples per label
-        subset = df.groupby(target_col, group_keys=False).apply(
-            lambda x: x.sample(n=min(len(x), clf_per_label_samples), random_state=42)
-        ).reset_index(drop=True)
+        # Suppress FutureWarning about groupby.apply operating on grouping columns
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', category=FutureWarning)
+            try:
+                # Try with include_groups parameter (pandas >= 2.2.0)
+                subset = df.groupby(target_col, group_keys=False).apply(
+                    lambda x: x.sample(n=min(len(x), clf_per_label_samples), random_state=42),
+                    include_groups=False
+                ).reset_index(drop=True)
+            except TypeError:
+                # Fall back to old behavior if include_groups is not available
+                subset = df.groupby(target_col, group_keys=False).apply(
+                    lambda x: x.sample(n=min(len(x), clf_per_label_samples), random_state=42)
+                ).reset_index(drop=True)
     elif task_type == 'regression':
         # For regression: random sample from entire dataset
         total_samples = min(len(df), reg_samples)
@@ -124,3 +127,26 @@ def get_dataset_subset(data_path, target_col, task_type):
         raise ValueError(f"Unknown task type: {task_type}. Supported types are 'classification' and 'regression'.")
 
     return subset
+
+
+def get_model_training_prompt(user_prompt: str = None, is_fork: bool = False):
+    """
+    Prompt for implementing and running model training.
+
+    Supports an optional user_prompt (including when forking) that is
+    appended as explicit user instructions.
+    """
+    base_prompt = """
+    Your next task: implement any necessary code for training a model. Then train a single model.
+    The train script should save any files necessary to use the trained model for predictions (e.g. model file, tokenizers, ...).
+    If your model can be accelerated by GPU, implement the code to use GPU.
+    """
+    
+    if user_prompt:
+        return f"""
+    {base_prompt.strip()}
+    
+    User instructions: {user_prompt}
+    """
+    
+    return base_prompt

--- a/src/agents/steps/prediction_exploration.py
+++ b/src/agents/steps/prediction_exploration.py
@@ -20,8 +20,14 @@ class PredictionExploration(BaseModel):
         """
     )
 
-def get_prediction_exploration_prompt(validation_path, inference_path):
-    return f"""
+def get_prediction_exploration_prompt(validation_path, inference_path, user_prompt: str = None, is_fork: bool = False):
+    base_prompt = f"""
         Your next task: Generate predictions on the validation set ({validation_path}) and identify where those predictions succeed, fail, and prediction biases.
         You can use but not modify the inference script ({inference_path}). If you need to write code for prediction generation and/or analysis, create a separate script.
         """
+    
+    # Include user prompt if provided
+    if user_prompt:
+        return f"{base_prompt.strip()}\n\nUser instructions: {user_prompt}"
+    
+    return base_prompt

--- a/src/run_agent.py
+++ b/src/run_agent.py
@@ -3,11 +3,21 @@ import traceback
 import argparse
 from pathlib import Path
 import os
+import sys
 import time
+import json
+import warnings
+
+# Suppress noisy Pydantic warnings from dependencies
+warnings.filterwarnings('ignore', category=UserWarning, module='pydantic._internal._generate_schema')
 
 import wandb
 import weave
 from timeout_function_decorator import timeout as timeout_decorator
+from rich.console import Console
+from rich.panel import Panel
+
+console = Console()
 
 from run_logging.evaluate_log_run import run_inference_and_log
 from run_logging.logging_helpers import log_serial_metrics, log_feedback_failure, log_iteration_duration, log_new_best
@@ -27,13 +37,77 @@ from utils.report_logger import add_metrics_to_report, add_summary_to_report
 from utils.providers.provider import Provider, get_provider_from_string
 from feedback.feedback_agent import get_feedback
 from tools.setup_tools import create_tools, get_tool_names
-from utils.snapshots import reset_snapshot_if_val_split_changed, create_split_fingerprint, wipe_current_iter_files, delete_metrics_from_iteration_dir
+from utils.snapshots import reset_snapshot_if_val_split_changed, create_split_fingerprint, wipe_current_iter_files, delete_metrics_from_iteration_dir, get_best_iteration
 from agents.steps.data_split import DataSplit
+from utils.step_snapshots import get_latest_iteration, Step
+
+def load_source_run_config(workspace_dir: Path, fork_from_run: str):
+    """Load configuration from a source run for forking"""
+    storage_config_path = Path(workspace_dir) / ".agentomics_storage" / "config.json"
+    
+    if not storage_config_path.exists():
+        console.print(Panel(
+            f"[red]Cannot fork from run '{fork_from_run}'[/red]\n\n"
+            f"[bold]Reason:[/bold] Config file not found at:\n"
+            f"  [dim]{storage_config_path}[/dim]\n\n"
+            f"[bold]This usually means:[/bold]\n"
+            f"  • The run doesn't exist yet\n"
+            f"  • The run was created before config tracking was added\n\n"
+            f"[bold]To fix:[/bold]\n"
+            f"  1. Verify the run ID is correct\n"
+            f"  2. Re-run the original experiment to generate the config\n"
+            f"  3. Then try forking again",
+            title="Fork Error",
+            border_style="red"
+        ))
+        raise ValueError(f"Source run config not found: {storage_config_path}")
+    
+    with open(storage_config_path) as f:
+        return json.load(f)
 
 async def main(model_name, feedback_model_name, dataset, tags, val_metric,
                workspace_dir, prepared_datasets_dir, prepared_test_sets_dir, agent_datasets_dir, iterations, 
-               user_prompt, provider_name, on_new_best_callbacks, split_allowed_iterations, time_deadline):
+               user_prompt, provider_name, on_new_best_callbacks, split_allowed_iterations, time_deadline,
+               fork_from_run=None, fork_from_step=None, fork_from_iteration=None):
     agent_id = os.getenv('AGENT_ID')
+    
+    # If forking, validate configuration (already loaded in run_experiment)
+    source_config_dict = None
+    if fork_from_run and fork_from_step:
+        source_config_dict = load_source_run_config(workspace_dir, fork_from_run)
+        
+        # Validate dataset matches source
+        source_dataset = source_config_dict.get('dataset')
+        if dataset != source_dataset:
+            raise ValueError(
+                f"Dataset mismatch!\n"
+                f"  Source run used: {source_dataset}\n"
+                f"  Current config:  {dataset}\n"
+                f"  This should not happen - please report as a bug."
+            )
+        
+        # Determine what was inherited vs provided
+        default_prompt = "Create the best possible machine learning model that will generalize to new unseen data."
+        source_prompt = source_config_dict.get('user_prompt', default_prompt)
+        source_metric = source_config_dict.get('val_metric')
+        
+        prompt_inherited = (user_prompt == source_prompt)
+        metric_inherited = (val_metric == source_metric)
+        
+        # Print summary of fork configuration
+        config_text = f"[bold]Dataset:[/bold]         {dataset}\n"
+        config_text += f"                   [dim](from source run)[/dim]\n\n"
+        config_text += f"[bold]Val Metric:[/bold]      {val_metric}\n"
+        config_text += f"                   [dim]{'(from source run)' if metric_inherited else '(custom override)'}[/dim]\n\n"
+        
+        # Always show the actual prompt being used
+        prompt_display = user_prompt if len(user_prompt) <= 60 else user_prompt[:60] + '...'
+        config_text += f"[bold]User Prompt:[/bold]     [dim]{'(from source run)' if prompt_inherited else '(custom override)'}[/dim]\n"
+        config_text += f"                   [italic]{prompt_display}[/italic]"
+        
+        console.print(Panel(config_text, title="Fork Configuration", border_style="cyan"))
+    
+    # Initialize configuration
     # Initialize configuration 
     config = Config(
         agent_id=agent_id,
@@ -55,6 +129,26 @@ async def main(model_name, feedback_model_name, dataset, tags, val_metric,
     create_run_and_snapshot_dirs(config)
     config.print_summary()
     
+    # Save config to .agentomics_storage at start of run (for forking later)
+    export_config_to_snapshot(config)
+    
+    # Handle fork parameters
+    resume_from = None
+    if fork_from_run and fork_from_step:
+        # Use source_config_dict loaded earlier
+        if source_config_dict is None:
+            source_config_dict = load_source_run_config(workspace_dir, fork_from_run)
+        
+        # Auto-select iteration if not specified (defaults to latest)
+        if fork_from_iteration is None:
+            fork_from_iteration = get_latest_iteration(config.workspace_dir, fork_from_run)
+            print(f"Auto-selected latest iteration: {fork_from_iteration}")
+        
+        # Include source user prompt in resume_from for lineage tracking
+        source_user_prompt_for_lineage = source_config_dict.get('user_prompt', user_prompt)
+        resume_from = (fork_from_run, fork_from_step, fork_from_iteration, source_user_prompt_for_lineage)
+        print(f"Forking from run '{fork_from_run}' at step '{fork_from_step}' (iteration {fork_from_iteration})")
+    
     # initialize logging
     if are_wandb_vars_available():
         wandb_logged_in = setup_logging(config)
@@ -66,13 +160,14 @@ async def main(model_name, feedback_model_name, dataset, tags, val_metric,
     feedback_model = provider.create_model(config.feedback_model_name, config)
     #TODO Instantiate report logger model and pass it to add_summary_to_report
 
-    await run_agentomics(config=config, default_model=default_model, feedback_model=feedback_model, on_new_best_callbacks=on_new_best_callbacks, provider=provider)
+    await run_agentomics(config=config, default_model=default_model, feedback_model=feedback_model, 
+                        on_new_best_callbacks=on_new_best_callbacks, provider=provider, resume_from=resume_from)
 
     if(wandb_logged_in):
         wandb.finish()
 
 @weave.op(call_display_name=lambda call: f"Agentomics run - agent_id: {call.inputs['config'].agent_id}")
-async def run_agentomics(config: Config, default_model, feedback_model, on_new_best_callbacks, provider):
+async def run_agentomics(config: Config, default_model, feedback_model, on_new_best_callbacks, provider, resume_from=None):
     tools = create_tools(config)
     
     iter_to_outputs = {}
@@ -92,6 +187,10 @@ async def run_agentomics(config: Config, default_model, feedback_model, on_new_b
         try:
             # Not using feedback from failed iterations
             feedback = iter_to_feedback[last_successful_iter] if (last_successful_iter is not None) else "No instructions available"
+            
+            # Only use resume_from on the first iteration
+            iteration_resume_from = resume_from if run_index == 0 else None
+            
             structured_outputs = await run_iteration(
                 config=config,
                 model=default_model, 
@@ -99,6 +198,7 @@ async def run_agentomics(config: Config, default_model, feedback_model, on_new_b
                 feedback=feedback, 
                 tools=tools,
                 last_split_strategy=last_split_strategy,
+                resume_from=iteration_resume_from,
             )
             iter_to_duration[run_index] = time.time() - start
             log_iteration_duration(iteration=run_index, duration=iter_to_duration[run_index])
@@ -157,7 +257,9 @@ async def run_agentomics(config: Config, default_model, feedback_model, on_new_b
         is_current_new_best = is_new_best(config)
         if(is_current_new_best):
             log_new_best(iteration=run_index)
-            snapshot(config=config, iteration=run_index, structured_outputs=structured_outputs)  # Snapshotting overrides the previous snapshot, influencing the get_new_and_best_metrics function
+            # Snapshotting overrides the previous snapshot, influencing the get_new_and_best_metrics function
+            snapshot(config, run_index, structured_outputs)
+            # Also persist the latest config to .agentomics_storage for future forking
             export_config_to_snapshot(config)
             for callback in on_new_best_callbacks:
                 callback(config)
@@ -187,11 +289,22 @@ async def run_agentomics(config: Config, default_model, feedback_model, on_new_b
         add_metrics_to_report(config, run_index, new_metrics)
         await add_summary_to_report(default_model, config, run_index)
         log_files(config, iteration=run_index)
+    
+    # After all iterations, ensure we have a final snapshot
+    # This is important for forked runs that may not produce a "new best"
+    snapshot_dir = config.snapshots_dir / config.agent_id
+    if not snapshot_dir.exists() or not list(snapshot_dir.glob("*.py")):
+        # No snapshot exists yet, create one from the last successful iteration
+        if last_successful_iter is not None:
+            print(f"\nCreating final snapshot from iteration {last_successful_iter}...")
+            snapshot(config, last_successful_iter, iter_to_outputs[last_successful_iter])
+        else:
+            print("\nWarning: No successful iterations to snapshot")
 
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Runs agent and outputs results to the workspace directory")
-    parser.add_argument('--dataset-name', required=True, help='Name of the folder containing dataset files')
+    parser.add_argument('--dataset-name', help='Name of the folder containing dataset files (auto-detected when forking)')
     parser.add_argument('--model', help='LLM model to use', required=True)
     parser.add_argument('--provider', required=True, help=f'API provider to use. Available: {Provider.get_available_providers()}.')
     parser.add_argument('--workspace-dir', type=Path, default=Path('../workspace').resolve(), help='Path to a directory which will store agent runs, snapshots, and reports')
@@ -202,17 +315,57 @@ def parse_args():
     parser.add_argument('--iterations', type=int, default=5, help='Number of training iterations to run')
     parser.add_argument("--timeout", type=int, help="Timeout before the run is shut down in seconds")
     parser.add_argument('--split-allowed-iterations', type=int, default=1, help='Number of initial iterations that allow the agent to split the data into training and validation sets')
-
-    parser.add_argument('--user-prompt', type=str, default="Develop a machine learning model that generalizes well to new unseen data.", help='(Optional) Text to overwrite the default user prompt')
+    parser.add_argument('--user-prompt', type=str, default="Create the best possible machine learning model that will generalize to new unseen data.", help='(Optional) Custom instructions for the agent. When forking, inherits from source run unless explicitly provided.')
 
     val_metric_choices = get_classification_metrics_names() + get_regression_metrics_names()
-    parser.add_argument('--val-metric', help='Validation metric to use for the best model selection', required=True, choices=val_metric_choices)
+    parser.add_argument('--val-metric', help='Validation metric to use for the best model selection (auto-detected when forking)', choices=val_metric_choices)
+
+    # Fork arguments
+    fork_group = parser.add_argument_group('forking', 'Fork from a previous run')
+    fork_group.add_argument('--fork-from-run', type=str, help='Run ID to fork from')
+    fork_group.add_argument('--fork-from-step', type=str, 
+                           choices=Step.get_step_names(),
+                           help='Step name to fork from')
+    fork_group.add_argument('--fork-from-iteration', type=int, default=None, 
+                           help='Iteration to fork from. If omitted, uses the latest (most recent) iteration.')
 
     return parser.parse_args()
 
 async def run_experiment(model, dataset_name, val_metric, prepared_datasets_dir, prepared_test_sets_dir, agent_datasets_dir,
                           workspace_dir, tags, iterations, user_prompt, provider, timeout, 
-                          split_allowed_iterations=1, on_new_best_callbacks=[]):
+                          split_allowed_iterations=1, on_new_best_callbacks=[],
+                          fork_from_run=None, fork_from_step=None, fork_from_iteration=None):
+    
+    # If forking, load dataset/val_metric/user_prompt from source BEFORE setup
+    if fork_from_run and fork_from_step:
+        print(f"\n{'='*70}")
+        print(f"FORK: Loading configuration from source run...")
+        print(f"{'='*70}")
+        
+        source_config = load_source_run_config(workspace_dir, fork_from_run)
+        
+        # Auto-fill dataset if not provided
+        if dataset_name is None:
+            dataset_name = source_config.get('dataset')
+            print(f"[FORK] Auto-detected dataset: {dataset_name}")
+        
+        # Auto-fill val_metric if not provided
+        if val_metric is None:
+            val_metric = source_config.get('val_metric')
+            print(f"[FORK] Auto-detected validation metric: {val_metric}")
+        
+        # Auto-fill user_prompt if not provided
+        default_prompt = "Create the best possible machine learning model that will generalize to new unseen data."
+        if user_prompt == default_prompt:
+            source_prompt = source_config.get('user_prompt', default_prompt)
+            user_prompt = source_prompt
+            print(f"[FORK] Using user prompt from source run")
+        else:
+            print(f"[FORK] Using custom user prompt (not from source)")
+        
+        print(f"[FORK] Active user_prompt: {user_prompt[:80]}{'...' if len(user_prompt) > 80 else ''}")
+        print(f"{'='*70}\n")
+    
     setup_nonsensitive_dataset_files_for_agent(
         prepared_datasets_dir=Path(prepared_datasets_dir),
         agent_datasets_dir=Path(agent_datasets_dir),
@@ -239,6 +392,9 @@ async def run_experiment(model, dataset_name, val_metric, prepared_datasets_dir,
             split_allowed_iterations=split_allowed_iterations,
             prepared_test_sets_dir=prepared_test_sets_dir,
             time_deadline=time_deadline,
+            fork_from_run=fork_from_run,
+            fork_from_step=fork_from_step,
+            fork_from_iteration=fork_from_iteration,
         )
     except TimeoutError:
         print('Timeout reached')
@@ -247,6 +403,20 @@ async def run_experiment(model, dataset_name, val_metric, prepared_datasets_dir,
 
 async def run_experiment_from_terminal():
     args = parse_args()
+    
+    # Validate required arguments (can be auto-filled when forking)
+    is_forking = args.fork_from_run and args.fork_from_step
+    
+    if not is_forking:
+        # When NOT forking, dataset and val_metric are required
+        if not args.dataset_name:
+            print("Error: --dataset-name is required when not forking")
+            print("Use --fork-from-run to auto-detect dataset from source run")
+            sys.exit(1)
+        if not args.val_metric:
+            print("Error: --val-metric is required when not forking")
+            print("Use --fork-from-run to auto-detect metric from source run")
+            sys.exit(1)
 
     await run_experiment(
         model=args.model, 
@@ -262,6 +432,9 @@ async def run_experiment_from_terminal():
         provider=args.provider,
         split_allowed_iterations=args.split_allowed_iterations,
         timeout=args.timeout,
+        fork_from_run=args.fork_from_run,
+        fork_from_step=args.fork_from_step,
+        fork_from_iteration=args.fork_from_iteration,
     )
 
 if __name__ == "__main__":

--- a/src/run_agent_interactive.py
+++ b/src/run_agent_interactive.py
@@ -2,10 +2,14 @@ import argparse
 import sys
 import asyncio
 from pathlib import Path
+import warnings
 from rich.console import Console
 from rich.panel import Panel
 import json
 import dotenv
+
+# Suppress noisy Pydantic warnings from dependencies
+warnings.filterwarnings('ignore', category=UserWarning, module='pydantic._internal._generate_schema')
 
 from utils.dataset_utils import get_all_prepared_datasets_info
 from utils.datasets_interactive_utils import interactive_dataset_selection, print_datasets_table
@@ -14,6 +18,7 @@ from utils.providers.provider import Provider, get_provider_and_api_key
 from utils.metrics import get_classification_metrics_names, get_regression_metrics_names
 from utils.env_utils import are_wandb_vars_available
 from utils.user_input import get_user_input_for_int
+from utils.step_snapshots import Step
 from run_agent import run_experiment
 
 console = Console()
@@ -37,16 +42,21 @@ def main():
     parser.add_argument("--list-datasets", action="store_true", help="List available datasets and exit")
     parser.add_argument("--list-metrics", action="store_true", help="List available validation metrics and exit")
     parser.add_argument("--root-privileges", action="store_true", help="Whether the script has root privileges to create a new user for the agent (recommended)")
-    parser.add_argument("--dataset", help="Dataset name")
+    parser.add_argument("--dataset", help="Dataset name (auto-detected when forking)")
     parser.add_argument("--iterations", type=int, help="Number of iterations to run")
     parser.add_argument("--timeout", type=int, help="Timeout before the run is shut down in seconds")
     parser.add_argument("--split-allowed-iterations", type=int, help="Number of initial iterations that are allowed to (re)split the data into train/validation", default=1)
     parser.add_argument("--tags", nargs="*", default=[], help="(Optional) Comma-separated tags to associate with the run")
-    parser.add_argument('--user-prompt', type=str, default="Develop a machine learning model that generalizes well to new unseen data.", help='(Optional) Text to overwrite the default user prompt')
+    parser.add_argument('--user-prompt', type=str, default="Create the best possible machine learning model that will generalize to new unseen data.", help='(Optional) Custom instructions for the agent. When forking, inherits from source run unless explicitly provided.')
     parser.add_argument("--model", help="Model name. Should be compatible with the selected provider")
 
     available_metrics = get_classification_metrics_names() + get_regression_metrics_names()
-    parser.add_argument("--val-metric", help="Validation metric", choices=available_metrics)
+    parser.add_argument("--val-metric", help="Validation metric (auto-detected when forking)", choices=available_metrics)
+    
+    # Fork arguments
+    parser.add_argument('--fork-from-run', type=str, help='The run ID to fork from')
+    parser.add_argument('--fork-from-step', type=str, choices=Step.get_step_names(), help='Step name to fork from')
+    parser.add_argument('--fork-from-iteration', type=int, help='(Optional) Specific iteration to fork from. If omitted, uses the latest iteration.')
     
     args = parser.parse_args()
     dotenv.load_dotenv()
@@ -86,10 +96,15 @@ def main():
         display_metrics_table()  # Show all metrics when listing
         return 0
     
+    # Check if we're forking
+    is_forking = args.fork_from_run and args.fork_from_step
+    
     # For interactive mode (when dataset/model/val_metric missing), require interactive terminal
-    if (not dataset or not model or not args.val_metric) and not check_tty_available():
+    # UNLESS we're forking (in which case these are auto-detected)
+    if not is_forking and (not dataset or not model or not args.val_metric) and not check_tty_available():
         console.print("Interactive terminal required for dataset/model/val_metric selection but not available", style="red")
         console.print("For non-interactive use, specify --dataset, --model, and --val-metric arguments", style="cyan")
+        console.print("Or use --fork-from-run to fork from an existing run (auto-detects parameters)", style="cyan")
         console.print("Example: python agentomics-entrypoint.py --dataset breast_cancer --model 'openai/gpt-4' --val-metric 'ACC'", style="cyan")
         return 1
     
@@ -98,22 +113,35 @@ def main():
         console.print("To setup wandb, provide WANDB_API_KEY, WANDB_PROJECT_NAME, and WANDB_ENTITY env variables", style="yellow")
     
     # Go to interactive selection if dataset/model/val_metric not provided
+    # When forking, these will be auto-detected from source run
     print_welcome()
-    if not dataset:
-        datasets = get_all_prepared_datasets_info(paths["prepared_datasets_dir"], paths["prepared_test_sets_dir"])
-        dataset = interactive_dataset_selection(datasets)
-        if not dataset:
-            console.print("No dataset selected", style="red")
-            return 1
     
-    # Load metadata
-    prepared_dataset_path = Path(paths["prepared_datasets_dir"]) / dataset
-    metadata_path = prepared_dataset_path / "metadata.json"
-    metadata = json.loads(metadata_path.read_text())
-    task_type = metadata.get("task_type")
+    if not is_forking:
+        # Not forking: need to select dataset and val_metric interactively if missing
+        if not dataset:
+            datasets = get_all_prepared_datasets_info(paths["prepared_datasets_dir"])
+            dataset = interactive_dataset_selection(datasets)
+            if not dataset:
+                console.print("No dataset selected", style="red")
+                return 1
+        
+        # Load metadata for task type (needed for metric selection)
+        prepared_dataset_path = Path(paths["prepared_datasets_dir"]) / dataset
+        metadata_path = prepared_dataset_path / "metadata.json"
+        metadata = json.loads(metadata_path.read_text())
+        task_type = metadata.get("task_type")
 
-    if not val_metric:
-        val_metric = interactive_metric_selection(task_type)
+        if not val_metric:
+            val_metric = interactive_metric_selection(task_type)
+    else:
+        # Forking: dataset and val_metric will be auto-detected
+        # But we still need task_type for the run_experiment call if dataset was provided
+        if dataset:
+            prepared_dataset_path = Path(paths["prepared_datasets_dir"]) / dataset
+            metadata_path = prepared_dataset_path / "metadata.json"
+            if metadata_path.exists():
+                metadata = json.loads(metadata_path.read_text())
+                task_type = metadata.get("task_type")
     
     if not model:
         model = provider.interactive_model_selection(limit=50)
@@ -136,6 +164,9 @@ def main():
         provider=provider_name,
         split_allowed_iterations=args.split_allowed_iterations,
         timeout=args.timeout,
+        fork_from_run=args.fork_from_run,
+        fork_from_step=args.fork_from_step,
+        fork_from_iteration=args.fork_from_iteration,
     ))
     return 0
         

--- a/src/run_logging/evaluate_log_test.py
+++ b/src/run_logging/evaluate_log_test.py
@@ -32,7 +32,11 @@ def load_run_config(snapshots_dir):
     assert len(subdirs) > 0, 'No snapshot folder found'
     assert len(subdirs) == 1, f'Expected 1 snapshot folder, found {len(subdirs)}'
     snapshot_dir = subdirs[0]
-    config_path = snapshot_dir.resolve() / "config.json"
+    
+    # Load config from .agentomics_storage
+    workspace_dir = snapshots_dir.parent
+    config_path = workspace_dir / ".agentomics_storage" / "config.json"
+    
     with open(config_path, 'r') as f:
         config_dict = json.load(f)
 

--- a/src/run_logging/log_files.py
+++ b/src/run_logging/log_files.py
@@ -36,5 +36,11 @@ def export_config_to_snapshot(config):
         if isinstance(value, Path):
             config_dict[key] = str(value)
 
-    config_path = (config.snapshots_dir / config.agent_id).resolve() / "config.json"
-    config_path.write_text(json.dumps(config_dict, indent=2))
+    # Save to .agentomics_storage
+    storage_dir = config.workspace_dir / ".agentomics_storage"
+    storage_dir.mkdir(parents=True, exist_ok=True, mode=0o755)
+    storage_dir.chmod(0o755)
+    
+    storage_config_path = storage_dir / "config.json"
+    storage_config_path.write_text(json.dumps(config_dict, indent=2))
+    storage_config_path.chmod(0o644)

--- a/src/utils/content_store.py
+++ b/src/utils/content_store.py
@@ -1,0 +1,211 @@
+"""
+Content-addressed storage for workspace snapshots.
+
+This module implements a git-like object store where files are stored once
+by their content hash, and snapshots reference these files via lightweight manifests.
+
+Directory Structure:
+    .agentomics_storage/
+    ├── objects/          # Content-addressed file storage (deduplicated)
+    │   └── {hash[:2]}/
+    │       └── {hash[2:]}
+    ├── snapshots/        # Step-level snapshot manifests
+    │   └── {run_id}/
+    │       └── iteration_{N}/
+    │           └── {step_index:02d}_{step_name}.json
+    └── configs/          # Run configuration files
+        └── {run_id}.json
+"""
+
+import hashlib
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+class ContentAddressedStore:
+    """
+    Git-like content-addressed storage for workspace snapshots.
+    
+    Files are stored once by their SHA-256 hash, and snapshots
+    just reference these hashes. This dramatically reduces storage
+    through deduplication.
+    """
+    
+    def __init__(self, workspace_dir: Path):
+        self.workspace_dir = Path(workspace_dir)
+        self.storage_dir = self.workspace_dir / ".agentomics_storage"
+        self.objects_dir = self.storage_dir / "objects"
+        self.snapshots_dir = self.storage_dir / "snapshots"
+        
+        # Create storage directories with readable permissions (755 = rwxr-xr-x)
+        self.objects_dir.mkdir(parents=True, exist_ok=True, mode=0o755)
+        self.snapshots_dir.mkdir(parents=True, exist_ok=True, mode=0o755)
+        
+        # Ensure parent directories also have readable permissions
+        self.storage_dir.chmod(0o755)
+        self.objects_dir.chmod(0o755)
+        self.snapshots_dir.chmod(0o755)
+    
+    def compute_file_hash(self, file_path: Path) -> str:
+        """Compute SHA-256 hash of a file"""
+        hasher = hashlib.sha256()
+        with open(file_path, 'rb') as f:
+            while chunk := f.read(65536):  # 64KB chunks
+                hasher.update(chunk)
+        return hasher.hexdigest()
+    
+    def store_file(self, file_path: Path) -> str:
+        """
+        Store a file in the object store.
+        
+        Returns: The hash of the stored file.
+        If file already exists (same hash), does nothing (deduplication!).
+        """
+        # Compute hash
+        file_hash = self.compute_file_hash(file_path)
+        
+        # Object path: objects/a1/23f4d5e6...
+        # (First 2 chars as directory, like git)
+        obj_dir = self.objects_dir / file_hash[:2]
+        obj_path = obj_dir / file_hash[2:]
+        
+        # If object already exists, we're done (deduplication!)
+        if obj_path.exists():
+            return file_hash
+        
+        # Store the file with readable permissions
+        obj_dir.mkdir(exist_ok=True, mode=0o755)
+        obj_dir.chmod(0o755)  # Ensure it has correct permissions if it already existed
+        
+        shutil.copy2(file_path, obj_path)
+        obj_path.chmod(0o644)  # Make file readable (rw-r--r--)
+        
+        return file_hash
+    
+    def store_directory(self, dir_path: Path, exclude_patterns: List[str] = None) -> Dict[str, str]:
+        """
+        Store all files in a directory.
+        
+        Returns: A manifest mapping relative paths to file hashes.
+        Example:
+            {
+                "train.csv": "a123f4d5...",
+                "validation.csv": "b789c2e1...",
+                "models/model.py": "c456d7e8..."
+            }
+        """
+        exclude_patterns = exclude_patterns or []
+        manifest = {}
+        
+        for item in dir_path.rglob("*"):
+            # Skip if not a file
+            if not item.is_file():
+                continue
+            
+            # Skip excluded patterns
+            if any(pattern in str(item) for pattern in exclude_patterns):
+                continue
+            
+            # Get relative path
+            rel_path = str(item.relative_to(dir_path))
+            
+            # Store file and get hash
+            file_hash = self.store_file(item)
+            manifest[rel_path] = file_hash
+        
+        return manifest
+    
+    def save_snapshot(self, run_id: str, iteration: int, step_name: str, 
+                     manifest: Dict[str, str], metadata: Dict):
+        """
+        Save a snapshot manifest.
+        
+        The manifest is just a JSON file mapping paths to hashes.
+        It's tiny (few KB), even if the workspace is huge.
+        """
+        snapshot_dir = self.snapshots_dir / run_id / f"iteration_{iteration}"
+        snapshot_dir.mkdir(parents=True, exist_ok=True, mode=0o755)
+        
+        # Ensure parent directories have correct permissions
+        run_dir = self.snapshots_dir / run_id
+        if run_dir.exists():
+            run_dir.chmod(0o755)
+        snapshot_dir.chmod(0o755)
+        
+        snapshot_file = snapshot_dir / f"{step_name}.json"
+        
+        snapshot_data = {
+            "manifest": manifest,
+            "metadata": metadata
+        }
+        
+        with open(snapshot_file, 'w') as f:
+            json.dump(snapshot_data, f, indent=2)
+        
+        # Make snapshot file readable
+        snapshot_file.chmod(0o644)
+    
+    def load_snapshot(self, run_id: str, iteration: int, step_name: str) -> tuple[Dict[str, str], Dict]:
+        """Load a snapshot manifest"""
+        snapshot_file = self.snapshots_dir / run_id / f"iteration_{iteration}" / f"{step_name}.json"
+        
+        if not snapshot_file.exists():
+            raise ValueError(f"Snapshot not found: {snapshot_file}")
+        
+        with open(snapshot_file, 'r') as f:
+            snapshot_data = json.load(f)
+        
+        return snapshot_data["manifest"], snapshot_data["metadata"]
+    
+    def restore_file(self, file_hash: str, dest_path: Path):
+        """Restore a file from the object store to a destination"""
+        obj_path = self.objects_dir / file_hash[:2] / file_hash[2:]
+        
+        if not obj_path.exists():
+            raise ValueError(f"Object not found: {file_hash}")
+        
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        
+        # Try copy-on-write, fallback to regular copy
+        if not self._try_cow_copy(obj_path, dest_path):
+            shutil.copy2(obj_path, dest_path)
+    
+    def _try_cow_copy(self, src: Path, dest: Path) -> bool:
+        """Try copy-on-write, return True if successful"""
+        try:
+            if sys.platform == 'darwin':
+                # macOS APFS clonefile
+                subprocess.run(
+                    ['cp', '-c', str(src), str(dest)],
+                    check=True,
+                    capture_output=True
+                )
+                return True
+            elif sys.platform == 'linux':
+                # Linux reflink (XFS, BTRFS)
+                result = subprocess.run(
+                    ['cp', '--reflink=always', str(src), str(dest)],
+                    capture_output=True
+                )
+                return result.returncode == 0
+        except:
+            pass
+        
+        return False
+    
+    def get_storage_stats(self) -> Dict:
+        """Get statistics about storage usage"""
+        total_objects = sum(1 for _ in self.objects_dir.rglob("*") if _.is_file())
+        total_size = sum(f.stat().st_size for f in self.objects_dir.rglob("*") if f.is_file())
+        total_snapshots = sum(1 for _ in self.snapshots_dir.rglob("*.json"))
+        
+        return {
+            "total_objects": total_objects,
+            "total_size_mb": total_size / (1024 * 1024),
+            "total_snapshots": total_snapshots,
+        }
+

--- a/src/utils/serialization.py
+++ b/src/utils/serialization.py
@@ -1,0 +1,33 @@
+"""
+Pickle-based serialization for step snapshots.
+Simple, robust, and handles any Python object.
+"""
+import pickle
+from typing import Any
+
+
+def serialize_object(obj: Any) -> bytes:
+    """
+    Serialize any Python object to bytes using pickle.
+    
+    Args:
+        obj: Any Python object to serialize
+        
+    Returns:
+        Pickled bytes representation
+    """
+    return pickle.dumps(obj, protocol=pickle.HIGHEST_PROTOCOL)
+
+
+def deserialize_object(data: bytes) -> Any:
+    """
+    Deserialize bytes back to Python object using pickle.
+    
+    Args:
+        data: Pickled bytes from serialize_object
+        
+    Returns:
+        Reconstructed Python object
+    """
+    return pickle.loads(data)
+

--- a/src/utils/step_snapshots.py
+++ b/src/utils/step_snapshots.py
@@ -1,0 +1,762 @@
+"""
+Step-level snapshotting and forking system.
+
+This module provides decorators and utilities for snapshotting workspace state
+after each step, enabling forking from any point in the pipeline.
+"""
+
+import datetime
+import hashlib
+import json
+import shutil
+from contextlib import asynccontextmanager
+from enum import Enum
+from functools import wraps
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.tree import Tree
+
+from utils.content_store import ContentAddressedStore
+from utils.serialization import serialize_object, deserialize_object
+
+console = Console()
+
+
+class Step(Enum):
+    """Predefined steps in the Agentomics pipeline (in execution order)"""
+    DATA_EXPLORATION = "data_exploration"
+    DATA_SPLIT = "data_split"
+    DATA_REPRESENTATION = "data_representation"
+    MODEL_ARCHITECTURE = "model_architecture"
+    MODEL_TRAINING = "model_training"
+    MODEL_INFERENCE = "model_inference"
+    PREDICTION_EXPLORATION = "prediction_exploration"
+    
+    @classmethod
+    def get_step_names(cls) -> List[str]:
+        """Get ordered list of step names"""
+        return [step.value for step in cls]
+    
+    @classmethod
+    def get_step_index(cls, step_name: str) -> int:
+        """Get the index of a step by name"""
+        names = cls.get_step_names()
+        if step_name not in names:
+            raise ValueError(f"Unknown step: {step_name}. Valid steps: {names}")
+        return names.index(step_name)
+
+
+class StepRegistry:
+    """Global registry tracking execution context"""
+    _current_iteration = None
+    _current_config = None
+    _run_manager = None
+    
+    @classmethod
+    def set_context(cls, config, iteration, run_manager):
+        """Set the current execution context"""
+        cls._current_config = config
+        cls._current_iteration = iteration
+        cls._run_manager = run_manager
+
+
+def snapshotable_step(name: str, forkable: bool = True):
+    """
+    Decorator to make a step automatically snapshotable and forkable.
+    
+    Usage:
+        @snapshotable_step("data_exploration")
+        async def run_data_exploration_step(...):
+            # step implementation
+            return messages, output
+    
+    The decorator automatically:
+    - Validates step name against predefined Step enum
+    - Snapshots workspace after step completion
+    - Enables forking from this step
+    - Tracks execution time
+    - Handles skipping when forking
+    
+    Args:
+        name: Step name (must be one of Step enum values)
+        forkable: Whether this step can be forked from (default: True)
+    """
+    
+    # Validate step name and get index from predefined enum
+    try:
+        index = Step.get_step_index(name)
+    except ValueError as e:
+        raise ValueError(f"Invalid step name in decorator: {e}")
+    
+    def decorator(func: Callable):
+        @wraps(func)
+        async def wrapper(*args, **kwargs):
+            # Get execution context
+            config = StepRegistry._current_config
+            iteration = StepRegistry._current_iteration
+            run_manager = StepRegistry._run_manager
+            
+            # If no run manager, just execute normally
+            if run_manager is None:
+                return await func(*args, **kwargs)
+            
+            # Check if we should skip this step (already done in fork)
+            if run_manager.should_skip_step(name):
+                source_run = run_manager.resume_from[0] if run_manager.resume_from else 'N/A'
+                console.print(f"\n⏭  [yellow]SKIPPING STEP [{index}]: {name}[/yellow]")
+                console.print(f"   [dim]Using cached results from: {source_run}[/dim]\n")
+                
+                # Return cached return value
+                cached_return = run_manager.get_cached_return(iteration, name)
+                
+                if cached_return is None:
+                    raise RuntimeError(
+                        f"Step {name} should be skipped but no cached output found!"
+                    )
+                
+                return cached_return
+            
+            # Execute the step
+            # Check if this is the first step after skipping (fork resume point)
+            is_resume_point = (
+                run_manager.resume_from is not None and 
+                run_manager.skip_until_step is not None and
+                index == run_manager.skip_until_step
+            )
+            
+            if is_resume_point:
+                console.print(Panel(
+                    "[bold]Fork point reached - starting fresh execution[/bold]",
+                    title="▶ Resuming Execution",
+                    border_style="bold green"
+                ))
+            
+            console.print(f"\n⚙  [bold cyan]EXECUTING STEP [{index}]: {name}[/bold cyan]")
+            start_time = datetime.datetime.now()
+            
+            try:
+                # Call the actual step function
+                result = await func(*args, **kwargs)
+                messages, output = result
+                
+                # Snapshot after completion
+                run_manager.snapshot_step(
+                    iteration=iteration,
+                    step_name=name,
+                    files_created=output.files_created if hasattr(output, 'files_created') else [],
+                    step_return_value=result
+                )
+                
+                duration = (datetime.datetime.now() - start_time).total_seconds()
+                console.print(f"\n✓ [green]COMPLETED STEP [{index}]: {name}[/green]")
+                console.print(f"  [dim]Duration: {duration:.2f}s[/dim]\n")
+                
+                return result
+                
+            except Exception as e:
+                console.print(f"\n✗ [red]FAILED STEP [{index}]: {name}[/red]")
+                console.print(f"  [dim]Error: {str(e)[:100]}[/dim]\n")
+                raise
+        
+        # Attach metadata to the wrapped function
+        wrapper._step_metadata = {
+            'name': name,
+            'index': index,
+            'forkable': forkable
+        }
+        
+        return wrapper
+    
+    return decorator
+
+
+@asynccontextmanager
+async def step_execution_context(config, iteration, run_manager: Optional['RunManager'] = None):
+    """Context manager for step execution with automatic tracking"""
+    StepRegistry.set_context(config, iteration, run_manager)
+    try:
+        yield run_manager
+    finally:
+        StepRegistry.set_context(None, None, None)
+
+
+class RunManager:
+    """Manages run lifecycle with step-level snapshotting"""
+    
+    def __init__(self, config, resume_from: Optional[tuple] = None, source_user_prompt: Optional[str] = None):
+        """
+        Args:
+            config: Configuration object
+            resume_from: Optional tuple of (run_id, step_name, iteration) to fork from
+            source_user_prompt: Optional user prompt from source run (for lineage tracking)
+        """
+        self.config = config
+        self.run_id = config.agent_id
+        self.run_dir = config.runs_dir / self.run_id
+        self.content_store = ContentAddressedStore(config.workspace_dir)
+        
+        # Skip configuration
+        self.skip_until_step = None
+        self._cached_returns = {}
+        
+        # Fork info
+        self.resume_from = resume_from
+        self.source_user_prompt = source_user_prompt
+        
+        # Lineage tracking (for fork relationships)
+        self.lineage = None
+        
+        # Initialize from fork if specified
+        if resume_from:
+            # Handle both old format (3-tuple) and new format (4-tuple with user_prompt)
+            if len(resume_from) == 4:
+                source_run_id, step_name, iteration, source_user_prompt = resume_from
+                self.source_user_prompt = source_user_prompt
+            else:
+                source_run_id, step_name, iteration = resume_from
+            self._initialize_from_fork(source_run_id, step_name, iteration)
+    
+    def _get_ancestor_chain(self, run_id: str) -> list[str]:
+        """Get the chain of ancestor runs by parsing fork naming convention.
+        
+        Supports multiple formats:
+        - Old format: 'run_A__fork_step_X__fork_step_Y'
+        - Intermediate format: 'run_A_forked_from_step_X_iterN_timestamp'
+        - Current format: 'run_A_fork_step_X_iterN_timestamp'
+        
+        Example: 'run_A_fork_step_X_iter2_20250112_143022' -> ['run_A']
+        Example: 'run_A_fork_step_X_iter2_20250112_fork_step_Y_iter3_20250113_144000' -> ['run_A', 'run_A_fork_step_X_iter2_20250112_143022']
+        """
+        ancestors = []
+        
+        # Try current format first (_fork_)
+        if '_fork_' in run_id and '_forked_from_' not in run_id:
+            parts = run_id.split('_fork_')
+            if len(parts) > 1:
+                # Build chain base -> ... -> immediate parent (exclude current run id)
+                current = parts[0]
+                ancestors.append(current)
+                for i in range(1, len(parts) - 1):
+                    current = current + '_fork_' + parts[i]
+                    ancestors.append(current)
+        # Try intermediate format (_forked_from_)
+        elif '_forked_from_' in run_id:
+            parts = run_id.split('_forked_from_')
+            if len(parts) > 1:
+                base = parts[0]
+                ancestors.append(base)
+                
+                # Reconstruct intermediate forks by joining parts progressively
+                for i in range(1, len(parts)):
+                    intermediate_parts = parts[:i+1]
+                    intermediate = '_forked_from_'.join(intermediate_parts)
+                    ancestors.append(intermediate)
+        # Fall back to old format (__fork_)
+        elif '__fork_' in run_id:
+            parts = run_id.split('__fork_')
+            if len(parts) > 1:
+                base = parts[0]
+                ancestors.append(base)
+                
+                # Reconstruct intermediate forks
+                for i in range(1, len(parts) - 1):
+                    intermediate = base + '__fork_' + '__fork_'.join(parts[1:i+1])
+                    ancestors.append(intermediate)
+        
+        return ancestors
+
+    def _locate_snapshot_file(
+        self,
+        run_candidates: List[str],
+        iteration: int,
+        step_name: str,
+        step_index: int,
+    ) -> tuple[str, Path]:
+        """
+        Find the snapshot file for a given step by searching the source run
+        and, if needed, its ancestors (most recent ancestor first).
+        """
+        for candidate in run_candidates:
+            snapshot_path = (
+                self.content_store.snapshots_dir
+                / candidate
+                / f"iteration_{iteration}"
+                / f"{step_index:02d}_{step_name}.json"
+            )
+            if snapshot_path.exists():
+                if candidate != run_candidates[0]:
+                    console.print(
+                        f"[yellow][FORK][/yellow] Snapshot for step '{step_name}' "
+                        f"not found in run '{run_candidates[0]}'. "
+                        f"Using ancestor run '{candidate}'."
+                    )
+                return candidate, snapshot_path
+        raise ValueError(
+            "Snapshot not found for step "
+            f"{step_name} (iteration {iteration}). "
+            f"Searched runs: {', '.join(run_candidates)}"
+        )
+    
+    def _initialize_from_fork(self, source_run_id: str, step_name: str, iteration: int):
+        """Initialize this run by forking from another run's step"""
+        fork_info = f"[bold]Source Run:[/bold]  {source_run_id}\n"
+        fork_info += f"[bold]Fork Point:[/bold]  {step_name} (iteration {iteration})"
+        
+        # Check for ancestor chain (fork-of-fork scenario)
+        ancestors = self._get_ancestor_chain(source_run_id)
+        if ancestors:
+            fork_info += f"\n[bold]Ancestor Chain:[/bold] {' → '.join(ancestors)}"
+        
+        console.print(Panel(fork_info, title="[bold]Forking Mode Active[/bold]", border_style="bold yellow"))
+        
+        # Get step index (needed for lineage loading)
+        step_index = self._get_step_index(step_name)
+        snapshot_search_order = [source_run_id] + list(reversed(ancestors))
+        
+        # Load snapshot manifest
+        _, snapshot_file = self._locate_snapshot_file(
+            snapshot_search_order,
+            iteration,
+            step_name,
+            step_index,
+        )
+        
+        with open(snapshot_file) as f:
+            snapshot = json.load(f)
+        
+        metadata = snapshot.get("metadata", {})
+        
+        # Recursively build full lineage chain by following parent links
+        full_lineage = self._build_full_lineage_chain(source_run_id, step_name, iteration)
+        
+        # Use provided source user prompt
+        parent_user_prompt = self.source_user_prompt
+        
+        # Store lineage for this run
+        self.lineage = {
+            "parent_run_id": source_run_id,
+            "fork_point": {
+                "step": step_name,
+                "iteration": iteration,
+                "user_prompt": self.config.user_prompt  # Current run's prompt
+            },
+            "full_lineage": full_lineage
+        }
+        
+        # Display lineage tree
+        self._display_lineage_tree(full_lineage, self.run_id)
+        
+        # Restore workspace files
+        print(f"[FORK] Restoring workspace from snapshot...")
+        manifest = snapshot["manifest"]
+        
+        self.run_dir.mkdir(parents=True, exist_ok=True)
+        
+        # Build list of directories to restore to:
+        # 1. Current fork directory
+        # 2. Source run directory
+        # 3. All ancestor directories (for fork-of-fork scenarios)
+        restore_dirs = [self.run_dir]
+        
+        source_run_dir = self.config.runs_dir / source_run_id
+        source_run_dir.mkdir(parents=True, exist_ok=True)
+        restore_dirs.append(source_run_dir)
+        
+        # Add ancestor directories for fork-of-fork support
+        for ancestor_id in ancestors:
+            ancestor_dir = self.config.runs_dir / ancestor_id
+            ancestor_dir.mkdir(parents=True, exist_ok=True)
+            restore_dirs.append(ancestor_dir)
+        
+        restored_count = 0
+        for rel_path, file_hash in manifest.items():
+            try:
+                # Restore to all directories to support hardcoded paths at any level
+                for target_dir in restore_dirs:
+                    self.content_store.restore_file(file_hash, target_dir / rel_path)
+                restored_count += 1
+            except Exception as e:
+                print(f"  Warning: Could not restore {rel_path}: {e}")
+        
+        dir_count = len(restore_dirs)
+        print(f"[FORK] Restored {restored_count} files to {dir_count} director{'y' if dir_count == 1 else 'ies'}\n")
+        
+        print(f"[FORK] Loading cached outputs from source run...")
+        
+        # Load cached return values for steps 0 through step_index
+        step_names = Step.get_step_names()
+        steps_to_skip = []
+        for i in range(step_index):
+            step_name = step_names[i]
+            _, step_snapshot_file = self._locate_snapshot_file(
+                snapshot_search_order,
+                iteration,
+                step_name,
+                i,
+            )
+            
+            with open(step_snapshot_file) as f:
+                step_snapshot = json.load(f)
+            
+            # Check if return_value_hash exists in metadata (for backward compatibility)
+            metadata = step_snapshot.get("metadata", {})
+            return_value_hash = metadata.get("return_value_hash")
+            
+            if return_value_hash is None:
+                raise ValueError(
+                    f"Snapshot for step {step_name} (iteration {iteration}) does not contain return_value_hash.\n"
+                    f"This snapshot was created before return value caching was implemented.\n"
+                    f"Please re-run the source run to create a new snapshot with return values."
+                )
+            
+            return_obj = self.content_store.objects_dir / return_value_hash[:2] / return_value_hash[2:]
+            
+            if not return_obj.exists():
+                raise ValueError(
+                    f"Return value object not found for step {step_name} (iteration {iteration}).\n"
+                    f"Expected path: {return_obj}\n"
+                    f"Hash: {return_value_hash}\n"
+                    f"The snapshot references a return value that doesn't exist in the object store.\n"
+                    f"This may indicate corrupted storage or a missing object."
+                )
+            
+            # Deserialize the entire (messages, output) tuple from pickle
+            try:
+                pickled_data = return_obj.read_bytes()
+                step_messages, step_output = deserialize_object(pickled_data)
+                
+                # Store cached return with iteration 0 (current iteration in new run)
+                # even though we loaded it from source iteration, because when we retrieve
+                # it later, we'll be looking it up with the current iteration (0)
+                self._cached_returns[(0, step_name)] = (step_messages, step_output)
+                steps_to_skip.append(f"[{i}] {step_name}")
+            except Exception as e:
+                raise RuntimeError(
+                    f"Failed to deserialize cached return value for step {step_name} (iteration {iteration}): {e}\n"
+                    f"Object path: {return_obj}"
+                ) from e
+        
+        # Set skip marker: skip everything before the fork point
+        self.skip_until_step = step_index
+        
+        # Print fork summary
+        summary_text = f"[bold]Steps to SKIP[/bold] (using cached results):\n"
+        for step in steps_to_skip:
+            summary_text += f"  • {step}\n"
+        
+        resume_step_index = step_index
+        if resume_step_index < len(step_names):
+            summary_text += f"\n[bold]Will RESUME execution at:[/bold]\n"
+            summary_text += f"  ▶ [{resume_step_index}] {step_names[resume_step_index]}"
+        else:
+            summary_text += "\n[bold]All steps already executed in source run.[/bold]"
+        
+        console.print(Panel(summary_text, title="Fork Summary", border_style="green"))
+    
+    def _extract_parent_lineage(self, metadata: Dict[str, Any]) -> Optional[List[Dict]]:
+        """Extract lineage information from snapshot metadata if present."""
+        parent_lineage = metadata.get("lineage")
+        if not parent_lineage:
+            return None
+        
+        if "full_lineage" in parent_lineage:
+            return parent_lineage["full_lineage"]
+        
+        if "parent_run_id" in parent_lineage:
+            return [{
+                "run_id": parent_lineage["parent_run_id"],
+                "fork_point": parent_lineage.get("fork_point", {})
+            }]
+        
+        return None
+    
+    def _build_full_lineage_chain(self, source_run_id: str, step_name: str, iteration: int) -> List[Dict]:
+        """Recursively build the full lineage chain by following parent links."""
+        # First, try to get full_lineage from the source run's snapshot
+        try:
+            step_index = self._get_step_index(step_name)
+            snapshot_search_order = [source_run_id] + list(reversed(self._get_ancestor_chain(source_run_id)))
+            
+            _, snapshot_file = self._locate_snapshot_file(
+                snapshot_search_order,
+                iteration,
+                step_name,
+                step_index,
+            )
+            
+            with open(snapshot_file) as f:
+                snapshot = json.load(f)
+            metadata = snapshot.get("metadata", {})
+            parent_lineage = self._extract_parent_lineage(metadata)
+            
+            # If parent has full_lineage, use it and add current fork point
+            if parent_lineage:
+                full_lineage = list(parent_lineage)  # Copy the list
+                full_lineage.append({
+                    "run_id": source_run_id,
+                    "fork_point": {
+                        "step": step_name,
+                        "iteration": iteration,
+                        "user_prompt": self.source_user_prompt or ""
+                    }
+                })
+                return full_lineage
+        except (ValueError, FileNotFoundError, KeyError):
+            pass
+        
+        # Fallback: recursively build lineage by following parent links
+        full_lineage = []
+        visited = set()
+        current_run_id = source_run_id
+        current_step = step_name
+        current_iter = iteration
+        current_prompt = self.source_user_prompt or ""
+        
+        while current_run_id and current_run_id not in visited:
+            visited.add(current_run_id)
+            
+            # Try to find lineage info for this run
+            try:
+                step_idx = self._get_step_index(current_step)
+                search_order = [current_run_id] + list(reversed(self._get_ancestor_chain(current_run_id)))
+                
+                # Find any snapshot from this run
+                found_snapshot = None
+                for candidate in search_order:
+                    for test_idx in range(len(Step.get_step_names())):
+                        test_step = Step.get_step_names()[test_idx]
+                        test_path = (
+                            self.content_store.snapshots_dir /
+                            candidate /
+                            f"iteration_{current_iter}" /
+                            f"{test_idx:02d}_{test_step}.json"
+                        )
+                        if test_path.exists():
+                            found_snapshot = test_path
+                            break
+                    if found_snapshot:
+                        break
+                
+                if found_snapshot:
+                    with open(found_snapshot) as f:
+                        snap = json.load(f)
+                    lineage = snap.get("metadata", {}).get("lineage")
+                    
+                    if lineage and "parent_run_id" in lineage:
+                        # Add current run to lineage
+                        full_lineage.insert(0, {
+                            "run_id": current_run_id,
+                            "fork_point": {
+                                "step": current_step,
+                                "iteration": current_iter,
+                                "user_prompt": current_prompt
+                            }
+                        })
+                        
+                        # Move to parent
+                        fork_pt = lineage.get("fork_point", {})
+                        current_run_id = lineage["parent_run_id"]
+                        current_step = fork_pt.get("step", "unknown")
+                        current_iter = fork_pt.get("iteration", 0)
+                        current_prompt = fork_pt.get("user_prompt", "")
+                        continue
+            except (ValueError, FileNotFoundError, KeyError):
+                pass
+            
+            # No parent found - this is an original run or we can't find lineage
+            full_lineage.insert(0, {
+                "run_id": current_run_id,
+                "fork_point": {
+                    "step": current_step,
+                    "iteration": current_iter,
+                    "user_prompt": current_prompt
+                } if current_step != "unknown" else {}
+            })
+            break
+        
+        return full_lineage
+    
+    def _display_lineage_tree(self, full_lineage: List[Dict], current_run_id: str):
+        """Display lineage as a Rich tree showing fork relationships"""
+        if not full_lineage:
+            return
+        
+        # Build Rich Tree
+        # Original run (first in lineage)
+        original = full_lineage[0]
+        original_run_id = original["run_id"]
+        original_fork = original.get("fork_point", {})
+        
+        # Determine if original is truly original (no fork_point) or a fork itself
+        is_original = not original_fork
+        
+        if is_original:
+            # Truly original run
+            root_label = f"[bold]{original_run_id}[/bold] [dim](original)[/dim]"
+        else:
+            # Original is itself a fork
+            root_label = f"[bold]{original_run_id}[/bold]"
+        
+        tree = Tree(root_label)
+        
+        # Add fork point info for original if it exists
+        if original_fork:
+            step = original_fork.get("step", "unknown")
+            iter_num = original_fork.get("iteration", "?")
+            prompt = original_fork.get("user_prompt")
+            fork_info = f"Fork @ [yellow]{step}[/yellow] (iter {iter_num})"
+            if prompt:
+                prompt_short = prompt[:50] + "..." if len(prompt) > 50 else prompt
+                fork_info += f"\n  [dim]Prompt:[/dim] {prompt_short}"
+            tree.add(fork_info)
+        
+        # Build tree structure for intermediate forks
+        current_branch = tree
+        
+        # Display intermediate forks
+        for fork in full_lineage[1:]:
+            fork_run_id = fork["run_id"]
+            fork_point = fork.get("fork_point", {})
+            step = fork_point.get("step", "unknown")
+            iter_num = fork_point.get("iteration", "?")
+            prompt = fork_point.get("user_prompt")
+            
+            # Add fork node
+            fork_node = current_branch.add(f"[bold]{fork_run_id}[/bold]")
+            fork_info = f"Fork @ [yellow]{step}[/yellow] (iter {iter_num})"
+            if prompt:
+                prompt_short = prompt[:50] + "..." if len(prompt) > 50 else prompt
+                fork_info += f"\n  [dim]Prompt:[/dim] {prompt_short}"
+            fork_node.add(fork_info)
+            current_branch = fork_node
+        
+        # Add current run with its user prompt
+        current_label = f"[bold green]{current_run_id}[/bold green] [dim](current)[/dim]"
+        current_node = current_branch.add(current_label)
+        if self.config.user_prompt:
+            prompt_short = self.config.user_prompt[:50] + "..." if len(self.config.user_prompt) > 50 else self.config.user_prompt
+            current_node.add(f"[dim]Prompt:[/dim] {prompt_short}")
+        
+        # Display the tree
+        console.print("\n[bold cyan]Fork Lineage Tree:[/bold cyan]")
+        console.print(tree)
+        console.print()  # Empty line after tree
+    
+    def snapshot_step(self, iteration: int, step_name: str, files_created: List[str], 
+                     step_return_value: tuple):
+        """Create a snapshot after a step completes"""
+        
+        step_index = self._get_step_index(step_name)
+        
+        print(f"  [SNAPSHOT] Saving step state for future forking...")
+        
+        # Snapshot workspace files
+        manifest = self.content_store.store_directory(
+            self.run_dir,
+            exclude_patterns=[
+                "iteration_",
+                "__pycache__",
+                ".cache",
+                ".agentomics_storage",
+                ".conda"  # Conda environments (large, rarely change, handled separately)
+            ]
+        )
+        
+        print(f"  [SNAPSHOT] Stored {len(manifest)} files")
+        
+        # Store return value (messages, output)
+        return_value_bytes = self._serialize_return_value(step_return_value)
+        return_value_hash = hashlib.sha256(return_value_bytes).hexdigest()
+        
+        return_obj = self.content_store.objects_dir / return_value_hash[:2] / return_value_hash[2:]
+        if not return_obj.exists():
+            return_obj.parent.mkdir(parents=True, exist_ok=True, mode=0o755)
+            return_obj.parent.chmod(0o755)  # Ensure correct permissions
+            return_obj.write_bytes(return_value_bytes)
+            return_obj.chmod(0o644)  # Make file readable
+        
+        # Save manifest
+        metadata = {
+            "step_name": step_name,
+            "timestamp": datetime.datetime.utcnow().isoformat(),
+            "files_created": files_created,
+            "return_value_hash": return_value_hash,
+        }
+        
+        # Add lineage information if this is a fork
+        if self.lineage is not None:
+            metadata["lineage"] = self.lineage
+        
+        self.content_store.save_snapshot(
+            self.run_id,
+            iteration,
+            f"{step_index:02d}_{step_name}",
+            manifest,
+            metadata
+        )
+        
+        print(f"  [SNAPSHOT] Step state saved - can fork from this point")
+        
+        print(f"  Snapshot saved ({len(manifest)} files)")
+    
+    def should_skip_step(self, step_name: str) -> bool:
+        """Check if a step should be skipped"""
+        if self.skip_until_step is None:
+            return False
+        
+        step_index = self._get_step_index(step_name)
+        return step_index < self.skip_until_step
+    
+    def get_cached_return(self, iteration: int, step_name: str):
+        """Get cached return value for a skipped step"""
+        return self._cached_returns.get((iteration, step_name))
+    
+    def _get_step_index(self, step_name: str) -> int:
+        """Get the index of a step by its name"""
+        return Step.get_step_index(step_name)
+    
+    def _serialize_return_value(self, step_return_value: tuple) -> bytes:
+        """Serialize (messages, output) tuple to bytes using pickle"""
+        return serialize_object(step_return_value)
+    
+
+
+def get_latest_iteration(workspace_dir: Path, run_id: str) -> int:
+    """
+    Find the latest (most recent) iteration for a run.
+    
+    Looks in .agentomics_storage/snapshots/{run_id}/ to find iteration directories.
+    This works even when forking, since we copy the storage directory.
+    """
+    # Look in the content-addressed storage snapshots directory
+    snapshots_dir = workspace_dir / ".agentomics_storage" / "snapshots" / run_id
+    
+    if not snapshots_dir.exists():
+        raise ValueError(f"No snapshots found for run '{run_id}'. Cannot determine latest iteration.")
+    
+    # Find all iteration directories
+    iteration_dirs = [
+        d for d in snapshots_dir.iterdir()
+        if d.is_dir() and d.name.startswith("iteration_")
+    ]
+    
+    if not iteration_dirs:
+        raise ValueError(f"No iteration snapshots found for run '{run_id}'.")
+    
+    # Extract iteration numbers and get the maximum
+    iteration_numbers = []
+    for d in iteration_dirs:
+        try:
+            iter_num = int(d.name.split("_")[1])
+            iteration_numbers.append(iter_num)
+        except (IndexError, ValueError):
+            continue
+    
+    if not iteration_numbers:
+        raise ValueError(f"Could not parse iteration numbers for run '{run_id}'.")
+    
+    return max(iteration_numbers)
+


### PR DESCRIPTION
Add comprehensive forking capability to resume ML workflows from any step:

- Implement content-addressed storage system for snapshots and outputs
- Add snapshotable_step decorator and RunManager for step execution tracking
- Support forking via --fork-from-run, --fork-from-step, --fork-from-iteration flags
- Integrate step registry with Data Representation, Data Split, Model Architecture, Model Training, Model Inference, and Prediction Exploration steps
- Auto-detect dataset, validation metric, and user prompt from forked runs
- Store workflow state in .agentomics_storage directory with lineage tracking
- Update run scripts to handle fork workflows and copy storage between containers
- Make foundation model downloads non-blocking in Docker build
- Add documentation for forking features and usage examples in README

This enables iterative refinement by allowing users to fork from any step and rerun downstream steps with modified instructions or configurations.