### PR TITLE
Forking

### DIFF
--- a/docs/configuration/cli-options.md
+++ b/docs/configuration/cli-options.md
@@ -45,6 +45,18 @@ The run stops when either the iteration count is reached or the timeout expires.
 | `--exploration-iterations <n>` | Baseline exploration iterations (default 4) |
 | `--run-python-timeout <seconds>` | Per-training timeout for `run_python` tool (default 21600) |
 
+## Forking
+
+| Option | Description |
+|--------|-------------|
+| `--fork-from-run <path>` | Path to a source `outputs/<run_id>` directory. Creates a new run branching off from a checkpoint in that run. Most other options are optional when forking — omitting them inherits from the source run config. |
+| `--fork-from-iteration <n>` | Iteration number to fork from (default: latest). Only used with `--fork-from-run`. |
+| `--fork-from-step <step>` | Step ID to fork from, e.g. `data_split` or `model_training` (default: latest checkpoint). Only used with `--fork-from-run`. |
+
+When `--iterations`, `--split-allowed-iterations`, or `--exploration-iterations` are provided alongside `--fork-from-run`, they are interpreted as *additional* iterations from the fork point rather than absolute totals.
+
+See [Forking a Run](../user-guide/forking.md) for a full guide and examples.
+
 ## Examples
 
 ### Basic Run

--- a/docs/user-guide/forking.md
+++ b/docs/user-guide/forking.md
@@ -1,0 +1,110 @@
+# Forking a Run
+
+Forking lets you branch off from a completed checkpoint in an existing run and continue from that point as an independent new run. The forked run inherits the full history — trained models, data splits, conda environment — but any new iterations it produces are completely separate from the source.
+
+## When to Use Forking
+
+- **Try a different strategy mid-run**: fork after iteration 3 to explore a new direction without losing the work already done.
+- **Extend a finished run**: add more iterations to a run that has already completed.
+- **Compare branches**: fork the same checkpoint twice with different prompts or models to run a controlled comparison.
+
+## Basic Usage
+
+```bash
+./run.sh \
+  --fork-from-run outputs/my_source_run \
+  --model openai/gpt-4 \
+  --iterations 3
+```
+
+Point `--fork-from-run` at an `outputs/<run_id>` directory. The fork starts from the latest checkpoint in that run and continues for 3 more iterations.
+
+## Choosing a Checkpoint
+
+By default, the fork starts from the latest checkpoint (the end of the last completed iteration). You can pick an earlier point with `--fork-from-step` and/or `--fork-from-iteration`:
+
+```bash
+# Fork from the end of iteration 2
+./run.sh --fork-from-run outputs/my_run --fork-from-iteration 2
+
+# Fork from after the data_split step in iteration 1
+./run.sh --fork-from-run outputs/my_run \
+  --fork-from-iteration 1 \
+  --fork-from-step data_split
+```
+
+If `--fork-from-iteration` is omitted, the most recent iteration for the given step is used. If both are omitted, the latest checkpoint overall is used.
+
+## Iteration Counting
+
+When `--iterations` is passed to a fork, it means **N additional iterations from the fork point**, not a total. If the source run completed 4 iterations and you pass `--iterations 2`, the fork will run iterations 4 and 5 (total 6).
+
+If `--iterations` is omitted, the source run's original total is reused.
+
+The same relative semantics apply to `--split-allowed-iterations` and `--exploration-iterations`.
+
+## Inherited vs Overridable Options
+
+Most run options are **optional** when forking — omitting them reuses the value from the source run:
+
+| Option | Behaviour on fork |
+|--------|------------------|
+| `--model` | Inherited if omitted |
+| `--provider` | Inherited if omitted |
+| `--iterations` | Relative increment if provided; source total if omitted |
+| `--split-allowed-iterations` | Relative increment if provided; inherited if omitted |
+| `--exploration-iterations` | Relative increment if provided; inherited if omitted |
+| `--run-python-timeout` | Inherited if omitted |
+| `--user-prompt` | Inherited if omitted |
+| `--foundation-models-type` | Inherited if omitted |
+| `--tags` | Inherited if omitted |
+| `--dataset` | **Always inherited, cannot be changed** |
+| `--val-metric` | **Always inherited, cannot be changed** |
+
+Dataset and validation metric are locked to keep all iterations comparable across the fork lineage.
+
+## What the Fork Copies
+
+When a fork is set up, the following happens before the new run starts:
+
+1. The entire source workspace is copied (models, splits, conda environment, reports).
+2. The git history in the run directory is checked out at the requested checkpoint — files added in later commits are removed.
+3. Absolute paths stored in step outputs are rewritten to point to the new workspace.
+4. The shared conda environment is renamed for the new run ID and updated from the stored `environment.yml`.
+
+The forked run then continues from that state exactly as if the original run had stopped there.
+
+## Example: Extend a Completed Run
+
+```bash
+# Original run finished after 5 iterations
+./run.sh \
+  --fork-from-run outputs/finished_run \
+  --iterations 5   # run 5 more, for a total of 10
+```
+
+## Example: Compare Two Strategies from the Same Checkpoint
+
+```bash
+# Fork A: aggressive regularization
+./run.sh \
+  --fork-from-run outputs/base_run \
+  --fork-from-iteration 3 \
+  --user-prompt "Focus on heavily regularized models to reduce overfitting" \
+  --iterations 4
+
+# Fork B: ensemble approach
+./run.sh \
+  --fork-from-run outputs/base_run \
+  --fork-from-iteration 3 \
+  --user-prompt "Try ensemble methods combining multiple base learners" \
+  --iterations 4
+```
+
+Both forks start from identical state at iteration 3 and produce independent outputs you can compare directly.
+
+## Related
+
+- [CLI Options](../configuration/cli-options.md#forking) — Complete fork flag reference
+- [Understanding Outputs](outputs.md) — What each run produces
+- [Running the Agent](running-agent.md) — General usage guide

--- a/docs/user-guide/running-agent.md
+++ b/docs/user-guide/running-agent.md
@@ -114,6 +114,20 @@ Override the default optimization goal:
 
 See [Custom Prompts](../configuration/custom-prompts.md) for more details.
 
+## Forking a Run
+
+You can branch off from a checkpoint in an existing run and continue as an independent new run:
+
+```bash
+./run.sh \
+  --fork-from-run outputs/my_source_run \
+  --iterations 3
+```
+
+Most options (`--model`, `--user-prompt`, etc.) are optional when forking — they are inherited from the source run if omitted. `--iterations` means *N more from the fork point*, not a total. Dataset and validation metric are always inherited and cannot be changed.
+
+See [Forking a Run](forking.md) for the full guide.
+
 ## Full Help
 
 ```bash

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,7 @@ nav:
     - Installation: getting-started/installation.md
   - User Guide:
     - Running the Agent: user-guide/running-agent.md
+    - Forking a Run: user-guide/forking.md
     - Preparing Datasets: user-guide/datasets.md
     - Re-training Models: user-guide/training.md
     - Running Inference: user-guide/inference.md

--- a/rescue_crashed_run.sh
+++ b/rescue_crashed_run.sh
@@ -83,44 +83,19 @@ fi
 echo "Rescuing run '${AGENT_ID}' from volume '${VOLUME_NAME}'..."
 
 # ── Extract workspace from volume ─────────────────────────────────────────────
-mkdir -p "${OUTPUT_DIR}/best_iteration_snapshot" \
-         "${OUTPUT_DIR}/run" \
-         "${OUTPUT_DIR}/reports" \
-         "${OUTPUT_DIR}/extras"
+mkdir -p "${OUTPUT_DIR}"
 
-echo "Copying run directory..."
-docker run --rm \
-    -v "${VOLUME_NAME}:/workspace" \
-    busybox chmod -R a+rX /workspace/run/ || true
-
+echo "Copying workspace..."
+docker run --rm -v "${VOLUME_NAME}:/workspace" busybox chmod -R a+rX /workspace/ || true
 docker run --rm \
     -u "$(id -u):$(id -g)" \
     -v "${VOLUME_NAME}:/source" \
     -v "$(pwd)/${OUTPUT_DIR}:/dest" \
-    busybox cp -r /source/run/. /dest/run/
-
-docker run --rm \
-    -u "$(id -u):$(id -g)" \
-    -v "${VOLUME_NAME}:/source" \
-    -v "$(pwd)/${OUTPUT_DIR}:/dest" \
-    busybox sh -c 'if [ -d /source/reports ]; then cp -r /source/reports/. /dest/reports/; fi'
-
-docker run --rm \
-    -u "$(id -u):$(id -g)" \
-    -v "${VOLUME_NAME}:/source" \
-    -v "$(pwd)/${OUTPUT_DIR}:/dest" \
-    busybox sh -c 'if [ -d /source/extras ]; then cp -r /source/extras/. /dest/extras/; fi'
+    busybox cp -r /source/. /dest/
 
 # ── Best iteration snapshot (only present if at least one iteration completed) ─
 HAS_SNAPSHOT=false
-if docker run --rm -v "${VOLUME_NAME}:/workspace" busybox test -f "/workspace/best_iteration_snapshot/runtime_info/iteration_metadata.json" 2>/dev/null; then
-    echo "Found best iteration snapshot — copying..."
-    docker run --rm -v "${VOLUME_NAME}:/workspace" busybox chmod -R a+rX /workspace/best_iteration_snapshot/ || true
-    docker run --rm \
-        -u "$(id -u):$(id -g)" \
-        -v "${VOLUME_NAME}:/source" \
-        -v "$(pwd)/${OUTPUT_DIR}:/dest" \
-        busybox cp -r /source/best_iteration_snapshot/. /dest/best_iteration_snapshot/
+if [[ -f "${OUTPUT_DIR}/best_iteration_snapshot/runtime_info/iteration_metadata.json" ]]; then
     HAS_SNAPSHOT=true
 fi
 

--- a/rescue_crashed_run.sh
+++ b/rescue_crashed_run.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# Rescues a crashed Docker run by extracting its workspace volume to outputs/.
+# The Docker volume persists after crashes and power loss; use this script to
+# recover what was completed before the failure.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+source scripts/bash_helpers.sh
+
+show_help() {
+    cat <<'EOF'
+Usage: ./rescue_crashed_run.sh --agent-id <id> [OPTIONS]
+
+Extracts the workspace of a crashed run from its Docker volume and saves the
+results to outputs/<agent_id>/, regenerating markdown reports from whatever
+iterations completed before the crash.
+
+Required (unless --list is given):
+  --agent-id <id>     Agent ID of the crashed run.
+                      Use --list to see available volumes.
+
+Options:
+  --list              List agent IDs with surviving Docker volumes, then exit.
+  --skip-reports      Copy raw files only; skip report generation.
+  -h, --help          Show this help and exit.
+
+The rescued outputs land in outputs/<agent_id>/. From there you can inspect
+completed iterations or fork from the last checkpoint:
+  ./run.sh --fork-from-run outputs/<agent_id> --iterations <N>
+EOF
+}
+
+AGENT_ID=""
+LIST_MODE=false
+SKIP_REPORTS=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --agent-id)
+            require_opt_value "$1" "${2:-}"
+            AGENT_ID="$2"
+            shift 2
+            ;;
+        --list)
+            LIST_MODE=true
+            shift
+            ;;
+        --skip-reports)
+            SKIP_REPORTS=true
+            shift
+            ;;
+        -h|--help)
+            show_help
+            exit 0
+            ;;
+        *)
+            die "Unknown argument: $1. Run with --help for usage."
+            ;;
+    esac
+done
+
+# ── List mode ─────────────────────────────────────────────────────────────────
+if [ "$LIST_MODE" = true ]; then
+    echo "Agent IDs with surviving Docker volumes:"
+    docker volume ls --filter "name=temp_agentomics_volume_" --format "{{.Name}}" \
+        | sed 's/^temp_agentomics_volume_//' \
+        | while read -r id; do echo "  $id"; done \
+        || echo "  (none found)"
+    exit 0
+fi
+
+[[ -n "$AGENT_ID" ]] || die "--agent-id is required. Use --list to see available volumes, or --help for usage."
+
+VOLUME_NAME="temp_agentomics_volume_${AGENT_ID}"
+OUTPUT_DIR="outputs/${AGENT_ID}"
+
+if ! docker volume ls --format "{{.Name}}" | grep -q "^${VOLUME_NAME}$"; then
+    die "Volume '${VOLUME_NAME}' not found. Use --list to see available volumes."
+fi
+
+echo "Rescuing run '${AGENT_ID}' from volume '${VOLUME_NAME}'..."
+
+# ── Extract workspace from volume ─────────────────────────────────────────────
+mkdir -p "${OUTPUT_DIR}/best_iteration_snapshot" \
+         "${OUTPUT_DIR}/run" \
+         "${OUTPUT_DIR}/reports" \
+         "${OUTPUT_DIR}/extras"
+
+echo "Copying run directory..."
+docker run --rm \
+    -v "${VOLUME_NAME}:/workspace" \
+    busybox chmod -R a+rX /workspace/run/ || true
+
+docker run --rm \
+    -u "$(id -u):$(id -g)" \
+    -v "${VOLUME_NAME}:/source" \
+    -v "$(pwd)/${OUTPUT_DIR}:/dest" \
+    busybox cp -r /source/run/. /dest/run/
+
+docker run --rm \
+    -u "$(id -u):$(id -g)" \
+    -v "${VOLUME_NAME}:/source" \
+    -v "$(pwd)/${OUTPUT_DIR}:/dest" \
+    busybox sh -c 'if [ -d /source/reports ]; then cp -r /source/reports/. /dest/reports/; fi'
+
+docker run --rm \
+    -u "$(id -u):$(id -g)" \
+    -v "${VOLUME_NAME}:/source" \
+    -v "$(pwd)/${OUTPUT_DIR}:/dest" \
+    busybox sh -c 'if [ -d /source/extras ]; then cp -r /source/extras/. /dest/extras/; fi'
+
+# ── Best iteration snapshot (only present if at least one iteration completed) ─
+HAS_SNAPSHOT=false
+if docker run --rm -v "${VOLUME_NAME}:/workspace" busybox test -d /workspace/best_iteration_snapshot 2>/dev/null; then
+    echo "Found best iteration snapshot — copying..."
+    docker run --rm -v "${VOLUME_NAME}:/workspace" busybox chmod -R a+rX /workspace/best_iteration_snapshot/ || true
+    docker run --rm \
+        -u "$(id -u):$(id -g)" \
+        -v "${VOLUME_NAME}:/source" \
+        -v "$(pwd)/${OUTPUT_DIR}:/dest" \
+        busybox cp -r /source/best_iteration_snapshot/. /dest/best_iteration_snapshot/
+    HAS_SNAPSHOT=true
+fi
+
+# ── Report generation ─────────────────────────────────────────────────────────
+if [ "$SKIP_REPORTS" = false ]; then
+    echo "Generating iteration reports..."
+    PYTHONPATH="$(pwd)/src" conda run -n agentomics-env python -m runtime.iteration_reports \
+        --agent-dir "${OUTPUT_DIR}"
+
+    if [ "$HAS_SNAPSHOT" = true ]; then
+        AGENTOMICS_IMAGE="agentomics_img"
+        if docker image inspect "$AGENTOMICS_IMAGE" > /dev/null 2>&1; then
+            echo "Generating PDF reports..."
+            docker run --rm \
+                -u "$(id -u):$(id -g)" \
+                -e MPLCONFIGDIR="/tmp/mplconfig" \
+                -e PYTHONPATH=/repository/src \
+                -v "$(pwd)":/repository \
+                -v "$(pwd)/${OUTPUT_DIR}":/agent_out \
+                --entrypoint /opt/conda/envs/agentomics-env/bin/python \
+                "$AGENTOMICS_IMAGE" /repository/src/runtime/generate_final_reports.py \
+                    --agent-dir /agent_out \
+                    --prepared-datasets /repository/prepared_datasets \
+                    --prepared-tests /repository/prepared_test_sets
+        else
+            warn "Docker image '${AGENTOMICS_IMAGE}' not found — skipping PDF reports."
+            warn "Build it first with: ./run.sh --build-images --list-datasets"
+        fi
+    fi
+fi
+
+write_outputs_readme "${AGENT_ID}"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo "Rescue complete. Files saved to: ${OUTPUT_DIR}/"
+if [ "$HAS_SNAPSHOT" = false ]; then
+    warn "No best iteration snapshot found — the run crashed before completing its first iteration."
+fi
+echo ""
+echo "To fork from the last checkpoint and continue:"
+echo "  ./run.sh --fork-from-run ${OUTPUT_DIR} --iterations <N>"

--- a/rescue_crashed_run.sh
+++ b/rescue_crashed_run.sh
@@ -113,7 +113,7 @@ docker run --rm \
 
 # ── Best iteration snapshot (only present if at least one iteration completed) ─
 HAS_SNAPSHOT=false
-if docker run --rm -v "${VOLUME_NAME}:/workspace" busybox test -d /workspace/best_iteration_snapshot 2>/dev/null; then
+if docker run --rm -v "${VOLUME_NAME}:/workspace" busybox test -f "/workspace/best_iteration_snapshot/runtime_info/iteration_metadata.json" 2>/dev/null; then
     echo "Found best iteration snapshot — copying..."
     docker run --rm -v "${VOLUME_NAME}:/workspace" busybox chmod -R a+rX /workspace/best_iteration_snapshot/ || true
     docker run --rm \

--- a/run.sh
+++ b/run.sh
@@ -404,30 +404,27 @@ if [ "$LOCAL_MODE" = true ]; then
         exit 0
     fi
 
-    mkdir -p outputs/${AGENT_ID}/best_iteration_snapshot outputs/${AGENT_ID}/reports outputs/${AGENT_ID}/run outputs/${AGENT_ID}/extras
-    cp -r "${WORKSPACE_DIR}/run/." outputs/${AGENT_ID}/run/
-    if [[ -d "${WORKSPACE_DIR}/reports" ]]; then
-        cp -r "${WORKSPACE_DIR}/reports/." outputs/${AGENT_ID}/reports/
-    fi
-    if [[ -d "${WORKSPACE_DIR}/extras" ]]; then
-        cp -r "${WORKSPACE_DIR}/extras/." outputs/${AGENT_ID}/extras/
-    fi
-
     RUN_SUCCEEDED=true
     if [[ -f "${WORKSPACE_DIR}/best_iteration_snapshot/runtime_info/iteration_metadata.json" ]]; then
         CONFIG_PATH="${WORKSPACE_DIR}/run/shared/config.json"
         if [[ ! -f "${CONFIG_PATH}" ]]; then
             die "Config not found: ${CONFIG_PATH}"
         fi
-
         export PYTHONPATH=./src
         python src/run_logging/test_evaluation.py --workspace-dir "$WORKSPACE_DIR" --prepared-test-sets-dir "$(pwd)/prepared_test_sets"
-        cp -r "${WORKSPACE_DIR}/best_iteration_snapshot/." outputs/${AGENT_ID}/best_iteration_snapshot/
+    else
+        RUN_SUCCEEDED=false
+    fi
+
+    mkdir -p "outputs/${AGENT_ID}"
+    cp -r "${WORKSPACE_DIR}/." "outputs/${AGENT_ID}/"
+
+    if [[ "$RUN_SUCCEEDED" = true ]]; then
         PYTHONPATH="$(pwd)/src" conda run -n agentomics-env python -m runtime.iteration_reports --agent-dir "outputs/${AGENT_ID}"
 
         if [ "$USE_PROVISIONING_KEY" = true ]; then
             echo "Logging costs and cleaning up temporary API key"
-            PYTHONPATH="$(pwd)/src" conda run -n agentomics-env python src/utils/api_keys.py cleanup-and-log --config-path "$CONFIG_PATH" --api-key-hash "$TEMP_API_KEY_HASH"
+            PYTHONPATH="$(pwd)/src" conda run -n agentomics-env python src/utils/api_keys.py cleanup-and-log --config-path "outputs/${AGENT_ID}/run/shared/config.json" --api-key-hash "$TEMP_API_KEY_HASH"
         fi
 
         write_outputs_readme "${AGENT_ID}"
@@ -448,7 +445,6 @@ if [ "$LOCAL_MODE" = true ]; then
         echo -e "${GREEN}Run finished. Report and files can be found in outputs/${AGENT_ID}${NOCOLOR}"
         echo -e "${GREEN}To run inference on new data, use ./inference.sh --agent-dir outputs/${AGENT_ID} --input <path_to_input_csv> --output <path_to_output_csv>${NOCOLOR}"
     else
-        RUN_SUCCEEDED=false
         PYTHONPATH="$(pwd)/src" conda run -n agentomics-env python -m runtime.iteration_reports --agent-dir "outputs/${AGENT_ID}"
         warn "Agent didn't produce any valid best iteration snapshot. Exported run artifacts to outputs/${AGENT_ID}."
         write_outputs_readme "${AGENT_ID}"
@@ -679,14 +675,6 @@ else
         if [[ "$RUN_EXIT_CODE" -ne 0 ]]; then
             warn "Run container exited with code ${RUN_EXIT_CODE}. Exporting available run state before exiting."
         fi
-        mkdir -p outputs/${AGENT_ID}/best_iteration_snapshot outputs/${AGENT_ID}/run outputs/${AGENT_ID}/reports outputs/${AGENT_ID}/extras
-
-        docker run --rm -v temp_agentomics_volume_${AGENT_ID}:/workspace busybox chmod -R a+rX /workspace/run/ || true
-
-        docker run --rm -u $(id -u):$(id -g) -v temp_agentomics_volume_${AGENT_ID}:/source -v $(pwd)/outputs/${AGENT_ID}:/dest busybox cp -r /source/run/. /dest/run/
-        docker run --rm -u $(id -u):$(id -g) -v temp_agentomics_volume_${AGENT_ID}:/source -v $(pwd)/outputs/${AGENT_ID}:/dest busybox sh -c 'if [ -d /source/reports ]; then cp -r /source/reports/. /dest/reports/; fi'
-        docker run --rm -u $(id -u):$(id -g) -v temp_agentomics_volume_${AGENT_ID}:/source -v $(pwd)/outputs/${AGENT_ID}:/dest busybox sh -c 'if [ -d /source/extras ]; then cp -r /source/extras/. /dest/extras/; fi'
-
         RUN_SUCCEEDED=true
         if docker run --rm -v temp_agentomics_volume_${AGENT_ID}:/workspace busybox test -f "/workspace/best_iteration_snapshot/runtime_info/iteration_metadata.json"; then
             echo "Running final evaluation on test set"
@@ -703,9 +691,15 @@ else
                 -v temp_agentomics_volume_${AGENT_ID}:/workspace \
                 --entrypoint /opt/conda/envs/agentomics-env/bin/python \
                 "$AGENTOMICS_IMAGE" src/run_logging/test_evaluation.py --prepared-test-sets-dir /repository/prepared_test_sets
+        else
+            RUN_SUCCEEDED=false
+        fi
 
-            docker run --rm -v temp_agentomics_volume_${AGENT_ID}:/workspace busybox chmod -R a+rX /workspace/best_iteration_snapshot/
-            docker run --rm -u $(id -u):$(id -g) -v temp_agentomics_volume_${AGENT_ID}:/source -v $(pwd)/outputs/${AGENT_ID}:/dest busybox cp -r /source/best_iteration_snapshot/. /dest/best_iteration_snapshot/
+        mkdir -p "outputs/${AGENT_ID}"
+        docker run --rm -v temp_agentomics_volume_${AGENT_ID}:/workspace busybox chmod -R a+rX /workspace/ || true
+        docker run --rm -u $(id -u):$(id -g) -v temp_agentomics_volume_${AGENT_ID}:/source -v $(pwd)/outputs/${AGENT_ID}:/dest busybox cp -r /source/. /dest/
+
+        if [[ "$RUN_SUCCEEDED" = true ]]; then
             PYTHONPATH="$(pwd)/src" conda run -n agentomics-env python -m runtime.iteration_reports --agent-dir "outputs/${AGENT_ID}"
 
             MPLCONFIGDIR_IN_CONTAINER="/tmp/mplconfig"
@@ -724,8 +718,7 @@ else
 
             if [ "$USE_PROVISIONING_KEY" = true ]; then
                 echo "Logging costs and cleaning up temporary API key"
-                CONFIG_PATH="outputs/${AGENT_ID}/run/shared/config.json"
-                PYTHONPATH="$(pwd)/src" conda run -n agentomics-env python src/utils/api_keys.py cleanup-and-log --config-path "$CONFIG_PATH" --api-key-hash "$TEMP_API_KEY_HASH"
+                PYTHONPATH="$(pwd)/src" conda run -n agentomics-env python src/utils/api_keys.py cleanup-and-log --config-path "outputs/${AGENT_ID}/run/shared/config.json" --api-key-hash "$TEMP_API_KEY_HASH"
             fi
 
             if [ "$ALL_ITERATIONS_TEST" = true ]; then
@@ -750,7 +743,6 @@ else
             echo -e "${GREEN}Run finished. Report and files can be found in outputs/${AGENT_ID}${NOCOLOR}"
             echo -e "${GREEN}To run inference on new data, use ./inference.sh --agent-dir outputs/${AGENT_ID} --input <path_to_input_csv> --output <path_to_output_csv>${NOCOLOR}"
         else
-            RUN_SUCCEEDED=false
             PYTHONPATH="$(pwd)/src" conda run -n agentomics-env python -m runtime.iteration_reports --agent-dir "outputs/${AGENT_ID}"
             warn "Agent didn't produce any valid best iteration snapshot. Exported run files for later continuation to outputs/${AGENT_ID}."
             write_outputs_readme "${AGENT_ID}"

--- a/run.sh
+++ b/run.sh
@@ -404,9 +404,8 @@ if [ "$LOCAL_MODE" = true ]; then
         cp -r "${WORKSPACE_DIR}/extras/." outputs/${AGENT_ID}/extras/
     fi
 
-    ARTIFACT_PATH="${WORKSPACE_DIR}/best_iteration_snapshot"
     RUN_SUCCEEDED=true
-    if [[ -d "$ARTIFACT_PATH" ]]; then
+    if [[ -f "${WORKSPACE_DIR}/best_iteration_snapshot/runtime_info/iteration_metadata.json" ]]; then
         CONFIG_PATH="${WORKSPACE_DIR}/run/shared/config.json"
         if [[ ! -f "${CONFIG_PATH}" ]]; then
             die "Config not found: ${CONFIG_PATH}"
@@ -679,9 +678,8 @@ else
         docker run --rm -u $(id -u):$(id -g) -v temp_agentomics_volume_${AGENT_ID}:/source -v $(pwd)/outputs/${AGENT_ID}:/dest busybox sh -c 'if [ -d /source/reports ]; then cp -r /source/reports/. /dest/reports/; fi'
         docker run --rm -u $(id -u):$(id -g) -v temp_agentomics_volume_${AGENT_ID}:/source -v $(pwd)/outputs/${AGENT_ID}:/dest busybox sh -c 'if [ -d /source/extras ]; then cp -r /source/extras/. /dest/extras/; fi'
 
-        ARTIFACT_PATH="/workspace/best_iteration_snapshot"
         RUN_SUCCEEDED=true
-        if docker run --rm -v temp_agentomics_volume_${AGENT_ID}:/workspace busybox test -d ${ARTIFACT_PATH}; then
+        if docker run --rm -v temp_agentomics_volume_${AGENT_ID}:/workspace busybox test -f "/workspace/best_iteration_snapshot/runtime_info/iteration_metadata.json"; then
             echo "Running final evaluation on test set"
             docker run \
                 --rm \

--- a/run.sh
+++ b/run.sh
@@ -264,7 +264,16 @@ if ! is_valid_foundation_models_type "$FOUNDATION_MODELS_TYPE"; then
     die "Invalid --foundation-models-type '$FOUNDATION_MODELS_TYPE'. Allowed: dna, rna, molecule, protein, all."
 fi
 
-EFFECTIVE_FOUNDATION_MODELS_TYPE="$(resolve_effective_foundation_models_type "$FOUNDATION_MODELS_TYPE" "$FORK_FROM_RUN")"
+EFFECTIVE_FOUNDATION_MODELS_TYPE="$(resolve_effective_string_field "$FOUNDATION_MODELS_TYPE" "$FORK_FROM_RUN" "foundation_models_type")"
+EFFECTIVE_DATASET_NAME="$(resolve_effective_string_field "$DATASET_NAME" "$FORK_FROM_RUN" "dataset" true)"
+
+if ! is_valid_foundation_models_type "$EFFECTIVE_FOUNDATION_MODELS_TYPE"; then
+    die "Invalid foundation model type '$EFFECTIVE_FOUNDATION_MODELS_TYPE' in the effective run configuration. Allowed: dna, rna, molecule, protein, all."
+fi
+
+if [[ -n "$FORK_FROM_RUN" && -n "$DATASET_NAME" && "$DATASET_NAME" != "$EFFECTIVE_DATASET_NAME" ]]; then
+    warn "--dataset '$DATASET_NAME' is ignored for forked runs. Using '$EFFECTIVE_DATASET_NAME' from the source run config."
+fi
 
 
 if [ "$LOCAL_MODE" = true ]; then
@@ -319,9 +328,9 @@ if [ "$LOCAL_MODE" = true ]; then
     fi
 
     mkdir -p prepared_datasets
-    if [ -n "$DATASET_NAME" ]; then
+    if [ -n "$EFFECTIVE_DATASET_NAME" ]; then
         conda run -n agentomics-prepare-env python src/prepare_datasets.py \
-            --dataset-dir "./datasets/${DATASET_NAME}" \
+            --dataset-dir "./datasets/${EFFECTIVE_DATASET_NAME}" \
             --prepared-datasets-dir "$(pwd)/prepared_datasets" \
             --prepared-test-sets-dir "$(pwd)/prepared_test_sets"
     else
@@ -498,8 +507,8 @@ else
                /opt/conda/envs/agentomics-env/bin/python "$AGENTOMICS_IMAGE" /repository/src/utils/agent_id.py)
 
     PREPARE_ARGS=()
-    if [ -n "$DATASET_NAME" ]; then
-        PREPARE_ARGS=(--dataset-dir "./datasets/${DATASET_NAME}")
+    if [ -n "$EFFECTIVE_DATASET_NAME" ]; then
+        PREPARE_ARGS=(--dataset-dir "./datasets/${EFFECTIVE_DATASET_NAME}")
     else
         PREPARE_ARGS=(--prepare-all)
     fi

--- a/run.sh
+++ b/run.sh
@@ -24,6 +24,9 @@ FOUNDATION_MODELS_TYPE=""
 ALL_ITERATIONS_TEST=false
 BUILD_IMAGES=false
 DOCKERHUB_USERNAME="biogemt"
+FORK_FROM_RUN=""
+FORK_FROM_STEP=""
+FORK_FROM_ITERATION=""
 
 show_help() {
     cat <<'EOF'
@@ -37,14 +40,34 @@ Required Arguments (for non-interactive runs):
   --provider <name>   When multiple api keys provided, optional provider override (e.g., 'openai', 'openrouter').
   --dataset <name>    The short identifier for the prepared dataset (e.g., 'breast_cancer').
   --iterations <N>    Number of iterations to run the agent (recommended more than 5).
+                      For forked runs, omitting it keeps the source run's total iteration limit.
+                      Providing it means N additional iterations from the fork point.
   --timeout <int>   Amount of seconds the agent is allowed to run for. This or --iterations will dictate the duration, whichever will expire first. (recommended
   ~480s)
   --run-python-timeout <int>  Timeout in seconds for each run_python tool execution - this will determine the maximum training time (default: 21600, i.e. 6 hours).
   --split-allowed-iterations <N>    Number of initial iterations that are allowed to (re)split the data into train/validation (e.g., 1).
+                      For forked runs, omitting it keeps the source run's split-allowed limit.
+                      Providing it means N more split-allowed iterations from the fork point.
   --exploration-iterations <N>     Number of initial iterations that should focus on baseline/exploration models (e.g., 4).
+                      For forked runs, omitting it keeps the source run's exploration limit.
+                      Providing it means N more exploration iterations from the fork point.
   --val-metric <name> Optional metric to optimize. Defaults: AUROC (classification), MAE (regression).
   --user-prompt <str> The main prompt/goal for the agent.
                       (Default: "Create the best possible machine learning model that will generalize to new unseen data.")
+
+Forking:
+  --fork-from-run <path>  Path to the source run workspace directory (the 'outputs/<run_id>' folder).
+                          Creates a new independent run branching off from the given checkpoint.
+                          When forking, most run arguments (--model, --iterations, --user-prompt, etc.)
+                          are optional — omitting them reuses the values from the source run's config.
+                          Two arguments are always inherited and cannot be overridden:
+                            --dataset    (tied to the data the source run was trained on)
+                            --val-metric (must stay consistent to compare iterations across the fork)
+  --fork-from-step <step> Only used with --fork-from-run. Step ID to fork from (e.g. 'model_training').
+                          Defaults to the latest completed step or iteraiton end checkpoint in the source run.
+  --fork-from-iteration <N>
+                          Only used with --fork-from-run. Iteration to fork from.
+                          Defaults to the latest iteration containing the specified step or iteration end checkpoint.
 
 Operational Flags:
   --local             Run the project using local Conda environments instead of Docker.
@@ -56,7 +79,9 @@ Operational Flags:
   --ollama            Enable support for an Ollama server running on the host machine.
   --build-images      Build Docker images locally instead of pulling prebuilt biogemt images from Docker Hub.
   --foundation-models-type <dna|rna|molecule|protein|all>
-                      Enable foundation models of a specific type. Use 'all' to download all types. When omitted, no foundation models are used or pre-downloaded.
+                      Enable foundation models of a specific type. Use 'all' to download all types.
+                      When omitted on a fresh run, no foundation models are used.
+                      When omitted on a forked run, the source run's foundation model type is reused.
   --use-provisioning-key  Use OpenRouter provisioning key to create temporary API key and log costs.
   --spend-limit <N>   Only applies when --use-provisioning-key is passed. Spend limit for a temporary key (default: 10).
   --tags              (Optional) Space separated tags for Weights and Biases logging.
@@ -170,6 +195,21 @@ while [[ $# -gt 0 ]]; do
                 shift
             done
             ;;
+        --fork-from-run)
+            require_opt_value "$1" "${2:-}"
+            FORK_FROM_RUN="$2"
+            shift 2
+            ;;
+        --fork-from-step)
+            require_opt_value "$1" "${2:-}"
+            FORK_FROM_STEP="$2"
+            shift 2
+            ;;
+        --fork-from-iteration)
+            require_opt_value "$1" "${2:-}"
+            FORK_FROM_ITERATION="$2"
+            shift 2
+            ;;
         --local)
             LOCAL_MODE=true
             shift
@@ -220,10 +260,11 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-if [ -n "$FOUNDATION_MODELS_TYPE" ] && [[ "$FOUNDATION_MODELS_TYPE" != "dna" && "$FOUNDATION_MODELS_TYPE" != "rna" && "$FOUNDATION_MODELS_TYPE" != "molecule" && "$FOUNDATION_MODELS_TYPE" != "protein" && "$FOUNDATION_MODELS_TYPE" != "all" ]]; then
+if ! is_valid_foundation_models_type "$FOUNDATION_MODELS_TYPE"; then
     die "Invalid --foundation-models-type '$FOUNDATION_MODELS_TYPE'. Allowed: dna, rna, molecule, protein, all."
-    exit 1
 fi
+
+EFFECTIVE_FOUNDATION_MODELS_TYPE="$(resolve_effective_foundation_models_type "$FOUNDATION_MODELS_TYPE" "$FORK_FROM_RUN")"
 
 
 if [ "$LOCAL_MODE" = true ]; then
@@ -233,8 +274,8 @@ if [ "$LOCAL_MODE" = true ]; then
         die "--test is only supported in Docker mode (remove --test or remove --local)"
     fi
     if [[ "$LIST_MODE" = false ]] && ! has_tty; then
-        if [[ -z "$MODEL_NAME" || -z "$DATASET_NAME" ]]; then
-            die "Non-interactive runs require --model and --dataset (or run in an interactive terminal)"
+        if [[ -z "$FORK_FROM_RUN" && ( -z "$MODEL_NAME" || -z "$DATASET_NAME" ) ]]; then
+            die "Non-interactive runs require --model and --dataset (or --fork-from-run) (or run in an interactive terminal)"
         fi
     fi
 
@@ -250,18 +291,24 @@ if [ "$LOCAL_MODE" = true ]; then
     AGENT_ID=$(python src/utils/agent_id.py)
     export AGENT_ID
 
-    WORKSPACE_DIR="$(dirname "$AGENTOMICS_DIR")/workspace"
+    WORKSPACE_ROOT="$(dirname "$AGENTOMICS_DIR")/workspace"
+    WORKSPACE_CACHE_DIR="$WORKSPACE_ROOT/cache"
+    WORKSPACE_DIR="$WORKSPACE_ROOT/runs/$AGENT_ID"
+    mkdir -p "$WORKSPACE_CACHE_DIR" "$(dirname "$WORKSPACE_DIR")"
+    rm -rf "$WORKSPACE_DIR"
     mkdir -p "$WORKSPACE_DIR"
 
     if [ "$CPU_ONLY" = true ]; then
         export CUDA_VISIBLE_DEVICES=""
     fi
 
-    if [ -n "$FOUNDATION_MODELS_TYPE" ]; then
-        export HF_HOME="$WORKSPACE_DIR/foundation_models"
+    if [ -n "$EFFECTIVE_FOUNDATION_MODELS_TYPE" ]; then
+        FOUNDATION_MODELS_YAML_PATH="$(pwd)/foundation_models/models.yaml"
+        [[ -f "$FOUNDATION_MODELS_YAML_PATH" ]] || die "Foundation models YAML not found: $FOUNDATION_MODELS_YAML_PATH"
+        export HF_HOME="$WORKSPACE_CACHE_DIR/foundation_models"
         mkdir -p "$HF_HOME"
-        AGENTOMICS_ARGS+=(--foundation-models-type "$FOUNDATION_MODELS_TYPE")
-        AGENTOMICS_ARGS+=(--foundation-models-yaml "$(pwd)/foundation_models/models.yaml")
+        AGENTOMICS_ARGS+=(--foundation-models-type "$EFFECTIVE_FOUNDATION_MODELS_TYPE")
+        AGENTOMICS_ARGS+=(--foundation-models-yaml "$FOUNDATION_MODELS_YAML_PATH")
     fi
 
     echo -e "${RED}Running in local mode - this is only recommended if you run in a non-vulnerable environment!${NOCOLOR}"
@@ -287,19 +334,19 @@ if [ "$LOCAL_MODE" = true ]; then
     if ! conda env list | grep -q "^agent_start_env "; then
         conda env create -f envs/environment_agent.yaml -q
     fi
-    START_ENV_PKG_PATH="$WORKSPACE_DIR/agent_start_env.tar"
+    START_ENV_PKG_PATH="$WORKSPACE_CACHE_DIR/agent_start_env.tar"
     if [[ ! -f "$START_ENV_PKG_PATH" ]]; then
         echo "Packing agent start environment to ${START_ENV_PKG_PATH}"
         conda run -n agent_start_env conda-pack --format tar -o "$START_ENV_PKG_PATH"
     fi
     export START_ENV_PKG="$START_ENV_PKG_PATH"
 
-    if [ -n "$FOUNDATION_MODELS_TYPE" ]; then
-        FOUNDATION_MODELS_MARKER="$HF_HOME/.downloaded_${FOUNDATION_MODELS_TYPE}"
+    if [ -n "$EFFECTIVE_FOUNDATION_MODELS_TYPE" ]; then
+        FOUNDATION_MODELS_MARKER="$HF_HOME/.downloaded_${EFFECTIVE_FOUNDATION_MODELS_TYPE}"
         if [[ ! -f "$FOUNDATION_MODELS_MARKER" ]]; then
             conda run -n agentomics-env python src/utils/download_foundation_models.py \
-                --foundation-models-type "$FOUNDATION_MODELS_TYPE" \
-                --models-yaml "$(pwd)/foundation_models/models.yaml"
+                --foundation-models-type "$EFFECTIVE_FOUNDATION_MODELS_TYPE" \
+                --models-yaml "$FOUNDATION_MODELS_YAML_PATH"
             touch "$FOUNDATION_MODELS_MARKER"
         fi
     fi
@@ -314,6 +361,12 @@ if [ "$LOCAL_MODE" = true ]; then
     fi
 
     AGENTOMICS_ARGS+=(--workspace-dir "$WORKSPACE_DIR" --prepared-datasets-dir "$(pwd)/prepared_datasets")
+
+    if [ -n "$FORK_FROM_RUN" ]; then
+        FORK_FROM_RUN_ABS="$(cd "$FORK_FROM_RUN" && pwd)"
+        build_setup_fork_args "$FORK_FROM_RUN_ABS" "$WORKSPACE_DIR" "$AGENT_ID" "$FORK_FROM_STEP" "$FORK_FROM_ITERATION"
+        PYTHONPATH="$(pwd)/src" conda run -n agentomics-env python src/runtime/setup_fork.py "${SETUP_FORK_ARGS[@]}"
+    fi
 
     RUN_EXIT_CODE=0
     if [[ -n "$TIMEOUT_SECS" ]]; then
@@ -405,16 +458,17 @@ else
         die "Docker is not running or not accessible (start Docker and retry). Alternatively, run with --local argument(./run.sh --local), if you are running in a non-vulnerable environment."
     fi
     if [[ "$LIST_MODE" = false ]] && ! has_tty; then
-        if [[ -z "$MODEL_NAME" || ( -z "$DATASET_NAME" && -z "$FORK_FROM_RUN" ) ]]; then
-            die "Non-interactive runs require --model and --dataset (or run in an interactive terminal)"
+        if [[ -z "$FORK_FROM_RUN" && ( -z "$MODEL_NAME" || -z "$DATASET_NAME" ) ]]; then
+            die "Non-interactive runs require --model and --dataset (or --fork-from-run) (or run in an interactive terminal)"
         fi
     fi
 
 
     DOCKER_BUILD_ARGS=()
-    if [ -n "$FOUNDATION_MODELS_TYPE" ]; then
-        DOCKER_BUILD_ARGS+=(--build-arg "FOUNDATION_MODEL_TYPE=$FOUNDATION_MODELS_TYPE")
-        AGENTOMICS_ARGS+=(--foundation-models-type "$FOUNDATION_MODELS_TYPE")
+    if [ -n "$EFFECTIVE_FOUNDATION_MODELS_TYPE" ]; then
+        DOCKER_BUILD_ARGS+=(--build-arg "FOUNDATION_MODEL_TYPE=$EFFECTIVE_FOUNDATION_MODELS_TYPE")
+        AGENTOMICS_ARGS+=(--foundation-models-type "$EFFECTIVE_FOUNDATION_MODELS_TYPE")
+        AGENTOMICS_ARGS+=(--foundation-models-yaml /foundation_models/models.yaml)
     fi
 
     AGENTOMICS_IMAGE="agentomics_img"
@@ -430,8 +484,8 @@ else
         echo "Build done"
     else
         FM_TAG="NONE"
-        if [ -n "$FOUNDATION_MODELS_TYPE" ]; then
-            FM_TAG="$(echo "$FOUNDATION_MODELS_TYPE" | tr '[:lower:]' '[:upper:]')"
+        if [ -n "$EFFECTIVE_FOUNDATION_MODELS_TYPE" ]; then
+            FM_TAG="$(echo "$EFFECTIVE_FOUNDATION_MODELS_TYPE" | tr '[:lower:]' '[:upper:]')"
         fi
         AGENTOMICS_IMAGE="${DOCKERHUB_USERNAME}/agentomics:FM-${FM_TAG}-latest"
         PREPARE_IMAGE="${DOCKERHUB_USERNAME}/agentomics-prepare:latest"
@@ -564,7 +618,7 @@ else
             ${ENV_FILE_ARGS[@]+"${ENV_FILE_ARGS[@]}"} \
             -e AGENT_ID=${AGENT_ID} \
             -e PYTHONWARNINGS=ignore \
-            ${FOUNDATION_MODELS_TYPE:+-e FOUNDATION_MODELS_TYPE=${FOUNDATION_MODELS_TYPE}} \
+            ${EFFECTIVE_FOUNDATION_MODELS_TYPE:+-e FOUNDATION_MODELS_TYPE=${EFFECTIVE_FOUNDATION_MODELS_TYPE}} \
             ${GPU_FLAGS[@]+"${GPU_FLAGS[@]}"} \
             ${OLLAMA_FLAGS[@]+"${OLLAMA_FLAGS[@]}"} \
             ${DOCKER_API_KEY_ENV_VARS[@]+"${DOCKER_API_KEY_ENV_VARS[@]}"} \
@@ -575,6 +629,22 @@ else
             -v temp_agentomics_volume_${AGENT_ID}:/workspace \
             ${TEST_EXEC[@]+"${TEST_EXEC[@]}"}
     else
+        AGENTOMICS_ARGS+=(--workspace-dir /workspace --prepared-datasets-dir /repository/prepared_datasets)
+
+        if [ -n "$FORK_FROM_RUN" ]; then
+            FORK_FROM_RUN_ABS="$(cd "$FORK_FROM_RUN" && pwd)"
+            FORK_MOUNT_FLAGS=(-v "${FORK_FROM_RUN_ABS}:/fork_source:ro")
+
+            build_setup_fork_args /fork_source /workspace "$AGENT_ID" "$FORK_FROM_STEP" "$FORK_FROM_ITERATION"
+            docker run --rm \
+                -e PYTHONPATH=/repository/src \
+                ${FORK_MOUNT_FLAGS[@]+"${FORK_MOUNT_FLAGS[@]}"} \
+                -v "$(pwd)/src":/repository/src:ro \
+                -v temp_agentomics_volume_${AGENT_ID}:/workspace \
+                --entrypoint /opt/conda/envs/agentomics-env/bin/python \
+                "$AGENTOMICS_IMAGE" /repository/src/runtime/setup_fork.py "${SETUP_FORK_ARGS[@]}"
+        fi
+
         set +e
         docker run \
             --rm \

--- a/run.sh
+++ b/run.sh
@@ -629,6 +629,7 @@ else
             ${CODEX_DOCKER_FLAGS[@]+"${CODEX_DOCKER_FLAGS[@]}"} \
             -v "$(pwd)/src":/repository/src:ro \
             -v "$(pwd)/test":/repository/test:ro \
+            -v "$(pwd)/scripts":/repository/scripts:ro \
             -v "$(pwd)/prepared_datasets":/repository/prepared_datasets:ro \
             -v temp_agentomics_volume_${AGENT_ID}:/workspace \
             ${TEST_EXEC[@]+"${TEST_EXEC[@]}"}

--- a/run.sh
+++ b/run.sh
@@ -663,7 +663,6 @@ else
             ${CODEX_DOCKER_FLAGS[@]+"${CODEX_DOCKER_FLAGS[@]}"} \
             -v "$(pwd)/src":/repository/src:ro \
             -v "$(pwd)/prepared_datasets":/repository/prepared_datasets:ro \
-            -v "$(pwd)/prepared_test_sets":/repository/prepared_test_sets:ro \
             -v temp_agentomics_volume_${AGENT_ID}:/workspace \
             ${RUN_EXEC[@]+"${RUN_EXEC[@]}"}
         RUN_EXIT_CODE=$?

--- a/scripts/bash_helpers.sh
+++ b/scripts/bash_helpers.sh
@@ -80,43 +80,43 @@ is_valid_foundation_models_type() {
     esac
 }
 
-load_foundation_models_type_from_run_config() {
+load_string_field_from_run_config() {
     local source_workspace="$1"
+    local field_name="$2"
     local config_path="$source_workspace/run/shared/config.json"
     local field_line=""
     local field_value=""
 
     [[ -f "$config_path" ]] || die "Fork source config not found at $config_path"
 
-    field_line="$(grep -m1 -E '^[[:space:]]*"foundation_models_type"[[:space:]]*:' "$config_path" || true)"
-    [[ -n "$field_line" ]] || die "foundation_models_type is missing from $config_path"
+    field_line="$(grep -m1 -E "^[[:space:]]*\"${field_name}\"[[:space:]]*:" "$config_path" || true)"
+    [[ -n "$field_line" ]] || die "${field_name} is missing from $config_path"
 
-    if [[ "$field_line" =~ :[[:space:]]*null ]]; then
+    if [[ "$field_line" =~ :[[:space:]]*null([[:space:]]*,?[[:space:]]*)$ ]]; then
         return 0
     fi
 
-    field_value="$(printf '%s\n' "$field_line" | sed -nE 's/^[[:space:]]*"foundation_models_type"[[:space:]]*:[[:space:]]*"([^"]*)"[[:space:]]*,?[[:space:]]*$/\1/p')"
-    [[ -n "$field_value" ]] || die "Could not parse foundation_models_type from $config_path"
+    field_value="$(printf '%s\n' "$field_line" | sed -nE "s/^[[:space:]]*\"${field_name}\"[[:space:]]*:[[:space:]]*\"([^\"]*)\"[[:space:]]*,?[[:space:]]*$/\\1/p")"
+    [[ -n "$field_value" ]] || die "Could not parse ${field_name} from $config_path"
     printf '%s\n' "$field_value"
 }
 
-resolve_effective_foundation_models_type() {
-    local explicit_type="${1:-}"
+resolve_effective_string_field() {
+    local explicit_value="${1:-}"
     local fork_from_run="${2:-}"
-    local resolved_type=""
+    local field_name="$3"
+    local prefer_fork_value="${4:-false}"
 
-    if [[ -n "$explicit_type" ]]; then
-        resolved_type="$explicit_type"
-    elif [[ -n "$fork_from_run" ]]; then
-        resolved_type="$(load_foundation_models_type_from_run_config "$fork_from_run")"
+    if [[ "$prefer_fork_value" = true && -n "$fork_from_run" ]]; then
+        load_string_field_from_run_config "$fork_from_run" "$field_name"
+        return 0
     fi
-
-    if ! is_valid_foundation_models_type "$resolved_type"; then
-        die "Invalid foundation model type '$resolved_type' in the effective run configuration. Allowed: dna, rna, molecule, protein, all."
+    if [[ -n "$explicit_value" ]]; then
+        printf '%s\n' "$explicit_value"
+        return 0
     fi
-
-    if [[ -n "$resolved_type" ]]; then
-        printf '%s\n' "$resolved_type"
+    if [[ -n "$fork_from_run" ]]; then
+        load_string_field_from_run_config "$fork_from_run" "$field_name"
         return 0
     fi
 }

--- a/scripts/bash_helpers.sh
+++ b/scripts/bash_helpers.sh
@@ -135,6 +135,7 @@ build_setup_fork_args() {
     )
     [ -n "$fork_from_step" ] && SETUP_FORK_ARGS+=(--fork-from-step "$fork_from_step")
     [ -n "$fork_from_iteration" ] && SETUP_FORK_ARGS+=(--fork-from-iteration "$fork_from_iteration")
+    return 0
 }
 
 write_outputs_readme() {

--- a/scripts/bash_helpers.sh
+++ b/scripts/bash_helpers.sh
@@ -69,6 +69,74 @@ docker_has_gpu() {
     return 1
 }
 
+is_valid_foundation_models_type() {
+    case "${1:-}" in
+        ""|dna|rna|molecule|protein|all)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+load_foundation_models_type_from_run_config() {
+    local source_workspace="$1"
+    local config_path="$source_workspace/run/shared/config.json"
+    local field_line=""
+    local field_value=""
+
+    [[ -f "$config_path" ]] || die "Fork source config not found at $config_path"
+
+    field_line="$(grep -m1 -E '^[[:space:]]*"foundation_models_type"[[:space:]]*:' "$config_path" || true)"
+    [[ -n "$field_line" ]] || die "foundation_models_type is missing from $config_path"
+
+    if [[ "$field_line" =~ :[[:space:]]*null ]]; then
+        return 0
+    fi
+
+    field_value="$(printf '%s\n' "$field_line" | sed -nE 's/^[[:space:]]*"foundation_models_type"[[:space:]]*:[[:space:]]*"([^"]*)"[[:space:]]*,?[[:space:]]*$/\1/p')"
+    [[ -n "$field_value" ]] || die "Could not parse foundation_models_type from $config_path"
+    printf '%s\n' "$field_value"
+}
+
+resolve_effective_foundation_models_type() {
+    local explicit_type="${1:-}"
+    local fork_from_run="${2:-}"
+    local resolved_type=""
+
+    if [[ -n "$explicit_type" ]]; then
+        resolved_type="$explicit_type"
+    elif [[ -n "$fork_from_run" ]]; then
+        resolved_type="$(load_foundation_models_type_from_run_config "$fork_from_run")"
+    fi
+
+    if ! is_valid_foundation_models_type "$resolved_type"; then
+        die "Invalid foundation model type '$resolved_type' in the effective run configuration. Allowed: dna, rna, molecule, protein, all."
+    fi
+
+    if [[ -n "$resolved_type" ]]; then
+        printf '%s\n' "$resolved_type"
+        return 0
+    fi
+}
+
+build_setup_fork_args() {
+    local source_workspace="$1"
+    local target_workspace="$2"
+    local agent_id="$3"
+    local fork_from_step="${4:-}"
+    local fork_from_iteration="${5:-}"
+
+    SETUP_FORK_ARGS=(
+        --source-workspace "$source_workspace"
+        --target-workspace "$target_workspace"
+        --agent-id "$agent_id"
+    )
+    [ -n "$fork_from_step" ] && SETUP_FORK_ARGS+=(--fork-from-step "$fork_from_step")
+    [ -n "$fork_from_iteration" ] && SETUP_FORK_ARGS+=(--fork-from-iteration "$fork_from_iteration")
+}
+
 write_outputs_readme() {
     local agent_id="$1"
     local best_iter="No best iteration found"

--- a/src/agents/steps/base.py
+++ b/src/agents/steps/base.py
@@ -48,17 +48,22 @@ class RuntimeStep(ABC):
 
     async def run(self) -> None:
         if not self.should_run():
-            self.on_step_success(self.build_skipped_output())
+            return
+        if self.should_be_simulated():
+            self.on_step_success(self.build_simulated_output())
             return
         self.on_step_start()
         output = await self._execute()
         self.on_step_success(output)
 
     def should_run(self) -> bool:
-        return True
+        return not (self.config.current_iteration_dir / self.step_id / Config.STEP_OUTPUT_FILENAME).exists()
 
-    def build_skipped_output(self) -> Any:
-        raise RuntimeError(f"Step '{self.step_id}' does not support being skipped.")
+    def should_be_simulated(self) -> bool:
+        return False
+
+    def build_simulated_output(self) -> Any:
+        raise RuntimeError(f"Step '{self.step_id}' does not support being simulated.")
 
     @abstractmethod
     async def _execute(self) -> Any:

--- a/src/agents/steps/data_split.py
+++ b/src/agents/steps/data_split.py
@@ -146,10 +146,10 @@ class DataSplitStep(AgenticStep):
                 split_allowed = time.time() < self.config.split_time_deadline
         update_current_iteration_state(self.config, split_allowed_at_start=split_allowed)
 
-    def should_run(self) -> bool:
-        return bool(load_iteration_state(self.config.current_iteration_dir)["split_allowed_at_start"])
+    def should_be_simulated(self) -> bool:
+        return not bool(load_iteration_state(self.config.current_iteration_dir)["split_allowed_at_start"])
 
-    def build_skipped_output(self) -> DataSplitOutput:
+    def build_simulated_output(self) -> DataSplitOutput:
         latest_split_dir = self._get_latest_split_dir()
         if latest_split_dir is None:
             if not (self.config.agent_dataset_dir / "validation.csv").exists(): #check for explicit validation files

--- a/src/run_agent.py
+++ b/src/run_agent.py
@@ -6,7 +6,7 @@ import wandb
 from timeout_function_decorator import timeout as timeout_decorator
 
 from run_logging.wandb_setup import setup_logging
-from runtime.git_checkpoints import commit_run_start_if_needed, initialize_repo_if_needed
+from runtime.git_checkpoints import initialize_repo_if_needed
 from runtime.read_write_utils import initialize_run_directories, save_config
 from runtime.run_lifecycle import run_agentomics
 from utils.config import Config
@@ -75,7 +75,6 @@ async def run_experiment(
     config.wandb_run_id = setup_logging(config) if are_wandb_vars_available() else None
     save_config(config)
     initialize_repo_if_needed(config)
-    commit_run_start_if_needed(config)
 
     config.print_summary()
 

--- a/src/run_agent_interactive.py
+++ b/src/run_agent_interactive.py
@@ -7,6 +7,7 @@ import dotenv
 from rich.console import Console
 
 from run_agent import run_experiment
+from runtime.read_write_utils import get_next_iteration_index, load_config_from_run_dir
 from utils.config import Config
 from datasets.dataset_utils import get_all_prepared_datasets_info, get_task_type_from_prepared_dataset
 from datasets.datasets_interactive import interactive_dataset_selection, print_datasets_table
@@ -31,63 +32,67 @@ def parse_args():
     parser.add_argument("--list-metrics", action="store_true", help="List available validation metrics and exit")
 
     # Run configuration
-    parser.add_argument("--dataset", help="Dataset name")
-    parser.add_argument("--model", help="Model name. Should be compatible with the selected provider")
-    parser.add_argument("--provider", help="API provider to use. Auto-detected from env if not provided")
+    parser.add_argument("--dataset", help="Dataset name. If not provided, can be interactively selected. Cannot be changed for forked runs — always inherited from the source run config.")
+    parser.add_argument("--model", help="Model name compatible with the selected provider. If not provided, can be interactively selected. For forked runs, inherits from the source run config.")
+    parser.add_argument("--provider", help="API provider. If not provided, auto-detected from environment. For forked runs, inherits from the source run config.")
     parser.add_argument(
         "--val-metric",
-        help="Validation metric (defaults to AUROC for classification, MAE for regression)",
+        help="Validation metric. If not provided, defaults to AUROC for classification or MAE for regression. Cannot be changed for forked runs — always inherited from the source run config.",
         choices=get_classification_metrics_names() + get_regression_metrics_names(),
     )
     parser.add_argument(
         "--iterations",
         type=int,
         default=None,
-        help="Number of iterations to run (default: None, prompted interactively)",
+        help="Number of iterations to run. If not provided, can be interactively selected. For forked runs, omitting it keeps the source run's total iteration limit; providing it means that many additional iterations from the fork point.",
     )
     parser.add_argument(
         "--split-allowed-iterations",
         type=int,
-        default=Config.DEFAULT_SPLIT_ALLOWED_ITERATIONS,
-        help="Number of initial iterations that allow the agent to split the data into training and validation sets (default: %(default)s)",
+        default=None,
+        help=f"Number of initial iterations that allow the agent to split the data into training and validation sets. If not provided, defaults to {Config.DEFAULT_SPLIT_ALLOWED_ITERATIONS}. For forked runs, omitting it keeps the source run's split-allowed limit; providing it means that many more split-allowed iterations from the fork point.",
     )
     parser.add_argument(
         "--exploration-iterations",
         type=int,
-        default=Config.DEFAULT_EXPLORATION_ITERATIONS,
-        help="Number of initial iterations that should focus on baseline/exploration models (default: %(default)s)",
+        default=None,
+        help=f"Number of initial iterations that should focus on baseline/exploration models. If not provided, defaults to {Config.DEFAULT_EXPLORATION_ITERATIONS}. For forked runs, omitting it keeps the source run's exploration limit; providing it means that many more exploration iterations from the fork point.",
     )
     parser.add_argument("--timeout", type=int, help="Timeout before the run is shut down in seconds")
     parser.add_argument(
         "--split-timeout",
         type=int,
-        help="Timeout before the data splitting is no longer allowed in seconds. "
-        "If not provided, split iterations are used as the limit.",
+        help="Timeout before the data splitting is no longer allowed in seconds. If not provided, split iterations are used as the limit.",
     )
     parser.add_argument(
         "--run-python-timeout",
         type=int,
-        default=Config.DEFAULT_RUN_PYTHON_TOOL_TIMEOUT,
-        help="Timeout in seconds for each run_python tool execution (default: %(default)s)",
+        default=None,
+        help=f"Timeout in seconds for each run_python tool execution. If not provided, defaults to {Config.DEFAULT_RUN_PYTHON_TOOL_TIMEOUT}. For forked runs, inherits from the source run config.",
     )
     parser.add_argument(
         "--user-prompt",
         type=str,
-        default=Config.DEFAULT_USER_PROMPT,
-        help="Text to overwrite the default user prompt",
+        default=None,
+        help="Main goal for the agent. If not provided, defaults to the built-in default prompt. For forked runs, inherits from the source run config.",
     )
-    parser.add_argument("--tags", nargs="*", default=[], help="Tags to associate with the run")
+    parser.add_argument(
+        "--tags",
+        nargs="*",
+        default=None,
+        help="Tags to associate with the run. If not provided, defaults to no tags. For forked runs, inherits from the source run config.",
+    )
     parser.add_argument(
         "--foundation-models-type",
         type=str,
         default=None,
-        help="Foundation model type to enable (dna, rna, molecule, protein, all)",
+        help="Foundation model type to enable (dna, rna, molecule, protein, all). If not provided, no foundation models are used. For forked runs, inherits from the source run config.",
     )
     parser.add_argument(
         "--foundation-models-yaml",
         type=str,
         default=None,
-        help="Path to the foundation models YAML config file",
+        help="Path to the foundation models YAML config file. For forked runs, inherits from the source run config.",
     )
 
     # Paths
@@ -113,6 +118,44 @@ def parse_args():
     args = parser.parse_args()
     args.workspace_dir = args.workspace_dir.resolve()
     args.prepared_datasets_dir = args.prepared_datasets_dir.resolve()
+
+    # When parsing inside a forked workspace, merge CLI overrides with the source run config.
+    existing_config = load_config_from_run_dir(args.workspace_dir / Config.RUN_DIRNAME, missing_ok=True)
+    if existing_config is not None:
+        next_iteration_index = get_next_iteration_index(existing_config)
+        if args.dataset is not None and args.dataset != existing_config.dataset:
+            console.print(f"Warning: --dataset is ignored for forked runs. Using '{existing_config.dataset}' from the source run config.", style="red")
+        if args.val_metric is not None and args.val_metric != existing_config.val_metric:
+            console.print(f"Warning: --val-metric is ignored for forked runs. Using '{existing_config.val_metric}' from the source run config.", style="red")
+        args.dataset = existing_config.dataset
+        args.val_metric = existing_config.val_metric
+        if args.model is None:                     args.model = existing_config.model_name
+        if args.provider is None:                  args.provider = existing_config.provider_name
+        # For forked runs, explicit iteration-limit flags mean "N more from the fork point".
+        args.iterations = existing_config.iterations if args.iterations is None else next_iteration_index + args.iterations
+        if args.tags is None:                      args.tags = existing_config.tags
+        args.split_allowed_iterations = (
+            existing_config.split_allowed_iterations
+            if args.split_allowed_iterations is None
+            else next_iteration_index + args.split_allowed_iterations
+        )
+        args.exploration_iterations = (
+            existing_config.exploration_iterations
+            if args.exploration_iterations is None
+            else next_iteration_index + args.exploration_iterations
+        )
+        if args.run_python_timeout is None:        args.run_python_timeout = existing_config.run_python_tool_timeout
+        if args.user_prompt is None:               args.user_prompt = existing_config.user_prompt
+        if args.foundation_models_type is None:    args.foundation_models_type = existing_config.foundation_models_type
+        if args.foundation_models_yaml is None:    args.foundation_models_yaml = existing_config.foundation_models_yaml
+
+    # Apply built-in defaults only for still-unset optional args on fresh runs.
+    if args.tags is None:                      args.tags = []
+    if args.split_allowed_iterations is None:  args.split_allowed_iterations = Config.DEFAULT_SPLIT_ALLOWED_ITERATIONS
+    if args.exploration_iterations is None:    args.exploration_iterations = Config.DEFAULT_EXPLORATION_ITERATIONS
+    if args.run_python_timeout is None:        args.run_python_timeout = Config.DEFAULT_RUN_PYTHON_TOOL_TIMEOUT
+    if args.user_prompt is None:               args.user_prompt = Config.DEFAULT_USER_PROMPT
+
     return args
 
 

--- a/src/run_logging/test_evaluation.py
+++ b/src/run_logging/test_evaluation.py
@@ -11,6 +11,7 @@ from runtime.conda_utils import get_best_iteration_snapshot_environment_path
 from runtime.filesystem import remove_path
 from runtime.inference_runner import compute_metrics, run_inference_script
 from runtime.read_write_utils import load_config_from_run_dir, load_dataset_metadata
+from utils.config import Config
 from utils.exceptions import AgentScriptFailed
 from utils.metrics import get_task_to_metrics_names
 from utils.printing_utils import print_best_iteration_metrics
@@ -29,7 +30,7 @@ def run_test_evaluation(workspace_dir, prepared_test_sets_dir: Path):
     print("\nRunning final test evaluation...")
     config = None
     try:
-        config = load_config_from_run_dir(Path(workspace_dir) / "run")
+        config = load_config_from_run_dir(Path(workspace_dir) / Config.RUN_DIRNAME)
         resume_wandb_run(config)
         dataset_metadata = load_dataset_metadata(config)
         best_iteration_snapshot_dir = config.best_iteration_snapshot_dir

--- a/src/runtime/conda_utils.py
+++ b/src/runtime/conda_utils.py
@@ -47,7 +47,7 @@ def update_environment_from_descriptor(descriptor_path: Path, env_path: Path) ->
         raise FileNotFoundError(f"Missing environment descriptor at {descriptor_path}.")
 
     subprocess.run(
-        ["conda", "env", "update", "-p", str(env_path), "-f", str(descriptor_path), "-q"],
+        ["conda", "env", "update", "-p", str(env_path), "-f", str(descriptor_path), "-q", "--prune"],
         check=True,
     )
 

--- a/src/runtime/conda_utils.py
+++ b/src/runtime/conda_utils.py
@@ -51,6 +51,12 @@ def update_environment_from_descriptor(descriptor_path: Path, env_path: Path) ->
         check=True,
     )
 
+def ensure_environment_from_descriptor(descriptor_path: Path, env_path: Path) -> None:
+    if env_path.exists():
+        update_environment_from_descriptor(descriptor_path, env_path)
+        return
+    create_environment_from_descriptor(descriptor_path, env_path)
+
 def export_shared_environment_descriptor(config: Config) -> None:
     conda_env = get_shared_environment_path(config)
     export_environment_descriptor_to_path(

--- a/src/runtime/conda_utils.py
+++ b/src/runtime/conda_utils.py
@@ -42,6 +42,15 @@ def create_environment_from_descriptor(descriptor_path: Path, env_path: Path) ->
         check=True,
     )
 
+def update_environment_from_descriptor(descriptor_path: Path, env_path: Path) -> None:
+    if not descriptor_path.exists():
+        raise FileNotFoundError(f"Missing environment descriptor at {descriptor_path}.")
+
+    subprocess.run(
+        ["conda", "env", "update", "-p", str(env_path), "-f", str(descriptor_path), "-q"],
+        check=True,
+    )
+
 def export_shared_environment_descriptor(config: Config) -> None:
     conda_env = get_shared_environment_path(config)
     export_environment_descriptor_to_path(

--- a/src/runtime/generate_final_reports.py
+++ b/src/runtime/generate_final_reports.py
@@ -866,7 +866,7 @@ def main() -> None:
     prepared_datasets: Path = args.prepared_datasets.resolve()
     prepared_tests: Path = args.prepared_tests.resolve()
 
-    config = load_config_from_run_dir_and_reroot(agent_dir / "run")
+    config = load_config_from_run_dir_and_reroot(agent_dir / Config.RUN_DIRNAME)
     run_meta = load_run_meta(config)
     dataset_meta = load_prepared_dataset_meta(prepared_datasets, config.dataset)
 

--- a/src/runtime/git_checkpoints.py
+++ b/src/runtime/git_checkpoints.py
@@ -7,17 +7,17 @@ from utils.config import Config
 
 
 def initialize_repo_if_needed(config: Config) -> None:
-    run_dir = config.run_dir
-    if not (run_dir / ".git").exists():
-        subprocess.run(["git", "init"], cwd=run_dir, check=True, text=True, capture_output=True)
+    workspace_dir = Path(config.workspace_dir)
+    if not (workspace_dir / ".git").exists():
+        subprocess.run(["git", "init"], cwd=workspace_dir, check=True, text=True, capture_output=True)
     _configure_repo(config)
     _write_gitignore(config)
 
 def commit_step_checkpoint(config: Config, iteration: int, step_id: str) -> None:
-    _commit_all(config.run_dir, _step_message(config.agent_id, iteration, step_id))
+    _commit_all(Path(config.workspace_dir), _step_message(config.agent_id, iteration, step_id))
 
 def commit_iteration_end(config: Config, iteration: int) -> None:
-    _commit_all(config.run_dir, _iteration_end_message(config.agent_id, iteration))
+    _commit_all(Path(config.workspace_dir), _iteration_end_message(config.agent_id, iteration))
 
 def build_step_commit_message(run_id: str, iteration: int, step_id: str) -> str:
     return _step_message(run_id, iteration, step_id)
@@ -26,27 +26,27 @@ def build_iteration_end_commit_message(run_id: str, iteration: int) -> str:
     return _iteration_end_message(run_id, iteration)
 
 def create_and_checkout_branch_at_checkpoint(
-    run_dir: Path,
+    workspace_dir: Path,
     run_id: str,
     branch_name: str,
     step_id: str | None = None,
     iteration: int | None = None,
 ) -> None:
-    commit_hash = _find_checkpoint_commit(run_dir, run_id, step_id, iteration)
+    commit_hash = _find_checkpoint_commit(workspace_dir, run_id, step_id, iteration)
     subprocess.run(
         ["git", "checkout", "-b", branch_name, commit_hash],
-        cwd=run_dir, check=True, text=True, capture_output=True,
+        cwd=workspace_dir, check=True, text=True, capture_output=True,
     )
 
 def _find_checkpoint_commit(
-    run_dir: Path,
+    workspace_dir: Path,
     run_id: str,
     step_id: str | None,
     iteration: int | None,
 ) -> str:
     result = subprocess.run(
         ["git", "log", "--format=%H %s", "--all"],
-        cwd=run_dir, check=True, text=True, capture_output=True,
+        cwd=workspace_dir, check=True, text=True, capture_output=True,
     )
     # git log is newest-first so the first match is always the latest
     # Checkpoint commits have the format:
@@ -84,13 +84,19 @@ def _iteration_end_message(run_id: str, iteration: int) -> str:
     return f"agentomics/{run_id}/{iteration:04d}/end"
 
 def _configure_repo(config: Config) -> None:
-    subprocess.run(["git", "config", "user.name", "Agentomics Runtime"], cwd=config.run_dir, check=False, text=True, capture_output=True)
-    subprocess.run(["git", "config", "user.email", "agentomics@local"], cwd=config.run_dir, check=False, text=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Agentomics Runtime"], cwd=config.workspace_dir, check=False, text=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "agentomics@local"], cwd=config.workspace_dir, check=False, text=True, capture_output=True)
 
 def _write_gitignore(config: Config) -> None:
-    gitignore_lines = ["shared/.conda/", "__pycache__/", ".cache/", "*.pyc"]
-    (config.run_dir / ".gitignore").write_text("\n".join(gitignore_lines) + "\n", encoding="utf-8")
+    gitignore_lines = [
+        "run/shared/.conda/",
+        "best_iteration_snapshot/.conda/",
+        "__pycache__/",
+        ".cache/",
+        "*.pyc",
+    ]
+    (Path(config.workspace_dir) / ".gitignore").write_text("\n".join(gitignore_lines) + "\n", encoding="utf-8")
 
-def _commit_all(run_dir: Path, message: str) -> None:
-    subprocess.run(["git", "add", "-A"], cwd=run_dir, check=True, text=True, capture_output=True)
-    subprocess.run(["git", "commit", "--allow-empty", "-m", message], cwd=run_dir, check=True, text=True, capture_output=True)
+def _commit_all(workspace_dir: Path, message: str) -> None:
+    subprocess.run(["git", "add", "-A"], cwd=workspace_dir, check=True, text=True, capture_output=True)
+    subprocess.run(["git", "commit", "--allow-empty", "-m", message], cwd=workspace_dir, check=True, text=True, capture_output=True)

--- a/src/runtime/git_checkpoints.py
+++ b/src/runtime/git_checkpoints.py
@@ -90,7 +90,7 @@ def _configure_repo(config: Config) -> None:
 def _write_gitignore(config: Config) -> None:
     gitignore_lines = [
         "run/shared/.conda/",
-        "best_iteration_snapshot/.conda/",
+        f"{Config.BEST_ITERATION_SNAPSHOT_DIRNAME}/.conda/",
         "__pycache__/",
         ".cache/",
         "*.pyc",

--- a/src/runtime/git_checkpoints.py
+++ b/src/runtime/git_checkpoints.py
@@ -33,6 +33,12 @@ def create_and_checkout_branch_at_checkpoint(
     iteration: int | None = None,
 ) -> None:
     commit_hash = _find_checkpoint_commit(workspace_dir, run_id, step_id, iteration)
+    # The copied workspace may have files written after the last git commit (e.g. wandb
+    # binary logs). Reset to HEAD so the working tree is clean before switching branches.
+    subprocess.run(
+        ["git", "reset", "--hard", "HEAD"],
+        cwd=workspace_dir, check=True, text=True, capture_output=True,
+    )
     subprocess.run(
         ["git", "checkout", "-b", branch_name, commit_hash],
         cwd=workspace_dir, check=True, text=True, capture_output=True,

--- a/src/runtime/git_checkpoints.py
+++ b/src/runtime/git_checkpoints.py
@@ -1,71 +1,96 @@
 from __future__ import annotations
 
 import subprocess
+from pathlib import Path
 
 from utils.config import Config
 
 
 def initialize_repo_if_needed(config: Config) -> None:
     run_dir = config.run_dir
-    git_dir = run_dir / ".git"
-    if not git_dir.exists():
-        _git(config, ["init"])
-
+    if not (run_dir / ".git").exists():
+        subprocess.run(["git", "init"], cwd=run_dir, check=True, text=True, capture_output=True)
     _configure_repo(config)
     _write_gitignore(config)
 
-def commit_run_start_if_needed(config: Config) -> None:
-    _commit_all(config, build_run_start_commit_message(config.agent_id))
-
 def commit_step_checkpoint(config: Config, iteration: int, step_id: str) -> None:
-    _commit_all(config, build_step_commit_message(config.agent_id, iteration, step_id))
+    _commit_all(config.run_dir, _step_message(config.agent_id, iteration, step_id))
 
 def commit_iteration_end(config: Config, iteration: int) -> None:
-    _commit_all(config, build_iteration_end_commit_message(config.agent_id, iteration))
+    _commit_all(config.run_dir, _iteration_end_message(config.agent_id, iteration))
 
 def build_step_commit_message(run_id: str, iteration: int, step_id: str) -> str:
-    return f"agentomics: run={run_id} iteration={iteration:04d} step={step_id}"
+    return _step_message(run_id, iteration, step_id)
 
 def build_iteration_end_commit_message(run_id: str, iteration: int) -> str:
-    return f"agentomics: run={run_id} iteration={iteration:04d} end"
+    return _iteration_end_message(run_id, iteration)
 
-def build_run_start_commit_message(run_id: str) -> str:
-    return f"agentomics: run={run_id} start"
+def create_and_checkout_branch_at_checkpoint(
+    run_dir: Path,
+    run_id: str,
+    branch_name: str,
+    step_id: str | None = None,
+    iteration: int | None = None,
+) -> None:
+    commit_hash = _find_checkpoint_commit(run_dir, run_id, step_id, iteration)
+    subprocess.run(
+        ["git", "checkout", "-b", branch_name, commit_hash],
+        cwd=run_dir, check=True, text=True, capture_output=True,
+    )
+
+def _find_checkpoint_commit(
+    run_dir: Path,
+    run_id: str,
+    step_id: str | None,
+    iteration: int | None,
+) -> str:
+    result = subprocess.run(
+        ["git", "log", "--format=%H %s", "--all"],
+        cwd=run_dir, check=True, text=True, capture_output=True,
+    )
+    # git log is newest-first so the first match is always the latest
+    # Checkpoint commits have the format:
+    #   agentomics/{run_id}/{iteration:04d}/{step_id}
+    #   agentomics/{run_id}/{iteration:04d}/end
+    for line in result.stdout.splitlines():
+        commit_hash, _, message = line.partition(" ")
+        message = message.strip()
+
+        if not message.startswith(f"agentomics/{run_id}/"):
+            continue
+        after_run_id = message.removeprefix(f"agentomics/{run_id}/")
+        iter_part, slash, step_part = after_run_id.partition("/")
+        if not slash or not iter_part.isdigit():
+            continue
+
+        commit_iter, commit_step = int(iter_part), step_part
+        # If iteration or step are not specified, we take the latest
+        iter_matches = iteration is None or commit_iter == iteration
+        step_matches = step_id is None or commit_step == step_id
+        if iter_matches and step_matches:
+            return commit_hash
+
+    raise ValueError(
+        f"No checkpoint found for run={run_id!r}"
+        + (f", step={step_id!r}" if step_id else "")
+        + (f", iteration={iteration}" if iteration is not None else "")
+        + f".\nCommits in source run:\n{result.stdout}"
+    )
+
+def _step_message(run_id: str, iteration: int, step_id: str) -> str:
+    return f"agentomics/{run_id}/{iteration:04d}/{step_id}"
+
+def _iteration_end_message(run_id: str, iteration: int) -> str:
+    return f"agentomics/{run_id}/{iteration:04d}/end"
 
 def _configure_repo(config: Config) -> None:
-    _git(config, ["config", "user.name", "Agentomics Runtime"], check=False)
-    _git(config, ["config", "user.email", "agentomics@local"], check=False)
+    subprocess.run(["git", "config", "user.name", "Agentomics Runtime"], cwd=config.run_dir, check=False, text=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "agentomics@local"], cwd=config.run_dir, check=False, text=True, capture_output=True)
 
 def _write_gitignore(config: Config) -> None:
-    gitignore_path = config.run_dir / ".gitignore"
-    gitignore_lines = [
-        "shared/.conda/",
-        "__pycache__/",
-        ".cache/",
-        "*.pyc",
-    ]
-    gitignore_path.write_text("\n".join(gitignore_lines) + "\n", encoding="utf-8")
+    gitignore_lines = ["shared/.conda/", "__pycache__/", ".cache/", "*.pyc"]
+    (config.run_dir / ".gitignore").write_text("\n".join(gitignore_lines) + "\n", encoding="utf-8")
 
-def _commit_all(config: Config, message: str) -> None:
-    _git(config, ["add", "-A"])
-    status = _git(config, ["status", "--porcelain"], capture_output=True)
-    if not status.stdout.strip():
-        return
-    _git(config, ["commit", "-m", message])
-
-def _git(
-    config: Config,
-    args: list[str],
-    capture_output: bool = False,
-    check: bool = True,
-    verbose: bool = False,
-) -> subprocess.CompletedProcess[str]:
-    should_capture_output = capture_output or not verbose
-    return subprocess.run(
-        ["git", *args],
-        cwd=config.run_dir,
-        check=check,
-        text=True,
-        stdout=subprocess.PIPE if should_capture_output else None,
-        stderr=subprocess.PIPE if should_capture_output else None,
-    )
+def _commit_all(run_dir: Path, message: str) -> None:
+    subprocess.run(["git", "add", "-A"], cwd=run_dir, check=True, text=True, capture_output=True)
+    subprocess.run(["git", "commit", "--allow-empty", "-m", message], cwd=run_dir, check=True, text=True, capture_output=True)

--- a/src/runtime/iteration_reports.py
+++ b/src/runtime/iteration_reports.py
@@ -36,7 +36,7 @@ def write_iteration_report(
 
 
 def write_exported_run_reports(agent_dir: Path) -> list[Path]:
-    config = load_config_from_run_dir_and_reroot(agent_dir / "run")
+    config = load_config_from_run_dir_and_reroot(agent_dir / Config.RUN_DIRNAME)
     config.markdown_reports_dir.mkdir(parents=True, exist_ok=True)
     best_iteration = load_best_iteration_snapshot_iteration(config)
     saved_test_metrics = _load_metrics_file(config.best_iteration_snapshot_dir / "test_metrics.json")

--- a/src/runtime/read_write_utils.py
+++ b/src/runtime/read_write_utils.py
@@ -29,27 +29,27 @@ def save_config(config: Config) -> None:
     config.config_path.parent.mkdir(parents=True, exist_ok=True)
     config.config_path.write_text(json.dumps(asdict(config), indent=2), encoding="utf-8")
 
-def load_config(config_path: Path | str) -> Config:
-    payload = json.loads(Path(config_path).read_text(encoding="utf-8"))
+def load_config(config_path: Path | str, missing_ok: bool = False) -> Config | None:
+    config_path = Path(config_path)
+    if not config_path.exists():
+        if missing_ok:
+            return None
+        raise FileNotFoundError(f"Config not found at {config_path}")
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
         raise ValueError(f"Expected a JSON object at {config_path}.")
     return Config(**payload)
 
-def load_config_from_run_dir(run_dir: Path | str) -> Config:
-    return load_config(Path(run_dir) / Config.SHARED_DIRNAME / Config.CONFIG_FILENAME)
+def load_config_from_run_dir(run_dir: Path | str, missing_ok: bool = False) -> Config | None:
+    return load_config(Path(run_dir) / Config.SHARED_DIRNAME / Config.CONFIG_FILENAME, missing_ok=missing_ok)
 
 def load_config_from_run_dir_and_reroot(run_dir: Path) -> Config:
     config = load_config_from_run_dir(run_dir)
     return replace(config, workspace_dir=str(run_dir.parent))
 
 def initialize_current_iteration_workspace(config: Config) -> None:
-    current_iteration_dir = config.current_iteration_dir
-    if current_iteration_dir.exists():
-        raise FileExistsError(
-            f"Cannot initialize current iteration workspace because it already exists at {current_iteration_dir}."
-        )
-    current_iteration_dir.mkdir(parents=True, exist_ok=False)
-    config.current_iteration_runtime_info_dir.mkdir()
+    config.current_iteration_dir.mkdir(parents=True, exist_ok=True)
+    config.current_iteration_runtime_info_dir.mkdir(exist_ok=True)
 
 def archive_current_iteration(config: Config, iteration: int) -> None:
     export_shared_environment_descriptor(config)
@@ -205,6 +205,19 @@ def update_current_iteration_state(config: Config, **changes: object) -> None:
 
 def load_dataset_metadata(config: Config) -> dict[str, str]:
     return json.loads((config.prepared_dataset_dir / "metadata.json").read_text(encoding="utf-8"))
+
+def replace_string_in_tree_files(root_dir: Path, old: str, new: str, skip_dirs: set[str] | None = None) -> None:
+    for file_path in root_dir.rglob("*"):
+        if not file_path.is_file():
+            continue
+        if skip_dirs and any(part in skip_dirs for part in file_path.parts):
+            continue
+        try:
+            content = file_path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, PermissionError):
+            continue
+        if old in content:
+            file_path.write_text(content.replace(old, new), encoding="utf-8")
 
 def _file_matches_quoted_pattern(file_path, pattern: str) -> bool:
     content = Path(file_path).read_text(encoding="utf-8")

--- a/src/runtime/run_lifecycle.py
+++ b/src/runtime/run_lifecycle.py
@@ -72,10 +72,10 @@ async def _run_iteration(config: Config, iteration: int, default_model: Model, i
     log_files(config, iteration=iteration)
 
     archive_current_iteration(config, iteration)
+    commit_iteration_end(config, iteration=iteration)
     if iteration_state["status"] == "success":
         update_best_iteration_snapshot(config=config, iteration=iteration)
 
-    commit_iteration_end(config, iteration=iteration)
     _enforce_time_deadline(config)
 
 def _prepare_iteration_workspace(config: Config, iteration: int) -> None:

--- a/src/runtime/run_lifecycle.py
+++ b/src/runtime/run_lifecycle.py
@@ -72,9 +72,9 @@ async def _run_iteration(config: Config, iteration: int, default_model: Model, i
     log_files(config, iteration=iteration)
 
     archive_current_iteration(config, iteration)
-    commit_iteration_end(config, iteration=iteration)
     if iteration_state["status"] == "success":
         update_best_iteration_snapshot(config=config, iteration=iteration)
+    commit_iteration_end(config, iteration=iteration)
 
     _enforce_time_deadline(config)
 

--- a/src/runtime/setup_fork.py
+++ b/src/runtime/setup_fork.py
@@ -37,6 +37,7 @@ def fork_run(
         symlinks=False,
         copy_function=shutil.copy2,
         ignore=shutil.ignore_patterns(".conda"),
+        ignore_dangling_symlinks=True,
         dirs_exist_ok=True,
     )
 

--- a/src/runtime/setup_fork.py
+++ b/src/runtime/setup_fork.py
@@ -36,7 +36,7 @@ def fork_run(
         target_workspace_dir,
         symlinks=False,
         copy_function=shutil.copy2,
-        ignore=shutil.ignore_patterns(".conda"),
+        ignore=shutil.ignore_patterns(".conda", "reports", "extras"),
         ignore_dangling_symlinks=True,
         dirs_exist_ok=True,
     )

--- a/src/runtime/setup_fork.py
+++ b/src/runtime/setup_fork.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import shutil
+import subprocess
 from pathlib import Path
 
 from runtime.conda_utils import update_environment_from_descriptor
@@ -39,6 +40,9 @@ def fork_run(
         step_id=fork_from_step,
         iteration=fork_from_iteration,
     )
+    # Remove any untracked files left by a step that crashed before its checkpoint commit.
+    # -fd removes files and directories; omitting -x preserves gitignored paths (e.g. .conda/).
+    subprocess.run(["git", "clean", "-fd"], cwd=target_run_dir, check=True, text=True, capture_output=True)
 
     # 3. Fix absolute paths in stored step outputs that still point at the source workspace
     replace_string_in_tree_files(target_workspace_dir, str(source_workspace_dir), str(target_workspace_dir), skip_dirs={".conda"})

--- a/src/runtime/setup_fork.py
+++ b/src/runtime/setup_fork.py
@@ -45,7 +45,7 @@ def fork_run(
     subprocess.run(["git", "clean", "-fd"], cwd=target_run_dir, check=True, text=True, capture_output=True)
 
     # 3. Fix absolute paths in stored step outputs that still point at the source workspace
-    replace_string_in_tree_files(target_workspace_dir, str(source_workspace_dir), str(target_workspace_dir), skip_dirs={".conda"})
+    replace_string_in_tree_files(target_workspace_dir, str(source_workspace_dir), str(target_workspace_dir), skip_dirs={".conda", ".git"})
 
     # 4. Rename conda envs: the env directory is named after the agent ID, which changes on fork
     for conda_envs_dir in target_workspace_dir.rglob(".conda/envs"):

--- a/src/runtime/setup_fork.py
+++ b/src/runtime/setup_fork.py
@@ -5,7 +5,7 @@ import shutil
 import subprocess
 from pathlib import Path
 
-from runtime.conda_utils import update_environment_from_descriptor
+from runtime.conda_utils import ensure_environment_from_descriptor
 from runtime.git_checkpoints import create_and_checkout_branch_at_checkpoint
 from runtime.read_write_utils import load_config_from_run_dir, replace_string_in_tree_files
 from utils.config import Config
@@ -29,8 +29,16 @@ def fork_run(
     target_run_dir = target_workspace_dir / Config.RUN_DIRNAME
     source_config = load_config_from_run_dir(source_run_dir)
 
-    # 1. Copy entire workspace so the forked run inherits the best iteration snapshot and all outputs
-    shutil.copytree(source_workspace_dir, target_workspace_dir, symlinks=False, copy_function=shutil.copy2, dirs_exist_ok=True)
+    # 1. Copy the workspace contents so the fork inherits snapshots and derived outputs,
+    #    but skip .conda because envs are rebuilt from descriptors after checkout.
+    shutil.copytree(
+        source_workspace_dir,
+        target_workspace_dir,
+        symlinks=False,
+        copy_function=shutil.copy2,
+        ignore=shutil.ignore_patterns(".conda"),
+        dirs_exist_ok=True,
+    )
 
     # 2. Roll the workspace back to the requested checkpoint commit on a new branch
     create_and_checkout_branch_at_checkpoint(
@@ -44,18 +52,19 @@ def fork_run(
     # -fd removes files and directories; omitting -x preserves gitignored paths (e.g. .conda/).
     subprocess.run(["git", "clean", "-fd"], cwd=target_workspace_dir, check=True, text=True, capture_output=True)
 
-    # 3. Fix absolute paths in stored step outputs that still point at the source workspace
+    # 3. Fix absolute paths in stored step outputs that still point at the source workspace.
     replace_string_in_tree_files(target_workspace_dir, str(source_workspace_dir), str(target_workspace_dir), skip_dirs={".conda", ".git"})
 
-    # 4. Rename conda envs: the env directory is named after the agent ID, which changes on fork
-    for conda_envs_dir in target_workspace_dir.rglob(".conda/envs"):
-        (conda_envs_dir / f"{source_config.agent_id}_env").rename(conda_envs_dir / f"{target_agent_id}_env")
-
-    # 5. Since the conda env is not tracked by git, update the shared env using environment.yml
-    update_environment_from_descriptor(
+    # 4. Rebuild the untracked Conda envs from the checked-out descriptors.
+    ensure_environment_from_descriptor(
         target_run_dir / "shared" / "environment.yml",
         target_run_dir / "shared" / ".conda" / "envs" / f"{target_agent_id}_env",
     )
+    if (target_workspace_dir / Config.BEST_ITERATION_SNAPSHOT_DIRNAME / Config.RUNTIME_INFO_DIRNAME / Config.ITERATION_METADATA_FILENAME).exists():
+        ensure_environment_from_descriptor(
+            target_workspace_dir / Config.BEST_ITERATION_SNAPSHOT_DIRNAME / "environment.yml",
+            target_workspace_dir / Config.BEST_ITERATION_SNAPSHOT_DIRNAME / ".conda" / "envs" / f"{target_agent_id}_env",
+        )
 
 def _validate_fork_args(fork_from_run: Path) -> None:
     if not fork_from_run.is_dir():

--- a/src/runtime/setup_fork.py
+++ b/src/runtime/setup_fork.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+
+from runtime.conda_utils import update_environment_from_descriptor
+from runtime.git_checkpoints import create_and_checkout_branch_at_checkpoint
+from runtime.read_write_utils import load_config_from_run_dir, replace_string_in_tree_files
+from utils.config import Config
+
+
+def fork_run(
+    source_workspace_dir: Path,
+    target_agent_id: str,
+    target_workspace_dir: Path,
+    fork_from_step: str | None,
+    fork_from_iteration: int | None,
+) -> None:
+    _validate_fork_args(source_workspace_dir)
+    target_workspace_dir.mkdir(parents=True, exist_ok=True)
+    if any(target_workspace_dir.iterdir()):
+        raise FileExistsError(
+            f"Target workspace directory must be empty before fork setup: {target_workspace_dir}"
+        )
+
+    source_run_dir = source_workspace_dir / Config.RUN_DIRNAME
+    target_run_dir = target_workspace_dir / Config.RUN_DIRNAME
+    source_config = load_config_from_run_dir(source_run_dir)
+
+    # 1. Copy entire workspace so the forked run inherits the best iteration snapshot and all outputs
+    shutil.copytree(source_workspace_dir, target_workspace_dir, symlinks=False, copy_function=shutil.copy2, dirs_exist_ok=True)
+
+    # 2. Roll the run directory back to the requested checkpoint commit on a new branch
+    create_and_checkout_branch_at_checkpoint(
+        run_dir=target_run_dir,
+        run_id=source_config.agent_id,
+        branch_name=f"agentomics-run-{target_agent_id}",
+        step_id=fork_from_step,
+        iteration=fork_from_iteration,
+    )
+
+    # 3. Fix absolute paths in stored step outputs that still point at the source workspace
+    replace_string_in_tree_files(target_workspace_dir, str(source_workspace_dir), str(target_workspace_dir), skip_dirs={".conda"})
+
+    # 4. Rename conda envs: the env directory is named after the agent ID, which changes on fork
+    for conda_envs_dir in target_workspace_dir.rglob(".conda/envs"):
+        (conda_envs_dir / f"{source_config.agent_id}_env").rename(conda_envs_dir / f"{target_agent_id}_env")
+
+    # 5. Since the conda env is not tracked by git, update the shared env using environment.yml
+    update_environment_from_descriptor(
+        target_run_dir / "shared" / "environment.yml",
+        target_run_dir / "shared" / ".conda" / "envs" / f"{target_agent_id}_env",
+    )
+
+def _validate_fork_args(fork_from_run: Path) -> None:
+    if not fork_from_run.is_dir():
+        raise FileNotFoundError(
+            f"--fork-from-run path does not exist: {fork_from_run}\n"
+            f"Point it at a run workspace directory (the one containing '{Config.RUN_DIRNAME}/')."
+        )
+    source_run_dir = fork_from_run / Config.RUN_DIRNAME
+    if not source_run_dir.is_dir():
+        raise FileNotFoundError(
+            f"No '{Config.RUN_DIRNAME}/' subdirectory found under {fork_from_run}."
+        )
+    if not (source_run_dir / ".git").is_dir():
+        raise FileNotFoundError(
+            f"Source run at {source_run_dir} has no git repository (.git missing).\n"
+            "Only runs with git checkpointing enabled can be forked."
+        )
+
+def _main() -> None:
+    parser = argparse.ArgumentParser(description="Prepare a forked run workspace from a source checkpoint.")
+    parser.add_argument("--source-workspace", type=Path, required=True,
+                        help=f"Path to the source run workspace directory (containing '{Config.RUN_DIRNAME}/').")
+    parser.add_argument("--target-workspace", type=Path, required=True,
+                        help="Path to the target workspace directory.")
+    parser.add_argument("--agent-id", type=str, required=True,
+                        help="Agent ID for the new forked run (used as the git branch name).")
+    parser.add_argument("--fork-from-step", type=str, default=None,
+                        help="Step ID to fork from. Defaults to the latest checkpoint in the source run.")
+    parser.add_argument("--fork-from-iteration", type=int, default=None,
+                        help="Iteration number to fork from. Defaults to the latest iteration for the selected checkpoint.")
+    args = parser.parse_args()
+
+    fork_run(
+        source_workspace_dir=args.source_workspace,
+        target_agent_id=args.agent_id,
+        target_workspace_dir=args.target_workspace,
+        fork_from_step=args.fork_from_step,
+        fork_from_iteration=args.fork_from_iteration,
+    )
+
+if __name__ == "__main__":
+    _main()

--- a/src/runtime/setup_fork.py
+++ b/src/runtime/setup_fork.py
@@ -32,9 +32,9 @@ def fork_run(
     # 1. Copy entire workspace so the forked run inherits the best iteration snapshot and all outputs
     shutil.copytree(source_workspace_dir, target_workspace_dir, symlinks=False, copy_function=shutil.copy2, dirs_exist_ok=True)
 
-    # 2. Roll the run directory back to the requested checkpoint commit on a new branch
+    # 2. Roll the workspace back to the requested checkpoint commit on a new branch
     create_and_checkout_branch_at_checkpoint(
-        run_dir=target_run_dir,
+        workspace_dir=target_workspace_dir,
         run_id=source_config.agent_id,
         branch_name=f"agentomics-run-{target_agent_id}",
         step_id=fork_from_step,
@@ -42,7 +42,7 @@ def fork_run(
     )
     # Remove any untracked files left by a step that crashed before its checkpoint commit.
     # -fd removes files and directories; omitting -x preserves gitignored paths (e.g. .conda/).
-    subprocess.run(["git", "clean", "-fd"], cwd=target_run_dir, check=True, text=True, capture_output=True)
+    subprocess.run(["git", "clean", "-fd"], cwd=target_workspace_dir, check=True, text=True, capture_output=True)
 
     # 3. Fix absolute paths in stored step outputs that still point at the source workspace
     replace_string_in_tree_files(target_workspace_dir, str(source_workspace_dir), str(target_workspace_dir), skip_dirs={".conda", ".git"})
@@ -68,9 +68,9 @@ def _validate_fork_args(fork_from_run: Path) -> None:
         raise FileNotFoundError(
             f"No '{Config.RUN_DIRNAME}/' subdirectory found under {fork_from_run}."
         )
-    if not (source_run_dir / ".git").is_dir():
+    if not (fork_from_run / ".git").is_dir():
         raise FileNotFoundError(
-            f"Source run at {source_run_dir} has no git repository (.git missing).\n"
+            f"Source run workspace at {fork_from_run} has no git repository (.git missing).\n"
             "Only runs with git checkpointing enabled can be forked."
         )
 

--- a/src/runtime/stealth_test_evaluation.py
+++ b/src/runtime/stealth_test_evaluation.py
@@ -28,7 +28,7 @@ STEALTH_TEST_METRIC_PREFIX = "stealth_test"
 STEALTH_TEST_STEP_METRIC = "stealth_test/iteration"
 
 def evaluate_stealth_test_history(agent_dir: Path, prepared_test_sets_dir: Path) -> None:
-    config = load_config_from_run_dir_and_reroot(agent_dir / "run")
+    config = load_config_from_run_dir_and_reroot(agent_dir / Config.RUN_DIRNAME)
     metadata = load_dataset_metadata(config)
     prepared_test_set_dir = prepared_test_sets_dir / config.dataset
     test_input_path = prepared_test_set_dir / "test.no_label.csv"

--- a/src/tools/bash_tool.py
+++ b/src/tools/bash_tool.py
@@ -34,6 +34,10 @@ class BashProcess:
 
     def create_preloaded_conda(self):
         conda_env_path = get_shared_environment_path(self.config)
+        # Forked runs may already carry a fully initialized shared env.
+        # In that case, preserve it instead of unpacking the base start env over it.
+        if (conda_env_path / "bin" / "activate").exists():
+            return
         start_env_pkg = os.getenv('START_ENV_PKG')
         shared_dir = str(self.config.shared_dir)
         for cmd in [

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -14,6 +14,7 @@ class Config:
     RUN_DIRNAME: ClassVar[str] = "run"
     SHARED_DIRNAME: ClassVar[str] = "shared"
     RUNTIME_INFO_DIRNAME: ClassVar[str] = "runtime_info"
+    BEST_ITERATION_SNAPSHOT_DIRNAME: ClassVar[str] = "best_iteration_snapshot"
     ITERATION_DIR_PREFIX: ClassVar[str] = "iteration_"
     BASE_PROMPT_FILENAME: ClassVar[str] = "base_prompt.txt"
     SYSTEM_PROMPT_FILENAME: ClassVar[str] = "system_prompt.txt"
@@ -149,7 +150,7 @@ class Config:
 
     @property
     def best_iteration_snapshot_dir(self) -> Path:
-        return Path(self.workspace_dir) / "best_iteration_snapshot"
+        return Path(self.workspace_dir) / self.BEST_ITERATION_SNAPSHOT_DIRNAME
 
     def archived_step_dir(self, step_id: str) -> Path:
         return self.current_iteration_dir / step_id

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -11,6 +11,7 @@ from runtime.system_resources import get_resources_summary
 @dataclass(kw_only=True)
 class Config:
     CONFIG_FILENAME: ClassVar[str] = "config.json"
+    RUN_DIRNAME: ClassVar[str] = "run"
     SHARED_DIRNAME: ClassVar[str] = "shared"
     RUNTIME_INFO_DIRNAME: ClassVar[str] = "runtime_info"
     ITERATION_DIR_PREFIX: ClassVar[str] = "iteration_"
@@ -91,7 +92,7 @@ class Config:
 
     @property
     def run_dir(self) -> Path:
-        return Path(self.workspace_dir) / "run"
+        return Path(self.workspace_dir) / self.RUN_DIRNAME
 
 
     @property

--- a/test/test_agent_permissions.py
+++ b/test/test_agent_permissions.py
@@ -4,6 +4,7 @@ import unittest
 from pathlib import Path
 
 from test.test_utils import BaseAgentTest
+from utils.config import Config
 
 class TestAgentPermissions(BaseAgentTest):
     """Test suite for agent isolation and security."""
@@ -32,7 +33,7 @@ class TestAgentPermissions(BaseAgentTest):
         self.assertNotIn("Command failed", result, "Should be able to list workspace root")
         directories = [d.strip() for d in result.strip().split('\n') if d.strip() and not d.strip().startswith('[Tool call')]
 
-        self.assertIn("run", directories, f"Expected workspace to contain run/, found: {directories}")
+        self.assertIn(Config.RUN_DIRNAME, directories, f"Expected workspace to contain {Config.RUN_DIRNAME}/, found: {directories}")
         self.assertNotIn(self.agent_id, directories, f"Did not expect legacy per-agent run directory in workspace root: {directories}")
 
     def test_protection_test_dataset(self):
@@ -136,7 +137,7 @@ try:
     workspace_entries = sorted(os.listdir("/workspace"))
     print(f"Found workspace entries: {{workspace_entries}}")
 
-    if "run" in workspace_entries and "{self.agent_id}" not in workspace_entries:
+    if "{Config.RUN_DIRNAME}" in workspace_entries and "{self.agent_id}" not in workspace_entries:
         print("Good: Workspace uses shared run layout without legacy per-agent run directories")
     else:
         print(f"SECURITY_ISSUE: Unexpected workspace layout: {{workspace_entries}}")

--- a/test/test_best_iteration_snapshot_and_splits.py
+++ b/test/test_best_iteration_snapshot_and_splits.py
@@ -297,14 +297,14 @@ class TestDataSplitSkipReuse(unittest.TestCase):
         step = self._make_step_for_iteration(iteration=0)
         step.on_iteration_start(iteration=0)
 
-        self.assertTrue(step.should_run())
+        self.assertFalse(step.should_be_simulated())
 
     def test_split_blocked_after_budget_exhausted(self):
         self._create_split_dir(0)
         step = self._make_step_for_iteration(iteration=1)
         step.on_iteration_start(iteration=1)
 
-        self.assertFalse(step.should_run())
+        self.assertTrue(step.should_be_simulated())
 
     def test_split_blocked_when_explicit_validation_exists(self):
         (self.config.agent_dataset_dir / "validation.csv").write_text(
@@ -313,9 +313,9 @@ class TestDataSplitSkipReuse(unittest.TestCase):
         step = self._make_step_for_iteration(iteration=0)
         step.on_iteration_start(iteration=0)
 
-        self.assertFalse(step.should_run())
+        self.assertTrue(step.should_be_simulated())
 
-    def test_skipped_output_copies_latest_split(self):
+    def test_simulated_output_copies_latest_split(self):
         self._create_split_dir(0)
         self._archive_iteration_with_split(iteration=0, split_version=0)
         initialize_current_iteration_workspace(self.config)
@@ -323,7 +323,7 @@ class TestDataSplitSkipReuse(unittest.TestCase):
         initialize_current_iteration_state(self.config, started_at=100.0)
         step = DataSplitStep(self.config, Mock(), Mock(), Mock(), [])
 
-        output = step.build_skipped_output()
+        output = step.build_simulated_output()
 
         self.assertFalse(output.split_changed)
         self.assertIn("split_0", output.train_path)

--- a/test/test_forking.py
+++ b/test/test_forking.py
@@ -24,86 +24,88 @@ from runtime.read_write_utils import initialize_run_directories, save_config
 from utils.config import Config
 
 
-def _git(run_dir: Path, args: list[str]) -> subprocess.CompletedProcess[str]:
+def _git(repo_dir: Path, args: list[str]) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         ["git", *args],
-        cwd=run_dir,
+        cwd=repo_dir,
         check=True,
         capture_output=True,
         text=True,
     )
 
 
-def _setup_git_repo(run_dir: Path) -> None:
-    run_dir.mkdir(parents=True, exist_ok=True)
-    _git(run_dir, ["init"])
-    _git(run_dir, ["config", "user.name", "Test"])
-    _git(run_dir, ["config", "user.email", "test@test.com"])
+def _setup_git_repo(repo_dir: Path) -> None:
+    repo_dir.mkdir(parents=True, exist_ok=True)
+    _git(repo_dir, ["init"])
+    _git(repo_dir, ["config", "user.name", "Test"])
+    _git(repo_dir, ["config", "user.email", "test@test.com"])
 
 
-def _commit(run_dir: Path, message: str, filename: str = "state.txt", content: str = "") -> str:
-    (run_dir / filename).write_text(content or message, encoding="utf-8")
-    _git(run_dir, ["add", "-A"])
-    _git(run_dir, ["commit", "-m", message])
-    result = _git(run_dir, ["rev-parse", "HEAD"])
+def _commit(repo_dir: Path, message: str, filename: str = "state.txt", content: str = "") -> str:
+    file_path = repo_dir / filename
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text(content or message, encoding="utf-8")
+    _git(repo_dir, ["add", "-A"])
+    _git(repo_dir, ["commit", "-m", message])
+    result = _git(repo_dir, ["rev-parse", "HEAD"])
     return result.stdout.strip()
 
 
 class TestFindForkCheckpointCommit(unittest.TestCase):
     def setUp(self):
         self.temp_dir = tempfile.TemporaryDirectory()
-        self.run_dir = Path(self.temp_dir.name) / Config.RUN_DIRNAME
+        self.workspace_dir = Path(self.temp_dir.name) / "workspace"
         self.run_id = "test_run_abc"
-        _setup_git_repo(self.run_dir)
+        _setup_git_repo(self.workspace_dir)
 
     def tearDown(self):
         self.temp_dir.cleanup()
 
     def test_finds_step_commit_with_exact_iteration(self):
-        _commit(self.run_dir, f"agentomics/{self.run_id}/start", "f0.txt")
-        _commit(self.run_dir, build_step_commit_message(self.run_id, 0, "data_split"), "f1.txt")
-        target_hash = _commit(self.run_dir, build_step_commit_message(self.run_id, 0, "model_training"), "f2.txt")
-        _commit(self.run_dir, build_step_commit_message(self.run_id, 1, "model_training"), "f3.txt")
+        _commit(self.workspace_dir, f"agentomics/{self.run_id}/start", "f0.txt")
+        _commit(self.workspace_dir, build_step_commit_message(self.run_id, 0, "data_split"), "f1.txt")
+        target_hash = _commit(self.workspace_dir, build_step_commit_message(self.run_id, 0, "model_training"), "f2.txt")
+        _commit(self.workspace_dir, build_step_commit_message(self.run_id, 1, "model_training"), "f3.txt")
 
-        result = _find_checkpoint_commit(self.run_dir, self.run_id, "model_training", iteration=0)
+        result = _find_checkpoint_commit(self.workspace_dir, self.run_id, "model_training", iteration=0)
         self.assertEqual(result, target_hash)
 
     def test_finds_latest_step_commit_for_given_step(self):
-        _commit(self.run_dir, f"agentomics/{self.run_id}/start", "f0.txt")
-        _commit(self.run_dir, build_step_commit_message(self.run_id, 0, "model_training"), "f1.txt")
-        latest_hash = _commit(self.run_dir, build_step_commit_message(self.run_id, 1, "model_training"), "f2.txt")
+        _commit(self.workspace_dir, f"agentomics/{self.run_id}/start", "f0.txt")
+        _commit(self.workspace_dir, build_step_commit_message(self.run_id, 0, "model_training"), "f1.txt")
+        latest_hash = _commit(self.workspace_dir, build_step_commit_message(self.run_id, 1, "model_training"), "f2.txt")
 
-        result = _find_checkpoint_commit(self.run_dir, self.run_id, "model_training", iteration=None)
+        result = _find_checkpoint_commit(self.workspace_dir, self.run_id, "model_training", iteration=None)
         self.assertEqual(result, latest_hash)
 
     def test_finds_latest_step_commit_when_no_step_or_iteration(self):
-        _commit(self.run_dir, f"agentomics/{self.run_id}/start", "f0.txt")
-        _commit(self.run_dir, build_step_commit_message(self.run_id, 0, "data_split"), "f1.txt")
-        _commit(self.run_dir, build_step_commit_message(self.run_id, 0, "model_training"), "f2.txt")
-        latest_hash = _commit(self.run_dir, build_iteration_end_commit_message(self.run_id, 0), "f3.txt")
+        _commit(self.workspace_dir, f"agentomics/{self.run_id}/start", "f0.txt")
+        _commit(self.workspace_dir, build_step_commit_message(self.run_id, 0, "data_split"), "f1.txt")
+        _commit(self.workspace_dir, build_step_commit_message(self.run_id, 0, "model_training"), "f2.txt")
+        latest_hash = _commit(self.workspace_dir, build_iteration_end_commit_message(self.run_id, 0), "f3.txt")
 
-        result = _find_checkpoint_commit(self.run_dir, self.run_id, step_id=None, iteration=None)
+        result = _find_checkpoint_commit(self.workspace_dir, self.run_id, step_id=None, iteration=None)
         self.assertEqual(result, latest_hash)
 
     def test_finds_latest_checkpoint_for_iteration_when_step_omitted(self):
-        _commit(self.run_dir, build_step_commit_message(self.run_id, 0, "model_training"), "f0.txt")
-        latest_hash = _commit(self.run_dir, build_iteration_end_commit_message(self.run_id, 0), "f1.txt")
-        _commit(self.run_dir, build_step_commit_message(self.run_id, 1, "model_training"), "f2.txt")
+        _commit(self.workspace_dir, build_step_commit_message(self.run_id, 0, "model_training"), "f0.txt")
+        latest_hash = _commit(self.workspace_dir, build_iteration_end_commit_message(self.run_id, 0), "f1.txt")
+        _commit(self.workspace_dir, build_step_commit_message(self.run_id, 1, "model_training"), "f2.txt")
 
-        result = _find_checkpoint_commit(self.run_dir, self.run_id, step_id=None, iteration=0)
+        result = _find_checkpoint_commit(self.workspace_dir, self.run_id, step_id=None, iteration=0)
         self.assertEqual(result, latest_hash)
 
     def test_raises_when_step_not_found(self):
-        _commit(self.run_dir, f"agentomics/{self.run_id}/start", "f0.txt")
+        _commit(self.workspace_dir, f"agentomics/{self.run_id}/start", "f0.txt")
 
         with self.assertRaises(ValueError):
-            _find_checkpoint_commit(self.run_dir, self.run_id, "nonexistent_step", iteration=None)
+            _find_checkpoint_commit(self.workspace_dir, self.run_id, "nonexistent_step", iteration=None)
 
     def test_raises_when_iteration_not_found(self):
-        _commit(self.run_dir, build_step_commit_message(self.run_id, 0, "model_training"), "f0.txt")
+        _commit(self.workspace_dir, build_step_commit_message(self.run_id, 0, "model_training"), "f0.txt")
 
         with self.assertRaises(ValueError):
-            _find_checkpoint_commit(self.run_dir, self.run_id, "model_training", iteration=5)
+            _find_checkpoint_commit(self.workspace_dir, self.run_id, "model_training", iteration=5)
 
 
 class TestReplaceStringInTreeFiles(unittest.TestCase):
@@ -164,16 +166,19 @@ class TestForkRun(unittest.TestCase):
         initialize_run_directories(source_config)
         save_config(source_config)
 
+        _setup_git_repo(self.source_workspace)
         run_dir = source_config.run_dir
-        _setup_git_repo(run_dir)
-        (run_dir / ".gitignore").write_text("shared/.conda/\n__pycache__/\n.cache/\n*.pyc\n", encoding="utf-8")
+        (self.source_workspace / ".gitignore").write_text(
+            "run/shared/.conda/\nbest_iteration_snapshot/.conda/\n__pycache__/\n.cache/\n*.pyc\n",
+            encoding="utf-8",
+        )
 
         script = run_dir / "shared" / "train.py"
         script.write_text(f'data = "{self.source_workspace}/{Config.RUN_DIRNAME}/shared/data.csv"', encoding="utf-8")
         (run_dir / "shared" / "environment.yml").write_text("name: fork-test\n", encoding="utf-8")
         (run_dir / "shared" / ".conda" / "envs" / f"{run_id}_env").mkdir(parents=True)
 
-        _commit(run_dir, f"agentomics/{run_id}/start", "init.txt")
+        _commit(self.source_workspace, f"agentomics/{run_id}/start", "init.txt")
 
         current_iter = run_dir / "current_iteration" / "runtime_info"
         current_iter.mkdir(parents=True)
@@ -181,15 +186,23 @@ class TestForkRun(unittest.TestCase):
         (current_iter / "iteration_state.json").write_text('{"status": "running"}', encoding="utf-8")
         (run_dir / "current_iteration" / "data_split").mkdir()
         (run_dir / "current_iteration" / "data_split" / "output.json").write_text('{}', encoding="utf-8")
-        _commit(run_dir, build_step_commit_message(run_id, 0, "data_split"), "data_split_marker.txt")
+        _commit(self.source_workspace, build_step_commit_message(run_id, 0, "data_split"), "data_split_marker.txt")
 
         (run_dir / "current_iteration" / "model_training").mkdir()
         (run_dir / "current_iteration" / "model_training" / "output.json").write_text('{}', encoding="utf-8")
-        _commit(run_dir, build_step_commit_message(run_id, 0, "model_training"), "model_training_marker.txt")
+        _commit(self.source_workspace, build_step_commit_message(run_id, 0, "model_training"), "model_training_marker.txt")
 
         archived_iteration_dir = run_dir / "iteration_0"
         shutil.move(run_dir / "current_iteration", archived_iteration_dir)
-        _commit(run_dir, build_iteration_end_commit_message(run_id, 0), "iteration_end_marker.txt")
+        best_snapshot_runtime_info = self.source_workspace / "best_iteration_snapshot" / Config.RUNTIME_INFO_DIRNAME
+        best_snapshot_runtime_info.mkdir(parents=True, exist_ok=True)
+        (best_snapshot_runtime_info / Config.ITERATION_METADATA_FILENAME).write_text('{"iteration": 0}', encoding="utf-8")
+        (self.source_workspace / "best_iteration_snapshot" / "snapshot_marker.txt").write_text("best", encoding="utf-8")
+        (self.source_workspace / "reports" / "markdown").mkdir(parents=True, exist_ok=True)
+        (self.source_workspace / "reports" / "markdown" / "run_report_iter_0.md").write_text("report", encoding="utf-8")
+        (self.source_workspace / "extras" / "run_logs").mkdir(parents=True, exist_ok=True)
+        (self.source_workspace / "extras" / "run_logs" / "latest.log").write_text("log", encoding="utf-8")
+        _commit(self.source_workspace, build_iteration_end_commit_message(run_id, 0), "iteration_end_marker.txt")
 
     def _fork(self, source_run_id: str, target_run_id: str, **kwargs):
         self._build_source_run(source_run_id)
@@ -205,22 +218,32 @@ class TestForkRun(unittest.TestCase):
     def test_checks_out_correct_state(self):
         self._fork("src_run", "tgt_run", fork_from_step="data_split", fork_from_iteration=0)
         target_run_dir = self.target_workspace / Config.RUN_DIRNAME
-        self.assertTrue((target_run_dir / "data_split_marker.txt").exists())
-        self.assertFalse((target_run_dir / "model_training_marker.txt").exists())
-        self.assertFalse((target_run_dir / "iteration_end_marker.txt").exists())
+        self.assertTrue((self.target_workspace / "data_split_marker.txt").exists())
+        self.assertFalse((self.target_workspace / "model_training_marker.txt").exists())
+        self.assertFalse((self.target_workspace / "iteration_end_marker.txt").exists())
 
     def test_defaults_to_latest_checkpoint_when_none_given(self):
         self._fork("src_run", "tgt_run", fork_from_step=None, fork_from_iteration=None)
         target_run_dir = self.target_workspace / Config.RUN_DIRNAME
-        self.assertTrue((target_run_dir / "iteration_end_marker.txt").exists())
+        self.assertTrue((self.target_workspace / "iteration_end_marker.txt").exists())
         self.assertTrue((target_run_dir / "iteration_0" / "model_training" / "output.json").exists())
         self.assertFalse((target_run_dir / "current_iteration").exists())
+        self.assertTrue((self.target_workspace / "best_iteration_snapshot" / "snapshot_marker.txt").exists())
+        self.assertTrue((self.target_workspace / "reports" / "markdown" / "run_report_iter_0.md").exists())
+        self.assertTrue((self.target_workspace / "extras" / "run_logs" / "latest.log").exists())
 
     def test_rewrites_workspace_paths(self):
         self._fork("src_run", "tgt_run", fork_from_step="data_split", fork_from_iteration=0)
         content = (self.target_workspace / Config.RUN_DIRNAME / "shared" / "train.py").read_text(encoding="utf-8")
         self.assertIn(str(self.target_workspace), content)
         self.assertNotIn(str(self.source_workspace), content)
+
+    def test_rewinds_workspace_artifacts_with_checkpoint(self):
+        self._fork("src_run", "tgt_run", fork_from_step="data_split", fork_from_iteration=0)
+
+        self.assertFalse((self.target_workspace / "best_iteration_snapshot").exists())
+        self.assertFalse((self.target_workspace / "reports").exists())
+        self.assertFalse((self.target_workspace / "extras").exists())
 
     def test_updates_renamed_shared_environment(self):
         target_run_id = "tgt_run"
@@ -251,8 +274,7 @@ class TestForkRun(unittest.TestCase):
     def test_creates_target_branch(self):
         target_run_id = "tgt_run"
         self._fork("src_run", target_run_id, fork_from_step="data_split", fork_from_iteration=0)
-        target_run_dir = self.target_workspace / Config.RUN_DIRNAME
-        branch = _git(target_run_dir, ["branch", "--show-current"]).stdout.strip()
+        branch = _git(self.target_workspace, ["branch", "--show-current"]).stdout.strip()
         self.assertEqual(branch, f"agentomics-run-{target_run_id}")
 
 

--- a/test/test_forking.py
+++ b/test/test_forking.py
@@ -166,6 +166,7 @@ class TestForkRun(unittest.TestCase):
 
         run_dir = source_config.run_dir
         _setup_git_repo(run_dir)
+        (run_dir / ".gitignore").write_text("shared/.conda/\n__pycache__/\n.cache/\n*.pyc\n", encoding="utf-8")
 
         script = run_dir / "shared" / "train.py"
         script.write_text(f'data = "{self.source_workspace}/{Config.RUN_DIRNAME}/shared/data.csv"', encoding="utf-8")

--- a/test/test_forking.py
+++ b/test/test_forking.py
@@ -6,7 +6,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SRC_PATH = REPO_ROOT / "src"
@@ -169,7 +169,7 @@ class TestForkRun(unittest.TestCase):
         _setup_git_repo(self.source_workspace)
         run_dir = source_config.run_dir
         (self.source_workspace / ".gitignore").write_text(
-            "run/shared/.conda/\nbest_iteration_snapshot/.conda/\n__pycache__/\n.cache/\n*.pyc\n",
+            f"run/shared/.conda/\n{Config.BEST_ITERATION_SNAPSHOT_DIRNAME}/.conda/\n__pycache__/\n.cache/\n*.pyc\n",
             encoding="utf-8",
         )
 
@@ -194,10 +194,13 @@ class TestForkRun(unittest.TestCase):
 
         archived_iteration_dir = run_dir / "iteration_0"
         shutil.move(run_dir / "current_iteration", archived_iteration_dir)
-        best_snapshot_runtime_info = self.source_workspace / "best_iteration_snapshot" / Config.RUNTIME_INFO_DIRNAME
+        best_snapshot_runtime_info = self.source_workspace / Config.BEST_ITERATION_SNAPSHOT_DIRNAME / Config.RUNTIME_INFO_DIRNAME
         best_snapshot_runtime_info.mkdir(parents=True, exist_ok=True)
         (best_snapshot_runtime_info / Config.ITERATION_METADATA_FILENAME).write_text('{"iteration": 0}', encoding="utf-8")
-        (self.source_workspace / "best_iteration_snapshot" / "snapshot_marker.txt").write_text("best", encoding="utf-8")
+        (best_snapshot_runtime_info / "environment.yml").write_text("name: fork-test\n", encoding="utf-8")
+        (self.source_workspace / Config.BEST_ITERATION_SNAPSHOT_DIRNAME / "snapshot_marker.txt").write_text("best", encoding="utf-8")
+        (self.source_workspace / Config.BEST_ITERATION_SNAPSHOT_DIRNAME / "environment.yml").write_text("name: fork-test\n", encoding="utf-8")
+        (self.source_workspace / Config.BEST_ITERATION_SNAPSHOT_DIRNAME / ".conda" / "envs" / f"{run_id}_env").mkdir(parents=True)
         (self.source_workspace / "reports" / "markdown").mkdir(parents=True, exist_ok=True)
         (self.source_workspace / "reports" / "markdown" / "run_report_iter_0.md").write_text("report", encoding="utf-8")
         (self.source_workspace / "extras" / "run_logs").mkdir(parents=True, exist_ok=True)
@@ -206,14 +209,14 @@ class TestForkRun(unittest.TestCase):
 
     def _fork(self, source_run_id: str, target_run_id: str, **kwargs):
         self._build_source_run(source_run_id)
-        with patch("runtime.setup_fork.update_environment_from_descriptor") as update_environment:
+        with patch("runtime.setup_fork.ensure_environment_from_descriptor") as ensure_environment:
             fork_run(
                 source_workspace_dir=self.source_workspace,
                 target_agent_id=target_run_id,
                 target_workspace_dir=self.target_workspace,
                 **kwargs,
             )
-        return update_environment
+        return ensure_environment
 
     def test_checks_out_correct_state(self):
         self._fork("src_run", "tgt_run", fork_from_step="data_split", fork_from_iteration=0)
@@ -228,7 +231,7 @@ class TestForkRun(unittest.TestCase):
         self.assertTrue((self.target_workspace / "iteration_end_marker.txt").exists())
         self.assertTrue((target_run_dir / "iteration_0" / "model_training" / "output.json").exists())
         self.assertFalse((target_run_dir / "current_iteration").exists())
-        self.assertTrue((self.target_workspace / "best_iteration_snapshot" / "snapshot_marker.txt").exists())
+        self.assertTrue((self.target_workspace / Config.BEST_ITERATION_SNAPSHOT_DIRNAME / "snapshot_marker.txt").exists())
         self.assertTrue((self.target_workspace / "reports" / "markdown" / "run_report_iter_0.md").exists())
         self.assertTrue((self.target_workspace / "extras" / "run_logs" / "latest.log").exists())
 
@@ -239,22 +242,34 @@ class TestForkRun(unittest.TestCase):
         self.assertNotIn(str(self.source_workspace), content)
 
     def test_rewinds_workspace_artifacts_with_checkpoint(self):
-        self._fork("src_run", "tgt_run", fork_from_step="data_split", fork_from_iteration=0)
+        ensure_environment = self._fork("src_run", "tgt_run", fork_from_step="data_split", fork_from_iteration=0)
 
-        self.assertFalse((self.target_workspace / "best_iteration_snapshot").exists())
+        self.assertFalse((self.target_workspace / Config.BEST_ITERATION_SNAPSHOT_DIRNAME).exists())
         self.assertFalse((self.target_workspace / "reports").exists())
         self.assertFalse((self.target_workspace / "extras").exists())
-
-    def test_updates_renamed_shared_environment(self):
-        target_run_id = "tgt_run"
-        update_environment = self._fork("src_run", target_run_id, fork_from_step=None, fork_from_iteration=None)
-        target_run_dir = self.target_workspace / Config.RUN_DIRNAME
-        self.assertFalse((target_run_dir / "shared" / ".conda" / "envs" / "src_run_env").exists())
-        self.assertTrue((target_run_dir / "shared" / ".conda" / "envs" / f"{target_run_id}_env").exists())
-        update_environment.assert_called_once_with(
-            target_run_dir / "shared" / "environment.yml",
-            target_run_dir / "shared" / ".conda" / "envs" / f"{target_run_id}_env",
+        ensure_environment.assert_called_once_with(
+            self.target_workspace / Config.RUN_DIRNAME / "shared" / "environment.yml",
+            self.target_workspace / Config.RUN_DIRNAME / "shared" / ".conda" / "envs" / "tgt_run_env",
         )
+
+    def test_syncs_shared_and_snapshot_environments_from_descriptors(self):
+        target_run_id = "tgt_run"
+        ensure_environment = self._fork("src_run", target_run_id, fork_from_step=None, fork_from_iteration=None)
+        target_run_dir = self.target_workspace / Config.RUN_DIRNAME
+        target_snapshot_dir = self.target_workspace / Config.BEST_ITERATION_SNAPSHOT_DIRNAME
+        self.assertFalse((target_run_dir / "shared" / ".conda").exists())
+        self.assertFalse((target_snapshot_dir / ".conda").exists())
+        ensure_environment.assert_has_calls([
+            call(
+                target_run_dir / "shared" / "environment.yml",
+                target_run_dir / "shared" / ".conda" / "envs" / f"{target_run_id}_env",
+            ),
+            call(
+                target_snapshot_dir / "environment.yml",
+                target_snapshot_dir / ".conda" / "envs" / f"{target_run_id}_env",
+            ),
+        ])
+        self.assertEqual(ensure_environment.call_count, 2)
 
     def test_raises_when_target_workspace_not_empty(self):
         self._build_source_run("src_run")
@@ -262,7 +277,7 @@ class TestForkRun(unittest.TestCase):
         (self.target_workspace / "stale.txt").write_text("stale", encoding="utf-8")
 
         with self.assertRaises(FileExistsError):
-            with patch("runtime.setup_fork.update_environment_from_descriptor"):
+            with patch("runtime.setup_fork.ensure_environment_from_descriptor"):
                 fork_run(
                     source_workspace_dir=self.source_workspace,
                     target_agent_id="tgt_run",

--- a/test/test_forking.py
+++ b/test/test_forking.py
@@ -292,6 +292,72 @@ class TestForkRun(unittest.TestCase):
         branch = _git(self.target_workspace, ["branch", "--show-current"]).stdout.strip()
         self.assertEqual(branch, f"agentomics-run-{target_run_id}")
 
+    def test_handles_dangling_symlink_in_source(self):
+        # Regression: wandb creates debug-core.log as a symlink to a path inside the container
+        # (/root/.cache/wandb/...) which is dangling on the host. copytree must not raise.
+        self._build_source_run("src_run")
+        dangling = self.source_workspace / "extras" / "run_logs" / "debug-core.log"
+        dangling.parent.mkdir(parents=True, exist_ok=True)
+        dangling.symlink_to("/nonexistent/container/path/debug.log")
+
+        with patch("runtime.setup_fork.ensure_environment_from_descriptor"):
+            fork_run(
+                source_workspace_dir=self.source_workspace,
+                target_agent_id="tgt_run",
+                target_workspace_dir=self.target_workspace,
+                fork_from_step=None,
+                fork_from_iteration=None,
+            )
+
+    def test_handles_tracked_file_modified_after_last_commit(self):
+        # Regression: wandb appends to its .wandb binary log after the last git commit.
+        # The copied workspace therefore has modified tracked files, which made
+        # `git checkout -b` fail. The fix is `git reset --hard HEAD` before checkout.
+        self._build_source_run("src_run")
+        tracked_file = self.source_workspace / "model_training_marker.txt"
+        tracked_file.write_text("modified after commit", encoding="utf-8")
+
+        with patch("runtime.setup_fork.ensure_environment_from_descriptor"):
+            fork_run(
+                source_workspace_dir=self.source_workspace,
+                target_agent_id="tgt_run",
+                target_workspace_dir=self.target_workspace,
+                fork_from_step="data_split",
+                fork_from_iteration=0,
+            )
+
+
+class TestBashHelpers(unittest.TestCase):
+    def _run_bash(self, snippet: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["bash", "-c", f"set -euo pipefail; source scripts/bash_helpers.sh; {snippet}"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_build_setup_fork_args_includes_optional_args_when_provided(self):
+        result = self._run_bash(
+            "build_setup_fork_args /src /tgt agent123 data_split 2; "
+            'printf "%s\\n" "${SETUP_FORK_ARGS[@]}"'
+        )
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        args = result.stdout.splitlines()
+        self.assertIn("--fork-from-step", args)
+        self.assertIn("data_split", args)
+        self.assertIn("--fork-from-iteration", args)
+        self.assertIn("2", args)
+
+    def test_build_setup_fork_args_omits_optional_args_when_empty(self):
+        result = self._run_bash(
+            "build_setup_fork_args /src /tgt agent123; "
+            'printf "%s\\n" "${SETUP_FORK_ARGS[@]}"'
+        )
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        args = result.stdout.splitlines()
+        self.assertNotIn("--fork-from-step", args)
+        self.assertNotIn("--fork-from-iteration", args)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_forking.py
+++ b/test/test_forking.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_PATH = REPO_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+from runtime.setup_fork import fork_run
+from runtime.read_write_utils import replace_string_in_tree_files
+from runtime.git_checkpoints import (
+    build_iteration_end_commit_message,
+    build_step_commit_message,
+    _find_checkpoint_commit,
+)
+from runtime.read_write_utils import initialize_run_directories, save_config
+from utils.config import Config
+
+
+def _git(run_dir: Path, args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=run_dir,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _setup_git_repo(run_dir: Path) -> None:
+    run_dir.mkdir(parents=True, exist_ok=True)
+    _git(run_dir, ["init"])
+    _git(run_dir, ["config", "user.name", "Test"])
+    _git(run_dir, ["config", "user.email", "test@test.com"])
+
+
+def _commit(run_dir: Path, message: str, filename: str = "state.txt", content: str = "") -> str:
+    (run_dir / filename).write_text(content or message, encoding="utf-8")
+    _git(run_dir, ["add", "-A"])
+    _git(run_dir, ["commit", "-m", message])
+    result = _git(run_dir, ["rev-parse", "HEAD"])
+    return result.stdout.strip()
+
+
+class TestFindForkCheckpointCommit(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.run_dir = Path(self.temp_dir.name) / Config.RUN_DIRNAME
+        self.run_id = "test_run_abc"
+        _setup_git_repo(self.run_dir)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_finds_step_commit_with_exact_iteration(self):
+        _commit(self.run_dir, f"agentomics/{self.run_id}/start", "f0.txt")
+        _commit(self.run_dir, build_step_commit_message(self.run_id, 0, "data_split"), "f1.txt")
+        target_hash = _commit(self.run_dir, build_step_commit_message(self.run_id, 0, "model_training"), "f2.txt")
+        _commit(self.run_dir, build_step_commit_message(self.run_id, 1, "model_training"), "f3.txt")
+
+        result = _find_checkpoint_commit(self.run_dir, self.run_id, "model_training", iteration=0)
+        self.assertEqual(result, target_hash)
+
+    def test_finds_latest_step_commit_for_given_step(self):
+        _commit(self.run_dir, f"agentomics/{self.run_id}/start", "f0.txt")
+        _commit(self.run_dir, build_step_commit_message(self.run_id, 0, "model_training"), "f1.txt")
+        latest_hash = _commit(self.run_dir, build_step_commit_message(self.run_id, 1, "model_training"), "f2.txt")
+
+        result = _find_checkpoint_commit(self.run_dir, self.run_id, "model_training", iteration=None)
+        self.assertEqual(result, latest_hash)
+
+    def test_finds_latest_step_commit_when_no_step_or_iteration(self):
+        _commit(self.run_dir, f"agentomics/{self.run_id}/start", "f0.txt")
+        _commit(self.run_dir, build_step_commit_message(self.run_id, 0, "data_split"), "f1.txt")
+        _commit(self.run_dir, build_step_commit_message(self.run_id, 0, "model_training"), "f2.txt")
+        latest_hash = _commit(self.run_dir, build_iteration_end_commit_message(self.run_id, 0), "f3.txt")
+
+        result = _find_checkpoint_commit(self.run_dir, self.run_id, step_id=None, iteration=None)
+        self.assertEqual(result, latest_hash)
+
+    def test_finds_latest_checkpoint_for_iteration_when_step_omitted(self):
+        _commit(self.run_dir, build_step_commit_message(self.run_id, 0, "model_training"), "f0.txt")
+        latest_hash = _commit(self.run_dir, build_iteration_end_commit_message(self.run_id, 0), "f1.txt")
+        _commit(self.run_dir, build_step_commit_message(self.run_id, 1, "model_training"), "f2.txt")
+
+        result = _find_checkpoint_commit(self.run_dir, self.run_id, step_id=None, iteration=0)
+        self.assertEqual(result, latest_hash)
+
+    def test_raises_when_step_not_found(self):
+        _commit(self.run_dir, f"agentomics/{self.run_id}/start", "f0.txt")
+
+        with self.assertRaises(ValueError):
+            _find_checkpoint_commit(self.run_dir, self.run_id, "nonexistent_step", iteration=None)
+
+    def test_raises_when_iteration_not_found(self):
+        _commit(self.run_dir, build_step_commit_message(self.run_id, 0, "model_training"), "f0.txt")
+
+        with self.assertRaises(ValueError):
+            _find_checkpoint_commit(self.run_dir, self.run_id, "model_training", iteration=5)
+
+
+class TestReplaceStringInTreeFiles(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.run_dir = Path(self.temp_dir.name) / Config.RUN_DIRNAME
+        self.run_dir.mkdir()
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_replaces_path_in_text_files(self):
+        script = self.run_dir / "train.py"
+        script.write_text(f'data = "/old/workspace/{Config.RUN_DIRNAME}/shared/data.csv"', encoding="utf-8")
+
+        replace_string_in_tree_files(self.run_dir, "/old/workspace", "/new/workspace")
+
+        self.assertIn("/new/workspace", script.read_text(encoding="utf-8"))
+        self.assertNotIn("/old/workspace", script.read_text(encoding="utf-8"))
+
+    def test_skips_files_in_conda_dirs(self):
+        conda_dir = self.run_dir / ".conda" / "envs"
+        conda_dir.mkdir(parents=True)
+        conda_file = conda_dir / "activate.sh"
+        original = f"prefix: /old/workspace/{Config.RUN_DIRNAME}/shared/.conda"
+        conda_file.write_text(original, encoding="utf-8")
+
+        replace_string_in_tree_files(self.run_dir, "/old/workspace", "/new/workspace", skip_dirs={".conda"})
+
+        self.assertEqual(conda_file.read_text(encoding="utf-8"), original)
+
+
+class TestForkRun(unittest.TestCase):
+    """Integration tests for fork_run: builds a minimal source run, forks it, and verifies the result."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+        self.source_workspace = self.root / "source_workspace"
+        self.target_workspace = self.root / "target_workspace"
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def _build_source_run(self, run_id: str) -> None:
+        source_config = Config(
+            agent_id=run_id,
+            model_name="test-model",
+            iteration_plan_model_name="test-model",
+            dataset="toy",
+            tags=[],
+            val_metric="ACC",
+            workspace_dir=str(self.source_workspace),
+            prepared_datasets_dir=str(self.root / "prepared_datasets"),
+            user_prompt="test",
+            task_type="classification",
+        )
+        initialize_run_directories(source_config)
+        save_config(source_config)
+
+        run_dir = source_config.run_dir
+        _setup_git_repo(run_dir)
+
+        script = run_dir / "shared" / "train.py"
+        script.write_text(f'data = "{self.source_workspace}/{Config.RUN_DIRNAME}/shared/data.csv"', encoding="utf-8")
+        (run_dir / "shared" / "environment.yml").write_text("name: fork-test\n", encoding="utf-8")
+        (run_dir / "shared" / ".conda" / "envs" / f"{run_id}_env").mkdir(parents=True)
+
+        _commit(run_dir, f"agentomics/{run_id}/start", "init.txt")
+
+        current_iter = run_dir / "current_iteration" / "runtime_info"
+        current_iter.mkdir(parents=True)
+        (current_iter / "iteration_metadata.json").write_text('{"iteration": 0}', encoding="utf-8")
+        (current_iter / "iteration_state.json").write_text('{"status": "running"}', encoding="utf-8")
+        (run_dir / "current_iteration" / "data_split").mkdir()
+        (run_dir / "current_iteration" / "data_split" / "output.json").write_text('{}', encoding="utf-8")
+        _commit(run_dir, build_step_commit_message(run_id, 0, "data_split"), "data_split_marker.txt")
+
+        (run_dir / "current_iteration" / "model_training").mkdir()
+        (run_dir / "current_iteration" / "model_training" / "output.json").write_text('{}', encoding="utf-8")
+        _commit(run_dir, build_step_commit_message(run_id, 0, "model_training"), "model_training_marker.txt")
+
+        archived_iteration_dir = run_dir / "iteration_0"
+        shutil.move(run_dir / "current_iteration", archived_iteration_dir)
+        _commit(run_dir, build_iteration_end_commit_message(run_id, 0), "iteration_end_marker.txt")
+
+    def _fork(self, source_run_id: str, target_run_id: str, **kwargs):
+        self._build_source_run(source_run_id)
+        with patch("runtime.setup_fork.update_environment_from_descriptor") as update_environment:
+            fork_run(
+                source_workspace_dir=self.source_workspace,
+                target_agent_id=target_run_id,
+                target_workspace_dir=self.target_workspace,
+                **kwargs,
+            )
+        return update_environment
+
+    def test_checks_out_correct_state(self):
+        self._fork("src_run", "tgt_run", fork_from_step="data_split", fork_from_iteration=0)
+        target_run_dir = self.target_workspace / Config.RUN_DIRNAME
+        self.assertTrue((target_run_dir / "data_split_marker.txt").exists())
+        self.assertFalse((target_run_dir / "model_training_marker.txt").exists())
+        self.assertFalse((target_run_dir / "iteration_end_marker.txt").exists())
+
+    def test_defaults_to_latest_checkpoint_when_none_given(self):
+        self._fork("src_run", "tgt_run", fork_from_step=None, fork_from_iteration=None)
+        target_run_dir = self.target_workspace / Config.RUN_DIRNAME
+        self.assertTrue((target_run_dir / "iteration_end_marker.txt").exists())
+        self.assertTrue((target_run_dir / "iteration_0" / "model_training" / "output.json").exists())
+        self.assertFalse((target_run_dir / "current_iteration").exists())
+
+    def test_rewrites_workspace_paths(self):
+        self._fork("src_run", "tgt_run", fork_from_step="data_split", fork_from_iteration=0)
+        content = (self.target_workspace / Config.RUN_DIRNAME / "shared" / "train.py").read_text(encoding="utf-8")
+        self.assertIn(str(self.target_workspace), content)
+        self.assertNotIn(str(self.source_workspace), content)
+
+    def test_updates_renamed_shared_environment(self):
+        target_run_id = "tgt_run"
+        update_environment = self._fork("src_run", target_run_id, fork_from_step=None, fork_from_iteration=None)
+        target_run_dir = self.target_workspace / Config.RUN_DIRNAME
+        self.assertFalse((target_run_dir / "shared" / ".conda" / "envs" / "src_run_env").exists())
+        self.assertTrue((target_run_dir / "shared" / ".conda" / "envs" / f"{target_run_id}_env").exists())
+        update_environment.assert_called_once_with(
+            target_run_dir / "shared" / "environment.yml",
+            target_run_dir / "shared" / ".conda" / "envs" / f"{target_run_id}_env",
+        )
+
+    def test_raises_when_target_workspace_not_empty(self):
+        self._build_source_run("src_run")
+        self.target_workspace.mkdir(parents=True)
+        (self.target_workspace / "stale.txt").write_text("stale", encoding="utf-8")
+
+        with self.assertRaises(FileExistsError):
+            with patch("runtime.setup_fork.update_environment_from_descriptor"):
+                fork_run(
+                    source_workspace_dir=self.source_workspace,
+                    target_agent_id="tgt_run",
+                    target_workspace_dir=self.target_workspace,
+                    fork_from_step="data_split",
+                    fork_from_iteration=0,
+                )
+
+    def test_creates_target_branch(self):
+        target_run_id = "tgt_run"
+        self._fork("src_run", target_run_id, fork_from_step="data_split", fork_from_iteration=0)
+        target_run_dir = self.target_workspace / Config.RUN_DIRNAME
+        branch = _git(target_run_dir, ["branch", "--show-current"]).stdout.strip()
+        self.assertEqual(branch, f"agentomics-run-{target_run_id}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_runtime_lifecycle.py
+++ b/test/test_runtime_lifecycle.py
@@ -214,12 +214,11 @@ class TestIterationArchival(unittest.TestCase):
 
         self.assertIsNone(get_last_successful_iteration(config))
 
-    def test_init_workspace_rejects_existing_current_iteration(self):
+    def test_init_workspace_succeeds_if_already_exists(self):
         config = self._make_config("reject_agent")
         initialize_current_iteration_workspace(config)
-
-        with self.assertRaises(FileExistsError):
-            initialize_current_iteration_workspace(config)
+        initialize_current_iteration_workspace(config)
+        self.assertTrue(config.current_iteration_dir.is_dir())
 
     def test_iteration_state_preserves_fields_across_partial_updates(self):
         config = self._make_config("state_agent")


### PR DESCRIPTION
This PR will add forking support. You can fork from any iteration and step.

There is no --resume option as forking from the run (without specifyting iteration/step) simply forks from the last stable point and runs further. Resuming would mean the run_id stays the same, the output folder stays the same, wandb stays the same etc... it becomes a bit messy, IMO forking-only is good enough.

Also fixed a bug where we were not passing the foundation models yaml to the agentomics run

Also added a rescue script (quickly vibecoded) that will rescue a crashed run and make it forkable.