### PR TITLE
Add Codex provider support

### DIFF
--- a/docs/configuration/providers.md
+++ b/docs/configuration/providers.md
@@ -8,6 +8,7 @@ Agentomics-ML supports multiple LLM providers out of the box.
 |----------|---------------------|--------|
 | [OpenRouter](https://openrouter.ai/) | `OPENROUTER_API_KEY` | 100+ models |
 | [OpenAI](https://openai.com/) | `OPENAI_API_KEY` | Use `--list-models` to see available models |
+| OpenAI Codex | `codex login` | Uses your local Codex/ChatGPT login |
 | [Ollama](https://ollama.ai/) | Local setup | Local models |
 
 ## OpenRouter
@@ -56,6 +57,33 @@ export OPENAI_API_KEY="sk-xxxxxxxxxxxx"
 ### Available Models
 
 Use `./run.sh --list-models` to see what your API key can access.
+
+---
+
+## Codex (ChatGPT OAuth)
+
+Experimental support for the local Codex CLI login flow.
+
+### Setup
+
+First, sign into Codex on the same machine:
+
+```bash
+codex login
+```
+
+Then run Agentomics with the `codex` provider:
+
+```bash
+./run.sh --provider codex --list-models
+./run.sh --provider codex --model gpt-5.4
+```
+
+This provider reads your local Codex auth state from `~/.codex/auth.json` and
+uses the ChatGPT Codex backend instead of `OPENAI_API_KEY`.
+
+If you are also setting `OPENAI_API_KEY` or `OPENROUTER_API_KEY`, pass
+`--provider codex` explicitly for non-interactive runs.
 
 ---
 

--- a/run.sh
+++ b/run.sh
@@ -26,7 +26,7 @@ BUILD_IMAGES=false
 DOCKERHUB_USERNAME="biogemt"
 
 show_help() {
-    cat << EOF
+    cat <<'EOF'
 Usage: ./run.sh [OPTIONS]
 
 Orchestrates the Agentomics training and evaluation process. By default, it runs in Docker containers.

--- a/run.sh
+++ b/run.sh
@@ -526,6 +526,7 @@ else
         CODEX_DOCKER_FLAGS+=(-e "CODEX_MODELS_CACHE_FILE=/tmp/codex/models_cache.json")
     fi
 
+    AGENTOMICS_ARGS+=(--workspace-dir /workspace --prepared-datasets-dir /repository/prepared_datasets)
     TEST_EXEC=(--entrypoint /opt/conda/envs/agentomics-env/bin/python "$AGENTOMICS_IMAGE" -m test.run_all_tests)
     RUN_EXEC=("$AGENTOMICS_IMAGE" "${AGENTOMICS_ARGS[@]}")
     if [[ ${#CODEX_DOCKER_FLAGS[@]} -gt 0 ]]; then
@@ -574,8 +575,6 @@ else
             -v temp_agentomics_volume_${AGENT_ID}:/workspace \
             ${TEST_EXEC[@]+"${TEST_EXEC[@]}"}
     else
-        AGENTOMICS_ARGS+=(--workspace-dir /workspace --prepared-datasets-dir /repository/prepared_datasets)
-
         set +e
         docker run \
             --rm \

--- a/run.sh
+++ b/run.sh
@@ -16,6 +16,7 @@ USE_PROVISIONING_KEY=false
 SPEND_LIMIT=10
 TIMEOUT_SECS=""
 MODEL_NAME=""
+PREFERRED_PROVIDER=""
 DATASET_NAME=""
 VAL_METRIC=""
 LIST_MODE=false
@@ -70,6 +71,8 @@ Environment:
   API keys read from 'src/utils/providers/configured_providers.yaml' must be set as
   environment variables in your host environment (e.g., in a shell session or .env file)
   to be injected into the Docker container.
+  For the 'codex' provider, run `codex login` on the host so `~/.codex/auth.json`
+  is available to the launcher.
 
 Output:
   Results are copied from the temporary workspace to the local 'outputs/<AGENT_ID>' directory.
@@ -110,6 +113,7 @@ while [[ $# -gt 0 ]]; do
         --provider)
             require_opt_value "$1" "${2:-}"
             AGENTOMICS_ARGS+=(--provider "$2")
+            PREFERRED_PROVIDER="$2"
             shift 2
             ;;
         --dataset)
@@ -514,6 +518,43 @@ else
         fi
     fi
 
+    CODEX_DOCKER_FLAGS=()
+    HOST_CODEX_DIR="${HOME}/.codex"
+    if [[ -d "$HOST_CODEX_DIR" ]] && ([[ -z "$PREFERRED_PROVIDER" ]] || [[ "$PREFERRED_PROVIDER" == "codex" ]]); then
+        CODEX_DOCKER_FLAGS+=(-v "${HOST_CODEX_DIR}:/mnt/codex-host:ro")
+        CODEX_DOCKER_FLAGS+=(-e "CODEX_AUTH_FILE=/tmp/codex/auth.json")
+        CODEX_DOCKER_FLAGS+=(-e "CODEX_MODELS_CACHE_FILE=/tmp/codex/models_cache.json")
+    fi
+
+    TEST_EXEC=(--entrypoint /opt/conda/envs/agentomics-env/bin/python "$AGENTOMICS_IMAGE" -m test.run_all_tests)
+    RUN_EXEC=("$AGENTOMICS_IMAGE" "${AGENTOMICS_ARGS[@]}")
+    if [[ ${#CODEX_DOCKER_FLAGS[@]} -gt 0 ]]; then
+        CODEX_BOOTSTRAP='
+            mkdir -p /tmp/codex
+            if [[ -f /mnt/codex-host/auth.json ]]; then cp -f /mnt/codex-host/auth.json /tmp/codex/auth.json; fi
+            if [[ -f /mnt/codex-host/models_cache.json ]]; then cp -f /mnt/codex-host/models_cache.json /tmp/codex/models_cache.json; fi
+            exec "$@"
+        '
+        TEST_EXEC=(
+            --entrypoint /bin/bash
+            "$AGENTOMICS_IMAGE"
+            -lc "$CODEX_BOOTSTRAP"
+            --
+            /opt/conda/envs/agentomics-env/bin/python
+            -m
+            test.run_all_tests
+        )
+        RUN_EXEC=(
+            --entrypoint /bin/bash
+            "$AGENTOMICS_IMAGE"
+            -lc "$CODEX_BOOTSTRAP"
+            --
+            /opt/conda/envs/agentomics-env/bin/python
+            /repository/src/run_agent_interactive.py
+            "${AGENTOMICS_ARGS[@]}"
+        )
+    fi
+
     if [ "$TEST_MODE" = true ]; then
         docker run \
             -it \
@@ -526,12 +567,12 @@ else
             ${GPU_FLAGS[@]+"${GPU_FLAGS[@]}"} \
             ${OLLAMA_FLAGS[@]+"${OLLAMA_FLAGS[@]}"} \
             ${DOCKER_API_KEY_ENV_VARS[@]+"${DOCKER_API_KEY_ENV_VARS[@]}"} \
+            ${CODEX_DOCKER_FLAGS[@]+"${CODEX_DOCKER_FLAGS[@]}"} \
             -v "$(pwd)/src":/repository/src:ro \
             -v "$(pwd)/test":/repository/test:ro \
             -v "$(pwd)/prepared_datasets":/repository/prepared_datasets:ro \
             -v temp_agentomics_volume_${AGENT_ID}:/workspace \
-            --entrypoint /opt/conda/envs/agentomics-env/bin/python \
-            "$AGENTOMICS_IMAGE" -m test.run_all_tests
+            ${TEST_EXEC[@]+"${TEST_EXEC[@]}"}
     else
         AGENTOMICS_ARGS+=(--workspace-dir /workspace --prepared-datasets-dir /repository/prepared_datasets)
 
@@ -546,11 +587,12 @@ else
             ${GPU_FLAGS[@]+"${GPU_FLAGS[@]}"} \
             ${OLLAMA_FLAGS[@]+"${OLLAMA_FLAGS[@]}"} \
             ${DOCKER_API_KEY_ENV_VARS[@]+"${DOCKER_API_KEY_ENV_VARS[@]}"} \
+            ${CODEX_DOCKER_FLAGS[@]+"${CODEX_DOCKER_FLAGS[@]}"} \
             -v "$(pwd)/src":/repository/src:ro \
             -v "$(pwd)/prepared_datasets":/repository/prepared_datasets:ro \
             -v "$(pwd)/prepared_test_sets":/repository/prepared_test_sets:ro \
             -v temp_agentomics_volume_${AGENT_ID}:/workspace \
-            "$AGENTOMICS_IMAGE" ${AGENTOMICS_ARGS+"${AGENTOMICS_ARGS[@]}"}
+            ${RUN_EXEC[@]+"${RUN_EXEC[@]}"}
         RUN_EXIT_CODE=$?
         set -e
 

--- a/src/utils/providers/codex_auth.py
+++ b/src/utils/providers/codex_auth.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import copy
+import json
+import os
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+
+DEFAULT_CODEX_AUTH_PATH = Path.home() / ".codex" / "auth.json"
+DEFAULT_CODEX_MODELS_CACHE_PATH = Path.home() / ".codex" / "models_cache.json"
+DEFAULT_CODEX_TOKEN_URL = "https://auth.openai.com/oauth/token"
+DEFAULT_CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+TOKEN_REFRESH_SKEW_SECONDS = 300
+
+
+def get_codex_auth_path() -> Path:
+    return Path(os.getenv("CODEX_AUTH_FILE", DEFAULT_CODEX_AUTH_PATH)).expanduser()
+
+
+def get_codex_models_cache_path() -> Path:
+    return Path(os.getenv("CODEX_MODELS_CACHE_FILE", DEFAULT_CODEX_MODELS_CACHE_PATH)).expanduser()
+
+
+def _decode_jwt_payload(token: str) -> dict[str, Any]:
+    parts = token.split(".")
+    if len(parts) < 2:
+        return {}
+
+    payload = parts[1]
+    payload += "=" * (-len(payload) % 4)
+    try:
+        decoded = base64.urlsafe_b64decode(payload.encode("ascii"))
+        data = json.loads(decoded.decode("utf-8"))
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass(slots=True)
+class CodexAuthState:
+    access_token: str
+    refresh_token: str
+    id_token: str | None
+    account_id: str | None
+    access_token_exp: int | None
+    raw_data: dict[str, Any]
+
+    @classmethod
+    def from_raw(cls, raw_data: dict[str, Any]) -> "CodexAuthState":
+        tokens = raw_data.get("tokens") or {}
+        access_token = tokens.get("access_token")
+        refresh_token = tokens.get("refresh_token")
+        if not access_token or not refresh_token:
+            raise ValueError("Codex auth file is missing access_token or refresh_token.")
+
+        access_claims = _decode_jwt_payload(access_token)
+        auth_claims = access_claims.get("https://api.openai.com/auth", {})
+        account_id = tokens.get("account_id") or auth_claims.get("chatgpt_account_id")
+
+        access_token_exp = access_claims.get("exp")
+        if not isinstance(access_token_exp, int):
+            access_token_exp = None
+
+        return cls(
+            access_token=access_token,
+            refresh_token=refresh_token,
+            id_token=tokens.get("id_token"),
+            account_id=account_id,
+            access_token_exp=access_token_exp,
+            raw_data=raw_data,
+        )
+
+    def needs_refresh(self, skew_seconds: int = TOKEN_REFRESH_SKEW_SECONDS) -> bool:
+        if self.access_token_exp is None:
+            return False
+        return time.time() >= self.access_token_exp - skew_seconds
+
+
+class CodexAuthStore:
+    def __init__(
+        self,
+        auth_path: Path | None = None,
+        *,
+        token_url: str | None = None,
+        client_id: str | None = None,
+        proxy_url: str | None = None,
+        timeout: float = 30.0,
+    ):
+        self.auth_path = (auth_path or get_codex_auth_path()).expanduser()
+        self.token_url = token_url or DEFAULT_CODEX_TOKEN_URL
+        self.client_id = client_id or DEFAULT_CODEX_CLIENT_ID
+        self.proxy_url = proxy_url
+        self.timeout = timeout
+        self._refresh_lock = asyncio.Lock()
+
+    @staticmethod
+    def is_available(auth_path: Path | None = None) -> bool:
+        path = (auth_path or get_codex_auth_path()).expanduser()
+        if not path.is_file():
+            return False
+        try:
+            CodexAuthState.from_raw(json.loads(path.read_text()))
+            return True
+        except Exception:
+            return False
+
+    def load_state(self) -> CodexAuthState:
+        raw_data = json.loads(self.auth_path.read_text())
+        return CodexAuthState.from_raw(raw_data)
+
+    def get_account_id(self) -> str:
+        account_id = self.load_state().account_id
+        if not account_id:
+            raise ValueError("Codex auth file is missing ChatGPT account metadata. Run `codex login` again.")
+        return account_id
+
+    async def get_access_token(self) -> str:
+        state = self.load_state()
+        if not state.needs_refresh():
+            return state.access_token
+
+        async with self._refresh_lock:
+            state = self.load_state()
+            if not state.needs_refresh():
+                return state.access_token
+
+            refreshed_state = await self._refresh_state(state)
+            self._write_state(refreshed_state.raw_data)
+            return refreshed_state.access_token
+
+    async def _refresh_state(self, state: CodexAuthState) -> CodexAuthState:
+        form_data = {
+            "grant_type": "refresh_token",
+            "refresh_token": state.refresh_token,
+            "client_id": self.client_id,
+        }
+        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+
+        async with httpx.AsyncClient(proxy=self.proxy_url, timeout=self.timeout) as client:
+            response = await client.post(self.token_url, data=form_data, headers=headers)
+            response.raise_for_status()
+
+        token_response = response.json()
+        if not isinstance(token_response, dict) or "access_token" not in token_response:
+            raise ValueError("Codex token refresh did not return an access_token.")
+
+        refreshed = copy.deepcopy(state.raw_data)
+        refreshed.setdefault("tokens", {})
+        refreshed["last_refresh"] = _utcnow_iso()
+        refreshed["tokens"]["access_token"] = token_response["access_token"]
+        refreshed["tokens"]["refresh_token"] = token_response.get("refresh_token") or state.refresh_token
+        if token_response.get("id_token"):
+            refreshed["tokens"]["id_token"] = token_response["id_token"]
+
+        access_claims = _decode_jwt_payload(refreshed["tokens"]["access_token"])
+        auth_claims = access_claims.get("https://api.openai.com/auth", {})
+        if auth_claims.get("chatgpt_account_id"):
+            refreshed["tokens"]["account_id"] = auth_claims["chatgpt_account_id"]
+
+        return CodexAuthState.from_raw(refreshed)
+
+    def _write_state(self, raw_data: dict[str, Any]) -> None:
+        self.auth_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = self.auth_path.with_suffix(f"{self.auth_path.suffix}.tmp")
+        tmp_path.write_text(json.dumps(raw_data, indent=2) + "\n")
+        try:
+            os.chmod(tmp_path, 0o600)
+        except OSError:
+            pass
+        tmp_path.replace(self.auth_path)

--- a/src/utils/providers/codex_provider.py
+++ b/src/utils/providers/codex_provider.py
@@ -43,19 +43,21 @@ class CodexResponsesModel(OpenAIResponsesModel):
     @staticmethod
     def _rewrite_messages_for_codex(messages: list[ModelMessage]) -> list[ModelMessage]:
         rewritten_messages: list[ModelMessage] = []
+        carried_instructions: str | None = None
         for message in messages:
             if not isinstance(message, ModelRequest):
                 rewritten_messages.append(message)
                 continue
 
             system_parts = [part.content for part in message.parts if isinstance(part, SystemPromptPart)]
-            if not system_parts:
-                rewritten_messages.append(message)
-                continue
+            instructions = message.instructions or carried_instructions
 
-            instructions = "\n\n".join(system_parts)
-            if message.instructions:
-                instructions = "\n\n".join([message.instructions, instructions])
+            if system_parts:
+                joined_system_parts = "\n\n".join(system_parts)
+                instructions = "\n\n".join([instructions, joined_system_parts]) if instructions else joined_system_parts
+
+            if instructions:
+                carried_instructions = instructions
 
             rewritten_messages.append(
                 replace(

--- a/src/utils/providers/codex_provider.py
+++ b/src/utils/providers/codex_provider.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from dataclasses import replace
+import json
+from typing import Any, AsyncIterator, Dict, List, Optional
+
+import httpx
+from openai import AsyncOpenAI
+from pydantic_ai.models.openai import OpenAIResponsesModel
+from pydantic_ai.messages import ModelMessage, ModelRequest, ModelResponse, SystemPromptPart
+from pydantic_ai.models import ModelRequestParameters, StreamedResponse
+from pydantic_ai.providers.openai import OpenAIProvider as PydanticOpenAIProvider
+from pydantic_ai.settings import ModelSettings
+from rich.panel import Panel
+
+from utils.config import Config
+from utils.user_input import get_user_input_for_int
+
+from .codex_auth import CodexAuthStore, get_codex_models_cache_path
+from .provider import Provider
+
+
+class AsyncCodexOpenAI(AsyncOpenAI):
+    def __init__(self, auth_store: CodexAuthStore, **kwargs):
+        self._codex_auth_store = auth_store
+        super().__init__(api_key=self._codex_auth_store.get_access_token, **kwargs)
+
+    @property
+    def default_headers(self) -> dict[str, str]:
+        headers = super().default_headers
+        headers["ChatGPT-Account-Id"] = self._codex_auth_store.get_account_id()
+        return headers
+
+
+class CodexResponsesModel(OpenAIResponsesModel):
+    @staticmethod
+    def _merge_codex_settings(model_settings: ModelSettings | None) -> ModelSettings:
+        merged_settings = dict(model_settings or {})
+        merged_settings["openai_store"] = False
+        return merged_settings
+
+    @staticmethod
+    def _rewrite_messages_for_codex(messages: list[ModelMessage]) -> list[ModelMessage]:
+        rewritten_messages: list[ModelMessage] = []
+        for message in messages:
+            if not isinstance(message, ModelRequest):
+                rewritten_messages.append(message)
+                continue
+
+            system_parts = [part.content for part in message.parts if isinstance(part, SystemPromptPart)]
+            if not system_parts:
+                rewritten_messages.append(message)
+                continue
+
+            instructions = "\n\n".join(system_parts)
+            if message.instructions:
+                instructions = "\n\n".join([message.instructions, instructions])
+
+            rewritten_messages.append(
+                replace(
+                    message,
+                    parts=[part for part in message.parts if not isinstance(part, SystemPromptPart)],
+                    instructions=instructions,
+                )
+            )
+
+        return rewritten_messages
+
+    async def request(
+        self,
+        messages: list[ModelRequest | ModelResponse],
+        model_settings: ModelSettings | None,
+        model_request_parameters: ModelRequestParameters,
+    ) -> ModelResponse:
+        messages = self._rewrite_messages_for_codex(messages)
+        async with super().request_stream(
+            messages,
+            self._merge_codex_settings(model_settings),
+            model_request_parameters,
+        ) as response:
+            async for _ in response:
+                pass
+            return response.get()
+
+    @asynccontextmanager
+    async def request_stream(
+        self,
+        messages: list[ModelMessage],
+        model_settings: ModelSettings | None,
+        model_request_parameters: ModelRequestParameters,
+        run_context: Any | None = None,
+    ) -> AsyncIterator[StreamedResponse]:
+        messages = self._rewrite_messages_for_codex(messages)
+        async with super().request_stream(
+            messages,
+            self._merge_codex_settings(model_settings),
+            model_request_parameters,
+            run_context=run_context,
+        ) as response:
+            yield response
+
+
+class CodexProvider(Provider):
+    def __init__(self, base_url: str, list_models_endpoint: str | None = None):
+        super().__init__(name="Codex", base_url=base_url, list_models_endpoint=list_models_endpoint)
+        self.auth_store = CodexAuthStore(proxy_url=self.get_proxy_url())
+
+    def fetch_models(self) -> Optional[List[Dict]]:
+        cache_path = get_codex_models_cache_path()
+        if not cache_path.is_file():
+            self.console.print(f"Codex model cache not found: {cache_path}", style="red")
+            return None
+
+        try:
+            raw_models = json.loads(cache_path.read_text()).get("models", [])
+            models: list[dict] = []
+            for raw_model in raw_models:
+                if raw_model.get("supported_in_api") is False:
+                    continue
+                if raw_model.get("visibility") == "hide":
+                    continue
+
+                slug = raw_model.get("slug") or raw_model.get("id")
+                if not slug:
+                    continue
+
+                models.append(
+                    {
+                        "id": slug,
+                        "display_name": raw_model.get("display_name", slug),
+                        "description": raw_model.get("description", ""),
+                        "priority": raw_model.get("priority", 999),
+                    }
+                )
+
+            if not models:
+                self.console.print("No Codex models available in the local cache.", style="red")
+                return None
+
+            models.sort(key=lambda model: (model.get("priority", 999), model.get("id", "")))
+            return models
+        except Exception as e:
+            self.console.print(f"Failed to read Codex model cache: {e}")
+            return None
+
+    def display_models(self, models: List[Dict] = None) -> None:
+        if models is None:
+            models = self.fetch_models()
+        if not models:
+            return
+
+        self.console.print(f"[bold blue]Available Models[/bold blue] ({len(models)} models)\n")
+
+        lines = []
+        max_num_width = len(str(len(models)))
+        max_name_width = max(len(model.get("display_name", model.get("id", ""))) for model in models)
+
+        for i, model in enumerate(models, 1):
+            num_str = str(i).rjust(max_num_width)
+            display_name = model.get("display_name", model.get("id", ""))
+            description = model.get("description", "")
+            lines.append(f"[dim]{num_str}.[/dim] [cyan]{display_name}[/cyan]")
+            if description:
+                lines.append(f"   [dim]{description}[/dim]")
+
+        panel_width = min(max_num_width + max_name_width + 14, 120)
+        panel = Panel(
+            "\n".join(lines),
+            title="[bold green]Codex[/bold green]",
+            title_align="left",
+            border_style="green",
+            width=panel_width,
+        )
+        self.console.print(panel)
+
+    def interactive_model_selection(self, limit: int = None) -> Optional[str]:
+        models = self.fetch_models()
+        if not models:
+            self.console.print("Could not load Codex models", style="red")
+            return None
+
+        if limit and limit < len(models):
+            models = models[:limit]
+
+        self.display_models(models)
+
+        choice = get_user_input_for_int(
+            prompt_text=f"Select model (1-{len(models)}) or Enter for first",
+            default=1,
+            valid_options=list(range(1, len(models) + 1)),
+        )
+
+        if choice:
+            return models[choice - 1].get("id")
+
+        return None
+
+    def create_model(self, model_name: str, config: Config) -> OpenAIResponsesModel:
+        # Fail early with a clear message instead of deferring until the first request.
+        self.auth_store.get_account_id()
+
+        proxy_url = self.get_proxy_url()
+        async_http_client = httpx.AsyncClient(
+            proxy=proxy_url if config.use_proxy else None,
+            timeout=config.llm_response_timeout,
+        )
+        client = AsyncCodexOpenAI(
+            auth_store=self.auth_store,
+            base_url=self.base_url,
+            http_client=async_http_client,
+        )
+        return CodexResponsesModel(
+            model_name=model_name,
+            provider=PydanticOpenAIProvider(openai_client=client),
+        )

--- a/src/utils/providers/codex_provider.py
+++ b/src/utils/providers/codex_provider.py
@@ -152,8 +152,6 @@ class CodexProvider(Provider):
         if not models:
             return
 
-        self.console.print(f"[bold blue]Available Models[/bold blue] ({len(models)} models)\n")
-
         lines = []
         max_num_width = len(str(len(models)))
         max_name_width = max(len(model.get("display_name", model.get("id", ""))) for model in models)
@@ -162,16 +160,16 @@ class CodexProvider(Provider):
             num_str = str(i).rjust(max_num_width)
             display_name = model.get("display_name", model.get("id", ""))
             description = model.get("description", "")
-            lines.append(f"[dim]{num_str}.[/dim] [cyan]{display_name}[/cyan]")
+            lines.append(f"[dim]{num_str}.[/dim] [white]{display_name}[/white]")
             if description:
                 lines.append(f"   [dim]{description}[/dim]")
 
         panel_width = min(max_num_width + max_name_width + 14, 120)
         panel = Panel(
             "\n".join(lines),
-            title="[bold green]Codex[/bold green]",
+            title="[bold white]Codex[/bold white]",
             title_align="left",
-            border_style="green",
+            border_style="cyan",
             width=panel_width,
         )
         self.console.print(panel)

--- a/src/utils/providers/codex_provider.py
+++ b/src/utils/providers/codex_provider.py
@@ -63,7 +63,7 @@ class CodexResponsesModel(OpenAIResponsesModel):
                 replace(
                     message,
                     parts=[part for part in message.parts if not isinstance(part, SystemPromptPart)],
-                    instructions=instructions,
+                    instructions=instructions or "You are an helpful assistant", #TODO remove this dummy prompt once actual sys prompt defined for iteration plan
                 )
             )
 

--- a/src/utils/providers/configured_providers.yaml
+++ b/src/utils/providers/configured_providers.yaml
@@ -3,6 +3,11 @@ providers:
     apikey: "${OPENAI_API_KEY}"
     base_url: "https://api.openai.com/v1"
     list_models_endpoint: "https://api.openai.com/v1/models"
+
+  - name: "Codex"
+    apikey: ""
+    base_url: "https://chatgpt.com/backend-api/codex"
+    list_models_endpoint: ""
   
   - name: "Anthropic"
     apikey: "${ANTHROPIC_API_KEY}"

--- a/src/utils/providers/provider.py
+++ b/src/utils/providers/provider.py
@@ -28,6 +28,17 @@ class Provider():
         self.base_url = base_url
         self.list_models_endpoint = list_models_endpoint
         self.headers = {}
+
+    @staticmethod
+    def get_proxy_url() -> Optional[str]:
+        return (
+            os.getenv("HTTPS_PROXY")
+            or os.getenv("https_proxy")
+            or os.getenv("HTTP_PROXY")
+            or os.getenv("http_proxy")
+            or os.getenv("ALL_PROXY")
+            or os.getenv("all_proxy")
+        )
     
     def fetch_models(self) -> Optional[List[Dict]]:
         """Get available models. Override in subclasses when necessary."""
@@ -152,6 +163,9 @@ class Provider():
         elif name_lower == "openai":
             from .openai_provider import OpenAiProvider
             return OpenAiProvider(api_key, base_url, provider_config["list_models_endpoint"])
+        elif name_lower == "codex":
+            from .codex_provider import CodexProvider
+            return CodexProvider(base_url, provider_config["list_models_endpoint"])
         # elif name_lower == "googleai": requires pydanticai version update
         #     from .googleai_provider import GoogleAiProvider
         #     return GoogleAiProvider(api_key, base_url, list_models_endpoint)
@@ -170,6 +184,11 @@ def get_provided_api_keys() -> Dict[str, str]:
 
         if (api_key_env and os.getenv(api_key_env)) or (provider_name.lower() == "ollama" and os.getenv("OLLAMA_BASE_URL")):
               provided_keys[provider_name] = os.getenv(api_key_env, "")
+        elif provider_name.lower() == "codex":
+            from .codex_auth import CodexAuthStore
+
+            if CodexAuthStore.is_available():
+                provided_keys[provider_name] = ""
 
     return provided_keys #{"provider": api_key, ...}
 
@@ -207,7 +226,9 @@ def get_provider_and_api_key(preferred_provider: str = None) -> tuple[str, str]:
     elif preferred_provider:
         match = next((key for key in api_keys_provided if key.lower() == preferred_provider.lower()), None)
         if match is None:
-            raise ValueError(f"--provider '{preferred_provider}' API key is not set in env variables. Available: {list(api_keys_provided.keys())}")
+            raise ValueError(
+                f"--provider '{preferred_provider}' is not configured. Available: {list(api_keys_provided.keys())}"
+            )
         return api_keys_provided[match], match
     elif len(api_keys_provided) > 1:
         if not (sys.stdin.isatty() and sys.stdout.isatty()): #non-interactive run
@@ -236,6 +257,8 @@ def list_required_api_keys() -> str:
             required_env_vars.append(api_key_env)
         elif provider_name.lower() == "ollama":
             required_env_vars.append("OLLAMA_BASE_URL")
+        elif provider_name.lower() == "codex":
+            required_env_vars.append("codex login (~/.codex/auth.json)")
     
     return ", ".join(required_env_vars)
 

--- a/test/test_codex_provider.py
+++ b/test/test_codex_provider.py
@@ -135,6 +135,17 @@ class TestCodexAuthStore(CodexTestCase):
         self.assertEqual(rewritten_request.instructions, "system")
         self.assertEqual([type(part).__name__ for part in rewritten_request.parts], ["UserPromptPart"])
 
+    def test_codex_carries_instructions_to_followup_requests(self):
+        requests = [
+            ModelRequest(parts=[SystemPromptPart(content="system"), UserPromptPart(content="user")]),
+            ModelRequest(parts=[UserPromptPart(content="follow-up")]),
+        ]
+
+        rewritten = CodexResponsesModel._rewrite_messages_for_codex(requests)
+
+        self.assertEqual(rewritten[0].instructions, "system")
+        self.assertEqual(rewritten[1].instructions, "system")
+
 
 class TestCodexRefresh(CodexTestCase, unittest.IsolatedAsyncioTestCase):
     async def test_refreshes_expiring_access_token_and_persists_new_tokens(self):

--- a/test/test_codex_provider.py
+++ b/test/test_codex_provider.py
@@ -1,0 +1,178 @@
+import base64
+import json
+import os
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_PATH = REPO_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+from pydantic_ai.messages import ModelRequest, SystemPromptPart, UserPromptPart
+
+from src.utils.providers.codex_auth import CodexAuthStore
+from src.utils.providers.codex_provider import CodexProvider, CodexResponsesModel
+from src.utils.providers.provider import get_provided_api_keys
+
+
+def make_jwt(payload: dict) -> str:
+    header = {"alg": "none", "typ": "JWT"}
+
+    def encode(part: dict) -> str:
+        raw = json.dumps(part, separators=(",", ":")).encode("utf-8")
+        return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+    return f"{encode(header)}.{encode(payload)}.signature"
+
+
+class CodexTestCase(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.auth_path = Path(self.tmpdir.name) / "auth.json"
+        self.models_cache_path = Path(self.tmpdir.name) / "models_cache.json"
+        self.account_id = "test-account-id"
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def write_auth_file(self, *, exp_offset_seconds: int = 3600, refresh_token: str = "refresh-token") -> str:
+        access_token = make_jwt(
+            {
+                "exp": int(time.time()) + exp_offset_seconds,
+                "https://api.openai.com/auth": {
+                    "chatgpt_account_id": self.account_id,
+                },
+            }
+        )
+        id_token = make_jwt({"exp": int(time.time()) + exp_offset_seconds})
+        auth_payload = {
+            "auth_mode": "chatgpt",
+            "OPENAI_API_KEY": None,
+            "last_refresh": "2026-04-01T00:00:00+00:00",
+            "tokens": {
+                "access_token": access_token,
+                "refresh_token": refresh_token,
+                "id_token": id_token,
+                "account_id": self.account_id,
+            },
+        }
+        self.auth_path.write_text(json.dumps(auth_payload))
+        return access_token
+
+
+class TestCodexAuthStore(CodexTestCase):
+    def test_load_state_extracts_account_metadata(self):
+        access_token = self.write_auth_file()
+
+        store = CodexAuthStore(auth_path=self.auth_path)
+        state = store.load_state()
+
+        self.assertEqual(state.access_token, access_token)
+        self.assertEqual(state.account_id, self.account_id)
+        self.assertFalse(state.needs_refresh())
+
+    def test_get_provided_api_keys_includes_codex_when_auth_file_exists(self):
+        self.write_auth_file()
+
+        with patch.dict(os.environ, {"CODEX_AUTH_FILE": str(self.auth_path)}, clear=True):
+            provided = get_provided_api_keys()
+
+        self.assertIn("Codex", provided)
+        self.assertEqual(provided["Codex"], "")
+
+    def test_codex_provider_reads_visible_models_from_cache(self):
+        self.write_auth_file()
+        self.models_cache_path.write_text(
+            json.dumps(
+                {
+                    "models": [
+                        {
+                            "slug": "gpt-5.4",
+                            "display_name": "gpt-5.4",
+                            "description": "Latest frontier agentic coding model.",
+                            "supported_in_api": True,
+                            "visibility": "list",
+                            "priority": 1,
+                        },
+                        {
+                            "slug": "gpt-5-codex-mini",
+                            "display_name": "gpt-5-codex-mini",
+                            "supported_in_api": True,
+                            "visibility": "hide",
+                            "priority": 2,
+                        },
+                    ]
+                }
+            )
+        )
+
+        with patch.dict(
+            os.environ,
+            {
+                "CODEX_AUTH_FILE": str(self.auth_path),
+                "CODEX_MODELS_CACHE_FILE": str(self.models_cache_path),
+            },
+            clear=True,
+        ):
+            provider = CodexProvider("https://chatgpt.com/backend-api/codex", "")
+            models = provider.fetch_models()
+
+        self.assertEqual([model["id"] for model in models], ["gpt-5.4"])
+
+    def test_codex_rewrites_system_prompts_into_instructions(self):
+        request = ModelRequest(parts=[SystemPromptPart(content="system"), UserPromptPart(content="user")])
+
+        rewritten = CodexResponsesModel._rewrite_messages_for_codex([request])
+
+        self.assertEqual(len(rewritten), 1)
+        rewritten_request = rewritten[0]
+        self.assertIsInstance(rewritten_request, ModelRequest)
+        self.assertEqual(rewritten_request.instructions, "system")
+        self.assertEqual([type(part).__name__ for part in rewritten_request.parts], ["UserPromptPart"])
+
+
+class TestCodexRefresh(CodexTestCase, unittest.IsolatedAsyncioTestCase):
+    async def test_refreshes_expiring_access_token_and_persists_new_tokens(self):
+        self.write_auth_file(exp_offset_seconds=-60, refresh_token="old-refresh-token")
+        refreshed_access_token = make_jwt(
+            {
+                "exp": int(time.time()) + 3600,
+                "https://api.openai.com/auth": {
+                    "chatgpt_account_id": self.account_id,
+                },
+            }
+        )
+
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        response.json.return_value = {
+            "access_token": refreshed_access_token,
+            "refresh_token": "new-refresh-token",
+            "id_token": make_jwt({"exp": int(time.time()) + 3600}),
+        }
+
+        http_client = AsyncMock()
+        http_client.post.return_value = response
+
+        http_client_cm = AsyncMock()
+        http_client_cm.__aenter__.return_value = http_client
+        http_client_cm.__aexit__.return_value = None
+
+        with patch("src.utils.providers.codex_auth.httpx.AsyncClient", return_value=http_client_cm):
+            store = CodexAuthStore(auth_path=self.auth_path)
+            access_token = await store.get_access_token()
+
+        self.assertEqual(access_token, refreshed_access_token)
+        self.assertEqual(http_client.post.await_count, 1)
+        refresh_request = http_client.post.await_args.kwargs["data"]
+        self.assertEqual(refresh_request["grant_type"], "refresh_token")
+        self.assertEqual(refresh_request["refresh_token"], "old-refresh-token")
+
+        saved_state = CodexAuthStore(auth_path=self.auth_path).load_state()
+        self.assertEqual(saved_state.access_token, refreshed_access_token)
+        self.assertEqual(saved_state.refresh_token, "new-refresh-token")


### PR DESCRIPTION
Adds support for running Agentomics with the Codex provider via local codex login auth, instead of an API key

user needs to have codex already installed and logged in

What changed:

- Load local Codex auth from ~/.codex/auth.json and refresh tokens when needed
- Make Codex model selection available in the existing interactive flow
- Mount Codex auth and model cache into Docker runs so the provider works inside the container
- Adapt request handling for the Codex Responses API, including required instructions
- Added documentation and some tests (we could remove the test file)