### PR TITLE
run.sh --use-provisioning-key fails in non-interactive runs even when .env contains PROVISIONING_OPENROUTER_API_KEY

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -73,6 +73,92 @@ Output:
 EOF
 }
 
+read_env_var_from_file() {
+    local env_file="$1"
+    local key_name="$2"
+    [[ -f "$env_file" ]] || return 0
+    while IFS= read -r line; do
+        [[ -z "$line" || "$line" == \#* ]] && continue
+        line="${line#export }"
+        if [[ "$line" == "$key_name="* ]]; then
+            local value="${line#*=}"
+            value="${value%\"}"
+            value="${value#\"}"
+            value="${value%\'}"
+            value="${value#\'}"
+            echo "$value"
+            return 0
+        fi
+    done < "$env_file"
+}
+
+resolve_openrouter_api_key() {
+    local env_file="$1"
+    if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+        echo "$OPENROUTER_API_KEY"
+        return 0
+    fi
+    read_env_var_from_file "$env_file" "OPENROUTER_API_KEY"
+}
+
+resolve_provisioning_openrouter_api_key() {
+    local env_file="$1"
+    if [[ -n "${PROVISIONING_OPENROUTER_API_KEY:-}" ]]; then
+        echo "$PROVISIONING_OPENROUTER_API_KEY"
+        return 0
+    fi
+    read_env_var_from_file "$env_file" "PROVISIONING_OPENROUTER_API_KEY"
+}
+
+print_openrouter_account_credit() {
+    local api_key="$1"
+    [[ -n "$api_key" ]] || return 0
+    local credits_out
+    if command -v python3 >/dev/null 2>&1; then
+        credits_out="$(python3 src/utils/api_keys_utils.py credits --api-key "$api_key" 2>/dev/null || true)"
+    elif command -v python >/dev/null 2>&1; then
+        credits_out="$(python src/utils/api_keys_utils.py credits --api-key "$api_key" 2>/dev/null || true)"
+    else
+        warn "Python not found, cannot display OpenRouter account credit."
+        return 0
+    fi
+    if [[ -z "$credits_out" ]]; then
+        warn "Could not fetch OpenRouter account credit."
+        return 0
+    fi
+
+    local account_limit account_usage account_remaining
+    account_limit="$(echo "$credits_out" | cut -d',' -f1)"
+    account_usage="$(echo "$credits_out" | cut -d',' -f2)"
+    account_remaining="$(echo "$credits_out" | cut -d',' -f3)"
+    if [[ -z "$account_limit" || -z "$account_usage" || -z "$account_remaining" ]]; then
+        warn "OpenRouter credit API response missing expected fields."
+        return 0
+    fi
+    print_credit_summary "OpenRouter account" "$account_limit" "$account_usage" "$account_remaining"
+}
+
+print_credit_summary() {
+    local label="$1"
+    local total="$2"
+    local usage="$3"
+    local remaining="$4"
+
+    local remaining_pct
+    remaining_pct="$(awk -v t="$total" -v r="$remaining" 'BEGIN { if (t+0 <= 0) { print "0.00" } else { printf "%.2f", (r/t)*100 } }')"
+
+    echo -e "${GREEN}================ Credit Summary ================${NOCOLOR}"
+    echo -e "${GREEN}${label}${NOCOLOR}"
+    echo "  total:     ${total}"
+    echo "  used:      ${usage}"
+    echo "  remaining: ${remaining} (${remaining_pct}%)"
+    echo -e "${GREEN}===============================================${NOCOLOR}"
+
+    if awk -v p="$remaining_pct" 'BEGIN { exit !(p < 10) }'; then
+        warn "Low OpenRouter credits remaining (${remaining_pct}%)."
+    fi
+}
+
 while [[ $# -gt 0 ]]; do
     case $1 in
         -h|--help)
@@ -306,11 +392,19 @@ if [ "$LOCAL_MODE" = true ]; then
 
     TEMP_API_KEY_HASH=""
     if [ "$USE_PROVISIONING_KEY" = true ]; then
+        RESOLVED_PROVISIONING_KEY="$(resolve_provisioning_openrouter_api_key "$(pwd)/.env")"
+        [[ -n "$RESOLVED_PROVISIONING_KEY" ]] || die "PROVISIONING_OPENROUTER_API_KEY is required when using --use-provisioning-key"
+        export PROVISIONING_OPENROUTER_API_KEY="$RESOLVED_PROVISIONING_KEY"
         echo "Creating temporary API key with spend limit: $SPEND_LIMIT"
         API_KEY_OUTPUT=$(PYTHONPATH="$(pwd)/src" conda run -n agentomics-env python src/utils/api_keys_utils.py create --name "agentomics_run_$(date +%s)" --limit "$SPEND_LIMIT")
-        TEMP_API_KEY=$(echo "$API_KEY_OUTPUT" | cut -d',' -f1)
-        TEMP_API_KEY_HASH=$(echo "$API_KEY_OUTPUT" | cut -d',' -f2)
+        IFS=',' read -r TEMP_API_KEY TEMP_API_KEY_HASH TEMP_API_KEY_LIMIT TEMP_API_KEY_USAGE TEMP_API_KEY_REMAINING <<< "$API_KEY_OUTPUT"
+        [[ -n "$TEMP_API_KEY" && -n "$TEMP_API_KEY_HASH" ]] || die "Failed to create temporary OpenRouter API key"
         export OPENROUTER_API_KEY="$TEMP_API_KEY"
+        [[ -n "$TEMP_API_KEY_LIMIT" && -n "$TEMP_API_KEY_USAGE" && -n "$TEMP_API_KEY_REMAINING" ]] || die "Failed to fetch temporary key credit from API"
+        print_credit_summary "Temporary key credit" "$TEMP_API_KEY_LIMIT" "$TEMP_API_KEY_USAGE" "$TEMP_API_KEY_REMAINING"
+    else
+        DEFAULT_OPENROUTER_KEY="$(resolve_openrouter_api_key "$(pwd)/.env")"
+        print_openrouter_account_credit "$DEFAULT_OPENROUTER_KEY"
     fi
 
     if [[ -n "$TIMEOUT_SECS" ]]; then
@@ -442,6 +536,9 @@ else
 
     TEMP_API_KEY_HASH=""
     if [ "$USE_PROVISIONING_KEY" = true ]; then
+        RESOLVED_PROVISIONING_KEY="$(resolve_provisioning_openrouter_api_key "$(pwd)/.env")"
+        [[ -n "$RESOLVED_PROVISIONING_KEY" ]] || die "PROVISIONING_OPENROUTER_API_KEY is required when using --use-provisioning-key"
+        export PROVISIONING_OPENROUTER_API_KEY="$RESOLVED_PROVISIONING_KEY"
         need_cmd conda
         if ! conda env list | grep -q "^agentomics-env "; then
             echo "Creating agentomics-env conda environment"
@@ -449,9 +546,11 @@ else
         fi
         echo "Creating temporary API key with spend limit: $SPEND_LIMIT"
         API_KEY_OUTPUT=$(PYTHONPATH="$(pwd)/src" conda run -n agentomics-env python src/utils/api_keys_utils.py create --name "agentomics_run_$(date +%s)" --limit "$SPEND_LIMIT")
-        TEMP_API_KEY=$(echo "$API_KEY_OUTPUT" | cut -d',' -f1)
-        TEMP_API_KEY_HASH=$(echo "$API_KEY_OUTPUT" | cut -d',' -f2)
+        IFS=',' read -r TEMP_API_KEY TEMP_API_KEY_HASH TEMP_API_KEY_LIMIT TEMP_API_KEY_USAGE TEMP_API_KEY_REMAINING <<< "$API_KEY_OUTPUT"
+        [[ -n "$TEMP_API_KEY" && -n "$TEMP_API_KEY_HASH" ]] || die "Failed to create temporary OpenRouter API key"
         export OPENROUTER_API_KEY="$TEMP_API_KEY"
+        [[ -n "$TEMP_API_KEY_LIMIT" && -n "$TEMP_API_KEY_USAGE" && -n "$TEMP_API_KEY_REMAINING" ]] || die "Failed to fetch temporary key credit from API"
+        print_credit_summary "Temporary key credit" "$TEMP_API_KEY_LIMIT" "$TEMP_API_KEY_USAGE" "$TEMP_API_KEY_REMAINING"
     fi
 
     if [ "$CPU_ONLY" = false ]; then
@@ -479,6 +578,10 @@ else
     ENV_FILE_PATH="$(pwd)/.env"
     [[ -f "$ENV_FILE_PATH" ]] || die "Env file not found: $ENV_FILE_PATH (create it from .env.example)"
     ENV_FILE_ARGS=(--env-file "$ENV_FILE_PATH")
+    if [ "$USE_PROVISIONING_KEY" = false ]; then
+        DEFAULT_OPENROUTER_KEY="$(resolve_openrouter_api_key "$ENV_FILE_PATH")"
+        print_openrouter_account_credit "$DEFAULT_OPENROUTER_KEY"
+    fi
 
     PROVIDERS_CONFIG_FILE="src/utils/providers/configured_providers.yaml"
     [[ -f "$PROVIDERS_CONFIG_FILE" ]] || die "Missing providers config: $PROVIDERS_CONFIG_FILE"

--- a/src/utils/api_keys.py
+++ b/src/utils/api_keys.py
@@ -8,7 +8,15 @@ dotenv.load_dotenv(Path(__file__).parents[2] / ".env") # load env in the root of
 PROVISIONING_API_KEY = os.getenv("PROVISIONING_OPENROUTER_API_KEY")
 BASE_URL = "https://openrouter.ai/api/v1/keys"
 
+def require_provisioning_key():
+    if not PROVISIONING_API_KEY:
+        raise ValueError(
+            "PROVISIONING_OPENROUTER_API_KEY is not set. "
+            "Set it in your environment/.env before using --use-provisioning-key."
+        )
+
 def create_new_api_key(name, limit):
+    require_provisioning_key()
     response = requests.post(
         f"{BASE_URL}",
         headers={
@@ -30,11 +38,13 @@ def create_new_api_key(name, limit):
 
 
 def get_api_key(key_hash):
+    require_provisioning_key()
     headers = {"Authorization": f"Bearer {PROVISIONING_API_KEY}"}
     response = requests.get(f"{BASE_URL}/{key_hash}", headers=headers)
     return response.json()
 
 def get_all_api_keys():
+    require_provisioning_key()
     response = requests.get(
     BASE_URL,
         headers={
@@ -53,6 +63,7 @@ def get_api_key_usage(key_hash):
     return data
 
 def delete_api_key(key_hash):
+    require_provisioning_key()
     response = requests.delete(
         f"{BASE_URL}/{key_hash}",
         headers={

--- a/src/utils/api_keys_utils.py
+++ b/src/utils/api_keys_utils.py
@@ -1,14 +1,30 @@
 import argparse
 import json
-import dotenv
-import wandb
+from decimal import Decimal, InvalidOperation
+import urllib.request
 from pathlib import Path
 
-from utils.config import Config
-from utils.api_keys import create_new_api_key, get_api_key_usage, delete_api_key
-from run_logging.wandb_setup import resume_wandb_run
+def to_decimal(value):
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError, TypeError) as exc:
+        raise ValueError(f"Invalid numeric value from API: {value!r}") from exc
+
+def format_decimal_for_csv(value):
+    normalized = value.normalize()
+    text = format(normalized, "f")
+    if "." in text:
+        text = text.rstrip("0").rstrip(".")
+    return text or "0"
+
+def decimal_to_json_number(value):
+    if value == value.to_integral_value():
+        return int(value)
+    return float(value)
 
 def load_run_config(config_path):
+    from utils.config import Config
+
     with open(config_path, 'r') as f:
         config_dict = json.load(f)
 
@@ -31,10 +47,35 @@ def load_run_config(config_path):
     return config
 
 def create_key(args):
+    from utils.api_keys import create_new_api_key, get_api_key_usage
+
     result = create_new_api_key(args.name, args.limit)
-    print(f"{result['key']},{result['hash']}")
+    usage_info = get_api_key_usage(result["hash"])
+    limit = to_decimal(usage_info.get("limit"))
+    usage = to_decimal(usage_info.get("usage"))
+    remaining = limit - usage
+    payload = {
+        **result,
+        "limit": decimal_to_json_number(limit),
+        "usage": decimal_to_json_number(usage),
+        "remaining": decimal_to_json_number(remaining),
+    }
+    if args.output == "json":
+        print(json.dumps(payload))
+    else:
+        print(
+            f"{result['key']},{result['hash']},"
+            f"{format_decimal_for_csv(limit)},"
+            f"{format_decimal_for_csv(usage)},"
+            f"{format_decimal_for_csv(remaining)}"
+        )
 
 def cleanup_and_log(args):
+    import dotenv
+    import wandb
+    from utils.api_keys import get_api_key_usage, delete_api_key
+    from run_logging.wandb_setup import resume_wandb_run
+
     dotenv.load_dotenv()
     config = load_run_config(args.config_path)
     resume_wandb_run(config, dir='./cleanup_wandb_logs')
@@ -48,6 +89,40 @@ def cleanup_and_log(args):
 
     delete_api_key(args.api_key_hash)
 
+def fetch_credits(args):
+    req = urllib.request.Request(
+        "https://openrouter.ai/api/v1/credits",
+        headers={"Authorization": f"Bearer {args.api_key}"}
+    )
+    with urllib.request.urlopen(req, timeout=10) as response:
+        payload = json.loads(response.read().decode())
+
+    data = payload.get("data", {})
+    total_credits = data.get("total_credits")
+    total_usage = data.get("total_usage")
+    if total_credits is None or total_usage is None:
+        raise ValueError("OpenRouter credit API response missing total_credits or total_usage")
+    total_credits_dec = to_decimal(total_credits)
+    total_usage_dec = to_decimal(total_usage)
+    remaining = total_credits_dec - total_usage_dec
+
+    if args.output == "json":
+        print(
+            json.dumps(
+                {
+                    "total_credits": decimal_to_json_number(total_credits_dec),
+                    "total_usage": decimal_to_json_number(total_usage_dec),
+                    "remaining": decimal_to_json_number(remaining),
+                }
+            )
+        )
+    else:
+        print(
+            f"{format_decimal_for_csv(total_credits_dec)},"
+            f"{format_decimal_for_csv(total_usage_dec)},"
+            f"{format_decimal_for_csv(remaining)}"
+        )
+
 def main():
     parser = argparse.ArgumentParser(description="API key management")
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -55,10 +130,15 @@ def main():
     create_parser = subparsers.add_parser("create")
     create_parser.add_argument("--name", required=True)
     create_parser.add_argument("--limit", type=int, required=True)
+    create_parser.add_argument("--output", choices=["csv", "json"], default="csv")
 
     cleanup_parser = subparsers.add_parser("cleanup-and-log")
     cleanup_parser.add_argument("--config-path", required=True)
     cleanup_parser.add_argument("--api-key-hash", required=True)
+
+    credits_parser = subparsers.add_parser("credits")
+    credits_parser.add_argument("--api-key", required=True)
+    credits_parser.add_argument("--output", choices=["csv", "json"], default="csv")
 
     args = parser.parse_args()
 
@@ -67,6 +147,8 @@ def main():
             create_key(args)
         elif args.command == "cleanup-and-log":
             cleanup_and_log(args)
+        elif args.command == "credits":
+            fetch_credits(args)
     except Exception as e:
         print(f"Error: {str(e)}", file=__import__('sys').stderr)
         __import__('sys').exit(1)


### PR DESCRIPTION
Fixes #82

Implemented in commit:
https://github.com/BioGeMT/agentomics-ml/commit/e6f4478