### PR TITLE
Iter plan model arg

### DIFF
--- a/docs/configuration/cli-options.md
+++ b/docs/configuration/cli-options.md
@@ -38,6 +38,7 @@ The run stops when either the iteration count is reached or the timeout expires.
 | Option | Description |
 |--------|-------------|
 | `--user-prompt <text>` | Custom prompt for the agent |
+| `--iteration-plan-model <name>` | LLM model used for generating the iteration plan (defaults to `--model`) |
 | `--foundation-model-type <type>` | Pre-download foundation models (`dna`, `rna`, `protein`, `molecule`, `all`) |
 | `--use-provisioning-key` | Use OpenRouter temporary API key |
 | `--spend-limit <n>` | Spend limit for provisioning key (requires `--use-provisioning-key`) |

--- a/run.sh
+++ b/run.sh
@@ -37,6 +37,8 @@ Use --local to run with a local Conda environment.
 
 Required Arguments (for non-interactive runs):
   --model <name>      The LLM model name (e.g., 'openai/gpt-4').
+  --iteration-plan-model <name> The LLM model name used for generating the iteration plan (e.g., 'openai/gpt-5.4'). 
+                                If not provided, defaults to the same model as --model.
   --provider <name>   When multiple api keys provided, optional provider override (e.g., 'openai', 'openrouter').
   --dataset <name>    The short identifier for the prepared dataset (e.g., 'breast_cancer').
   --iterations <N>    Number of iterations to run the agent (recommended more than 5).
@@ -133,6 +135,11 @@ while [[ $# -gt 0 ]]; do
             require_opt_value "$1" "${2:-}"
             AGENTOMICS_ARGS+=(--model "$2")
             MODEL_NAME="$2"
+            shift 2
+            ;;
+        --iteration-plan-model)
+            require_opt_value "$1" "${2:-}"
+            AGENTOMICS_ARGS+=(--iteration-plan-model "$2")
             shift 2
             ;;
         --provider)

--- a/run.sh
+++ b/run.sh
@@ -37,23 +37,31 @@ Use --local to run with a local Conda environment.
 
 Required Arguments (for non-interactive runs):
   --model <name>      The LLM model name (e.g., 'openai/gpt-4').
-  --iteration-plan-model <name> The LLM model name used for generating the iteration plan (e.g., 'openai/gpt-5.4'). 
-                                If not provided, defaults to the same model as --model.
-  --provider <name>   When multiple api keys provided, optional provider override (e.g., 'openai', 'openrouter').
   --dataset <name>    The short identifier for the prepared dataset (e.g., 'breast_cancer').
+                      Can be replaced by --fork-from-run, which inherits the dataset from the source run.
+
+Optional Arguments:
+  --iteration-plan-model <name>
+                      The LLM model used for generating the iteration plan (e.g., 'openai/gpt-5.4').
+                      If not provided, defaults to the same model as --model.
+  --provider <name>   When multiple api keys are provided, provider override (e.g., 'openai', 'openrouter').
   --iterations <N>    Number of iterations to run the agent (recommended more than 5).
                       For forked runs, omitting it keeps the source run's total iteration limit.
                       Providing it means N additional iterations from the fork point.
-  --timeout <int>   Amount of seconds the agent is allowed to run for. This or --iterations will dictate the duration, whichever will expire first. (recommended
-  ~480s)
-  --run-python-timeout <int>  Timeout in seconds for each run_python tool execution - this will determine the maximum training time (default: 21600, i.e. 6 hours).
-  --split-allowed-iterations <N>    Number of initial iterations that are allowed to (re)split the data into train/validation (e.g., 1).
+  --timeout <int>     Amount of seconds the agent is allowed to run for. This or --iterations will dictate the duration,
+                      whichever expires first (recommended ~480s).
+  --run-python-timeout <int>
+                      Timeout in seconds for each run_python tool execution — this determines the maximum training time
+                      (default: 21600, i.e. 6 hours).
+  --split-allowed-iterations <N>
+                      Number of initial iterations that are allowed to (re)split the data into train/validation (e.g., 1).
                       For forked runs, omitting it keeps the source run's split-allowed limit.
                       Providing it means N more split-allowed iterations from the fork point.
-  --exploration-iterations <N>     Number of initial iterations that should focus on baseline/exploration models (e.g., 4).
+  --exploration-iterations <N>
+                      Number of initial iterations that should focus on baseline/exploration models (e.g., 4).
                       For forked runs, omitting it keeps the source run's exploration limit.
                       Providing it means N more exploration iterations from the fork point.
-  --val-metric <name> Optional metric to optimize. Defaults: AUROC (classification), MAE (regression).
+  --val-metric <name> Metric to optimize. Defaults: AUROC (classification), MAE (regression).
   --user-prompt <str> The main prompt/goal for the agent.
                       (Default: "Create the best possible machine learning model that will generalize to new unseen data.")
 

--- a/src/run_agent.py
+++ b/src/run_agent.py
@@ -18,6 +18,7 @@ from utils.providers.provider import get_provider_from_string
 
 async def run_experiment(
     model: str,
+    iteration_plan_model: str,
     dataset_name: str,
     task_type: str,
     val_metric: str,
@@ -46,7 +47,7 @@ async def run_experiment(
     config = Config(
         agent_id=agent_id,
         model_name=model,
-        iteration_plan_model_name=model,
+        iteration_plan_model_name=iteration_plan_model,
         provider_name=provider,
         dataset=dataset_name,
         tags=tags,

--- a/src/run_agent_interactive.py
+++ b/src/run_agent_interactive.py
@@ -34,6 +34,7 @@ def parse_args():
     # Run configuration
     parser.add_argument("--dataset", help="Dataset name. If not provided, can be interactively selected. Cannot be changed for forked runs — always inherited from the source run config.")
     parser.add_argument("--model", help="Model name compatible with the selected provider. If not provided, can be interactively selected. For forked runs, inherits from the source run config.")
+    parser.add_argument("--iteration-plan-model", help="Iteration-plan model name compatible with the selected provider. If not provided, it defaults to --model. For forked runs, inherits from the source run config.")
     parser.add_argument("--provider", help="API provider. If not provided, auto-detected from environment. For forked runs, inherits from the source run config.")
     parser.add_argument(
         "--val-metric",
@@ -130,6 +131,7 @@ def parse_args():
         args.dataset = existing_config.dataset
         args.val_metric = existing_config.val_metric
         if args.model is None:                     args.model = existing_config.model_name
+        if args.iteration_plan_model is None:      args.iteration_plan_model = existing_config.iteration_plan_model_name
         if args.provider is None:                  args.provider = existing_config.provider_name
         # For forked runs, explicit iteration-limit flags mean "N more from the fork point".
         args.iterations = existing_config.iterations if args.iterations is None else next_iteration_index + args.iterations
@@ -244,6 +246,7 @@ def main():
         )
 
     dataset, model, iterations = resolve_interactive_params(args, provider)
+    iteration_plan_model = args.iteration_plan_model or model
 
     task_type = get_task_type_from_prepared_dataset(args.prepared_datasets_dir / dataset)
     val_metric = resolve_val_metric(task_type, args.val_metric)
@@ -255,6 +258,7 @@ def main():
     asyncio.run(
         run_experiment(
             model=model,
+            iteration_plan_model=iteration_plan_model,
             dataset_name=dataset,
             task_type=task_type,
             val_metric=val_metric,

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -55,6 +55,7 @@ class Config:
 
     # Required, settable through the CLI (run_agent_interactive.py)
     model_name: str
+    iteration_plan_model_name: str
     dataset: str
     tags: list[str]
     val_metric: str
@@ -63,7 +64,6 @@ class Config:
 
     # Required, not settable through the CLI
     agent_id: str
-    iteration_plan_model_name: str
     task_type: str
 
     # Optional, default values can be overwritten through the CLI


### PR DESCRIPTION
This PR will:
- Add iteration plan model argument to the CLI (defaults to --model if not provided)
- Updates the docs to include the new argument

I decided to not include the interactive selection of the iteration plan model as I do not want to have additional burden on the users when starting a run. 

Assumes --model and --iteration-plan-model are being used from the same provider.