### PR TITLE
Task type selection

### DIFF
--- a/docs/configuration/cli-options.md
+++ b/docs/configuration/cli-options.md
@@ -42,6 +42,8 @@ The run stops when either the iteration count is reached or the timeout expires.
 | `--foundation-model-type <type>` | Pre-download foundation models (`dna`, `rna`, `protein`, `molecule`, `all`) |
 | `--use-provisioning-key` | Use OpenRouter temporary API key |
 | `--spend-limit <n>` | Spend limit for provisioning key (requires `--use-provisioning-key`) |
+| `--verbosity <summary\|full>` | How much agent interaction detail is printed during the run (default: `full`) |
+| `--disable-training-reporting` | Disable the TrainingReporter helper that emits structured training progress updates from the agent's training script |
 | `--split-allowed-iterations <n>` | Iterations that can modify train/val split (default 1) |
 | `--exploration-iterations <n>` | Baseline exploration iterations (default 4) |
 | `--run-python-timeout <seconds>` | Per-training timeout for `run_python` tool (default 21600) |

--- a/docs/user-guide/datasets.md
+++ b/docs/user-guide/datasets.md
@@ -66,7 +66,7 @@ The agent auto-detects the target column from common names:
 
 If auto-detection fails, you'll be prompted to select the target column during preparation.
 
-For non-interactive preparation, pass `--target-col` to avoid prompts.
+For non-interactive preparation, prepare each dataset individually and pass both `--target-col` and `--task-type` to avoid prompts.
 
 ## Manual Dataset Preparation
 
@@ -92,7 +92,7 @@ Key options:
 | Option | Description |
 |--------|-------------|
 | `--dataset-dir` | Specific dataset to prepare |
-| `--task-type` | Force `classification` or `regression` |
+| `--task-type` | Specify `classification` or `regression` |
 | `--target-col` | Specify target column name |
 | `--positive-class` | Define positive class for binary classification |
 | `--negative-class` | Define negative class for binary classification |
@@ -133,7 +133,7 @@ Download example datasets:
 ### Regression
 
 - Target column should contain numeric values
-- The agent auto-detects regression when target is continuous
+- Select `regression` during preparation or pass `--task-type regression`
 
 ### Feature Columns
 
@@ -147,9 +147,10 @@ Download example datasets:
 
 Solution: Add `--target-col your_column_name` to preparation command, or rename your target column to `class`, `target`, `label`, or `y`.
 
-### "Task type unclear"
+### "Task type required"
 
-Solution: Add `--task-type classification` or `--task-type regression` to force the task type.
+Solution: Add `--task-type classification` or `--task-type regression`, or run
+dataset preparation interactively and select the task type when prompted.
 
 ## Next Steps
 

--- a/docs/user-guide/datasets.md
+++ b/docs/user-guide/datasets.md
@@ -11,7 +11,8 @@ datasets/my_dataset/
 ├── train.csv              # Required
 ├── validation.csv         # Optional
 ├── test.csv               # Optional
-└── dataset_description.md # Optional
+├── dataset_description.md # Optional
+└── dataset_config.json    # Optional — avoids interactive prompts during dataset preparation
 ```
 
 ## File Requirements
@@ -55,18 +56,32 @@ This dataset contains RNA-seq expression levels from tumor samples.
 - Consider using models that handle high-dimensional data
 ```
 
+## Dataset Config File (Optional)
+
+Add an optional `dataset_config.json` to your dataset folder to avoid interactive prompts during dataset preparation.
+
+**`task_type` is the most important field** — without it you'll be prompted every time you prepare the dataset.
+
+```jsonc
+{
+    "task_type": "classification",   // optional: "classification" or "regression", you will be prompted for this during dataset preparation if omitted
+    "target_col": "label",           // optional: column name to predict, auto-detected if omitted
+    "positive_class": 1,             // optional: value that counts as "positive", only applicable for some binary classification metrics, auto-detected if omitted
+    "negative_class": 0              // optional: value that counts as "negative", only applicable for some binary classification metrics, auto-detected if omitted
+}
+```
+
+Include only the fields you need — at minimum just `task_type`. Values from this file take precedence over auto-detection, but CLI flags (`--task-type`, `--target-col`, etc.) override the config file.
+
 ## Target Column Detection
 
-The agent auto-detects the target column from common names:
+The target column is resolved in this order:
+1. CLI flag (`--target-col`)
+2. `dataset_config.json` (`target_col` field)
+3. Auto-detection from common names: `class`, `target`, `label`, `y`
+4. Interactive prompt (if running interactively)
 
-- `class`
-- `target`
-- `label`
-- `y`
-
-If auto-detection fails, you'll be prompted to select the target column during preparation.
-
-For non-interactive preparation, prepare each dataset individually and pass both `--target-col` and `--task-type` to avoid prompts.
+If all of the above fail, preparation will raise an error.
 
 ## Manual Dataset Preparation
 
@@ -149,8 +164,9 @@ Solution: Add `--target-col your_column_name` to preparation command, or rename 
 
 ### "Task type required"
 
-Solution: Add `--task-type classification` or `--task-type regression`, or run
-dataset preparation interactively and select the task type when prompted.
+Solution (preferred): Add a `dataset_config.json` to your dataset folder with `{"task_type": "classification"}` or `{"task_type": "regression"}`.
+
+Alternative: Pass `--task-type classification` or `--task-type regression` to the preparation command, or run preparation interactively and select when prompted.
 
 ## Next Steps
 

--- a/envs/environment_prepare.yaml
+++ b/envs/environment_prepare.yaml
@@ -2,7 +2,7 @@ name: agentomics-prepare-env
 channels:
   - conda-forge
 dependencies:
-  - python==3.10
+  - python==3.12
   - pandas==2.3.1
   - pip
   - pip:

--- a/run.sh
+++ b/run.sh
@@ -21,6 +21,7 @@ DATASET_NAME=""
 VAL_METRIC=""
 LIST_MODE=false
 FOUNDATION_MODELS_TYPE=""
+VERBOSITY="full"
 ALL_ITERATIONS_TEST=false
 BUILD_IMAGES=false
 DOCKERHUB_USERNAME="biogemt"
@@ -94,6 +95,8 @@ Operational Flags:
                       When omitted on a forked run, the source run's foundation model type is reused.
   --use-provisioning-key  Use OpenRouter provisioning key to create temporary API key and log costs.
   --spend-limit <N>   Only applies when --use-provisioning-key is passed. Spend limit for a temporary key (default: 10).
+  --verbosity <summary|full>
+                      Control how much agent interaction detail is printed during the run (default: full).
   --tags              (Optional) Space separated tags for Weights and Biases logging.
   -h, --help          Show this help message and exit.
 
@@ -202,6 +205,11 @@ while [[ $# -gt 0 ]]; do
             AGENTOMICS_ARGS+=(--user-prompt "$2")
             shift 2
             ;;
+        --verbosity)
+            require_opt_value "$1" "${2:-}"
+            VERBOSITY="$2"
+            shift 2
+            ;;
         --tags)
             AGENTOMICS_ARGS+=(--tags)
             shift
@@ -278,6 +286,9 @@ done
 if ! is_valid_foundation_models_type "$FOUNDATION_MODELS_TYPE"; then
     die "Invalid --foundation-models-type '$FOUNDATION_MODELS_TYPE'. Allowed: dna, rna, molecule, protein, all."
 fi
+if [[ "$VERBOSITY" != "summary" && "$VERBOSITY" != "full" ]]; then
+    die "Invalid --verbosity '$VERBOSITY'. Allowed: summary, full."
+fi
 
 EFFECTIVE_FOUNDATION_MODELS_TYPE="$(resolve_effective_string_field "$FOUNDATION_MODELS_TYPE" "$FORK_FROM_RUN" "foundation_models_type")"
 EFFECTIVE_DATASET_NAME="$(resolve_effective_string_field "$DATASET_NAME" "$FORK_FROM_RUN" "dataset" true)"
@@ -314,6 +325,7 @@ if [ "$LOCAL_MODE" = true ]; then
 
     AGENT_ID=$(python src/utils/agent_id.py)
     export AGENT_ID
+    export AGENTOMICS_VERBOSITY="$VERBOSITY"
 
     WORKSPACE_ROOT="$(dirname "$AGENTOMICS_DIR")/workspace"
     WORKSPACE_CACHE_DIR="$WORKSPACE_ROOT/cache"
@@ -636,6 +648,7 @@ else
             --name agentomics_test_cont_${AGENT_ID} \
             ${ENV_FILE_ARGS[@]+"${ENV_FILE_ARGS[@]}"} \
             -e AGENT_ID=${AGENT_ID} \
+            -e AGENTOMICS_VERBOSITY=${VERBOSITY} \
             -e PYTHONWARNINGS=ignore \
             ${EFFECTIVE_FOUNDATION_MODELS_TYPE:+-e FOUNDATION_MODELS_TYPE=${EFFECTIVE_FOUNDATION_MODELS_TYPE}} \
             ${GPU_FLAGS[@]+"${GPU_FLAGS[@]}"} \
@@ -672,6 +685,7 @@ else
             --name agentomics_cont_${AGENT_ID} \
             ${ENV_FILE_ARGS[@]+"${ENV_FILE_ARGS[@]}"} \
             -e AGENT_ID=${AGENT_ID} \
+            -e AGENTOMICS_VERBOSITY=${VERBOSITY} \
             -e PYTHONWARNINGS=ignore \
             ${GPU_FLAGS[@]+"${GPU_FLAGS[@]}"} \
             ${OLLAMA_FLAGS[@]+"${OLLAMA_FLAGS[@]}"} \

--- a/run.sh
+++ b/run.sh
@@ -95,6 +95,8 @@ Operational Flags:
                       When omitted on a forked run, the source run's foundation model type is reused.
   --use-provisioning-key  Use OpenRouter provisioning key to create temporary API key and log costs.
   --spend-limit <N>   Only applies when --use-provisioning-key is passed. Spend limit for a temporary key (default: 10).
+  --disable-training-reporting
+                      Disable the TrainingReporter helper that emits structured best-effort training updates (enabled by default).
   --verbosity <summary|full>
                       Control how much agent interaction detail is printed during the run (default: full).
   --tags              (Optional) Space separated tags for Weights and Biases logging.
@@ -265,6 +267,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --all-iterations-test)
             ALL_ITERATIONS_TEST=true
+            shift
+            ;;
+        --disable-training-reporting)
+            AGENTOMICS_ARGS+=(--disable-training-reporting)
             shift
             ;;
         --cpu-only)

--- a/src/agents/injectables/training_reporter.py
+++ b/src/agents/injectables/training_reporter.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import sys
 
 
@@ -9,8 +8,9 @@ class TrainingReporter:
 
     Use `report_epoch()` when the trainer naturally produces epoch summaries,
     use `report_batch()` only when the chosen training API already exposes a
-    true batch loop or batch callback, and call `report_unavailable()` once
-    when the chosen training API exposes no real epoch or batch progress hooks.
+    true batch loop or batch callback, and call `report_unavailable()` when
+    the chosen training API exposes no real epoch or batch progress hooks.
+    If you use report_unavailable you must call `report_epoch()` at the end of training to report final metrics.
     """
 
     def __init__(self) -> None:
@@ -23,6 +23,8 @@ class TrainingReporter:
     def report_unavailable(self, reason: str) -> None:
         """Emit that no meaningful intermediate progress is available.
 
+        If you use this function you must call report_epoch() at the end of training to report final metrics.
+
         Args:
             reason: Short concrete reason, ideally one sentence.
         """
@@ -32,7 +34,7 @@ class TrainingReporter:
         """Accumulate batch losses and periodically emit a recent-batch summary.
 
         Args:
-            epoch: Current epoch number. Be consistent about 0-based vs 1-based.
+            epoch: Current epoch number.
             batch: Current batch index within the epoch.
             train_loss: Mean loss for this batch.
         """
@@ -61,45 +63,35 @@ class TrainingReporter:
         self,
         epoch: int,
         train_loss: float | None = None,
-        validation_loss: float | None = None,
-        validation_metric_name: str | None = None,
-        validation_metric: float | None = None,
+        val_loss: float | None = None,
+        val_metric_name: str | None = None,
+        val_metric: float | None = None,
         early_stopping_patience_remaining: int | None = None,
     ) -> None:
         """Emit an epoch summary.
 
         Args:
             epoch: Current epoch number for the summary being reported.
-            train_loss: Optional epoch training loss. Supply it when you
-                can compute it.
-            validation_loss: Optional epoch validation loss. Supply it when you
-                can compute it.
-            validation_metric_name: Optional metric label for the run's main
-                validation metric, such as `"AUROC"` or `"MAE"`. Supply it when you 
-                can compute it and only together with `validation_metric`.
-            validation_metric: Optional value for `validation_metric_name`.
-                Supply it only together with `validation_metric_name`.
-            early_stopping_patience_remaining: Optional number of epochs
-                remaining before early stopping would trigger. Supply it only
-                when the training code knows this value.
+            train_loss: Optional epoch training loss.
+            val_loss: Optional epoch validation loss.
+            val_metric_name: Optional label for the run's main validation
+                metric, such as "AUROC" or "MAE". Supply together with val_metric.
+            val_metric: Optional value for val_metric_name.
+                Supply together with val_metric_name.
+            early_stopping_patience_remaining: Optional not-improving epochs remaining before
+                early stopping triggers.
         """
         self._emit(
             "epoch",
             epoch=epoch,
             train_loss=train_loss,
-            validation_loss=validation_loss,
-            validation_metric_name=validation_metric_name,
-            validation_metric=validation_metric,
+            val_loss=val_loss,
+            val_metric_name=val_metric_name,
+            val_metric=val_metric,
             early_stopping_patience_remaining=early_stopping_patience_remaining,
         )
 
     def _emit(self, event: str, **fields: object) -> None:
-        payload: dict[str, object] = {"event": event}
-        for field_name, value in fields.items():
-            if value is None:
-                continue
-            if isinstance(value, float):
-                value = round(value, 6)
-            payload[field_name] = value
-        print(f"TRAINING_REPORT: {json.dumps(payload)}")
+        parts = [f"{k}={f'{v:.4f}' if isinstance(v, float) else v}" for k, v in fields.items() if v is not None]
+        print(f"\nTRAINING_REPORT ({event}): \033[1m{'  '.join(parts)}\033[0m")
         sys.stdout.flush()

--- a/src/agents/injectables/training_reporter.py
+++ b/src/agents/injectables/training_reporter.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import json
+import sys
+
+
+class TrainingReporter:
+    """Emit structured training updates.
+
+    Use `report_epoch()` when the trainer naturally produces epoch summaries,
+    use `report_batch()` only when the chosen training API already exposes a
+    true batch loop or batch callback, and call `report_unavailable()` once
+    when the chosen training API exposes no real epoch or batch progress hooks.
+    """
+
+    def __init__(self) -> None:
+        self._batch_report_interval = 50
+        self._current_epoch: int | None = None
+        self._batches_seen_in_epoch = 0
+        self._batch_loss_total_since_report = 0.0
+        self._batches_seen_since_report = 0
+
+    def report_unavailable(self, reason: str) -> None:
+        """Emit that no meaningful intermediate progress is available.
+
+        Args:
+            reason: Short concrete reason, ideally one sentence.
+        """
+        self._emit("unavailable", reason=reason.strip())
+
+    def report_batch(self, epoch: int, batch: int, train_loss: float) -> None:
+        """Accumulate batch losses and periodically emit a recent-batch summary.
+
+        Args:
+            epoch: Current epoch number. Be consistent about 0-based vs 1-based.
+            batch: Current batch index within the epoch.
+            train_loss: Mean loss for this batch.
+        """
+        if self._current_epoch != epoch:
+            self._current_epoch = epoch
+            self._batches_seen_in_epoch = 0
+            self._batch_loss_total_since_report = 0.0
+            self._batches_seen_since_report = 0
+
+        self._batches_seen_in_epoch += 1
+        self._batch_loss_total_since_report += float(train_loss)
+        self._batches_seen_since_report += 1
+
+        if self._batches_seen_in_epoch % self._batch_report_interval == 0:
+            average_batch_loss = self._batch_loss_total_since_report / self._batches_seen_since_report
+            self._emit(
+                "batch",
+                epoch=epoch,
+                batch=batch,
+                train_loss=average_batch_loss,
+            )
+            self._batch_loss_total_since_report = 0.0
+            self._batches_seen_since_report = 0
+
+    def report_epoch(
+        self,
+        epoch: int,
+        train_loss: float | None = None,
+        validation_loss: float | None = None,
+        validation_metric_name: str | None = None,
+        validation_metric: float | None = None,
+        early_stopping_patience_remaining: int | None = None,
+    ) -> None:
+        """Emit an epoch summary.
+
+        Args:
+            epoch: Current epoch number for the summary being reported.
+            train_loss: Optional epoch training loss. Supply it when you
+                can compute it.
+            validation_loss: Optional epoch validation loss. Supply it when you
+                can compute it.
+            validation_metric_name: Optional metric label for the run's main
+                validation metric, such as `"AUROC"` or `"MAE"`. Supply it when you 
+                can compute it and only together with `validation_metric`.
+            validation_metric: Optional value for `validation_metric_name`.
+                Supply it only together with `validation_metric_name`.
+            early_stopping_patience_remaining: Optional number of epochs
+                remaining before early stopping would trigger. Supply it only
+                when the training code knows this value.
+        """
+        self._emit(
+            "epoch",
+            epoch=epoch,
+            train_loss=train_loss,
+            validation_loss=validation_loss,
+            validation_metric_name=validation_metric_name,
+            validation_metric=validation_metric,
+            early_stopping_patience_remaining=early_stopping_patience_remaining,
+        )
+
+    def _emit(self, event: str, **fields: object) -> None:
+        payload: dict[str, object] = {"event": event}
+        for field_name, value in fields.items():
+            if value is None:
+                continue
+            if isinstance(value, float):
+                value = round(value, 6)
+            payload[field_name] = value
+        print(f"TRAINING_REPORT: {json.dumps(payload)}")
+        sys.stdout.flush()

--- a/src/agents/prompt_builder.py
+++ b/src/agents/prompt_builder.py
@@ -2,6 +2,7 @@ import json
 
 from runtime.system_resources import check_gpu_availability, get_resources_summary
 from utils.config import Config
+from utils.task_types import TaskTypes
 
 def get_system_prompt(config: Config):
     train_csv_path = config.agent_dataset_dir / "train.csv"
@@ -49,7 +50,7 @@ def get_dataset_knowledge(config: Config):
     dataset_knowledge_path = config.agent_dataset_dir / "dataset_description.md"
     with open(dataset_knowledge_path) as f:
         dataset_knowledge = f.read()
-    if config.task_type == "classification":
+    if config.task_type == TaskTypes.CLASSIFICATION:
         metadata = json.loads((config.prepared_dataset_dir / "metadata.json").read_text())
         dataset_knowledge += f"\n\nLabel mapping: {metadata.get('label_to_scalar', {})}"
     return dataset_knowledge

--- a/src/agents/steps/base.py
+++ b/src/agents/steps/base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shutil
 import subprocess
 from abc import ABC, abstractmethod
 from datetime import datetime
@@ -117,6 +118,28 @@ class AgenticStepOutput(BaseModel):
 class AgenticStep(RuntimeStep):
     output_type: type[AgenticStepOutput]
 
+    def on_step_start(self) -> None:
+        super().on_step_start()
+        self._setup_injected_scripts()
+
+    def injected_scripts(self) -> list[Path]:
+        return []
+
+    def _setup_injected_scripts(self) -> None:
+        scripts = self.injected_scripts()
+        if not scripts:
+            return
+        helpers_dir = self.config.current_step_dir / "helpers"
+        helpers_dir.mkdir(exist_ok=True)
+        (helpers_dir / "__init__.py").touch()
+        # In the Docker/agent_user setup, the step directory itself is handed to
+        # the agent user, but injected helpers are created here by the runtime
+        # afterward and are never chowned to that agent user. That leaves
+        # helpers/ importable but non-modifiable for the isolated agent process,
+        # so steps can safely depend on helper behavior.
+        for source_path in scripts:
+            shutil.copy2(source_path, helpers_dir / source_path.name)
+
     def create_agent(self) -> Agent[dict, AgenticStepOutput]:
         agent = Agent(
             model=self.model,
@@ -159,8 +182,11 @@ class AgenticStep(RuntimeStep):
         raise NotImplementedError(f"{type(self).__name__} must define step_prompt() or override build_user_prompt().")
 
     def build_user_prompt(self) -> str:
-        user_prompt = self.step_prompt()
-        return f"{user_prompt}\nSummarized outputs from your previous steps are in previous messages."
+        prompt = self.step_prompt()
+        if self.injected_scripts():
+            prompt += "\nYour current working directory contains a helpers/ package of read-only modules you can import."
+        prompt += "\nSummarized outputs from your previous steps are in previous messages."
+        return prompt
 
     def build_deps(self, step_started_at: datetime) -> dict[str, Any]:
         return {"start_time": step_started_at}

--- a/src/agents/steps/data_split.py
+++ b/src/agents/steps/data_split.py
@@ -13,6 +13,7 @@ import pandas as pd
 
 from agents.steps.base import AgenticStep, AgenticStepOutput
 from runtime.filesystem import chown_tree_to_root
+from utils.task_types import TaskTypes
 from runtime.read_write_utils import get_last_successful_iteration, load_current_iteration_index, load_iteration_state, update_current_iteration_state
 from runtime.step_outputs import load_step_output
 from run_logging.logging_helpers import log_split_is_allowed
@@ -107,12 +108,12 @@ class DataSplitStep(AgenticStep):
         latest_split_dir = self._get_latest_split_dir()
         current_step_dir = self.config.current_step_dir
 
-        if self.config.task_type == 'classification':
+        if self.config.task_type == TaskTypes.CLASSIFICATION:
             extra_instructions = "Ensure that the validation split contains representative samples from ALL classes."
-        elif self.config.task_type == 'regression':
+        elif self.config.task_type == TaskTypes.REGRESSION:
             extra_instructions = ""
         else:
-            raise ValueError(f"Unknown task type: {self.config.task_type}. Supported types are 'classification' and 'regression'.")
+            raise ValueError(f"Unknown task type: {self.config.task_type}. Supported types are {TaskTypes}.")
 
         if iteration != 0 and latest_split_dir is not None:
             extra_info = f"""

--- a/src/agents/steps/model_inference.py
+++ b/src/agents/steps/model_inference.py
@@ -20,6 +20,7 @@ from runtime.read_write_utils import (
 )
 from runtime.step_outputs import require_step_output
 from datasets.dataset_utils import get_classes_integers
+from utils.task_types import TaskTypes
 from utils.text_processing_utils import collapse_repeated_lines, concise_output
 
 
@@ -48,16 +49,16 @@ class ModelInferenceStep(AgenticStep):
 
     def step_prompt(self) -> str:
         model_training = require_step_output(self.config, ModelTrainingStep.step_id, self.config.current_iteration_dir)
-        if self.config.task_type == "classification":
+        if self.config.task_type == TaskTypes.CLASSIFICATION:
             probability_columns = "\n".join(
                 f"- 'probability_{class_id}': probability for class {class_id} (float)"
                 for class_id in get_classes_integers(self.config)
             )
             output_file_description = f"A csv with columns:\n- 'prediction': the predicted class (int)\n{probability_columns}"
-        elif self.config.task_type == "regression":
+        elif self.config.task_type == TaskTypes.REGRESSION:
             output_file_description = "A csv with a single column 'prediction' containing the predicted continuous values."
         else:
-            raise ValueError(f"Unknown task type: {self.config.task_type}. Supported types are 'classification' and 'regression'.")
+            raise ValueError(f"Unknown task type: {self.config.task_type}. Supported types are {TaskTypes}.")
 
         return f"""
         Your next task: create inference.py file.

--- a/src/agents/steps/model_training.py
+++ b/src/agents/steps/model_training.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import subprocess
 import traceback
+from datetime import datetime
 from pathlib import Path
 
 import pandas as pd
@@ -74,7 +75,7 @@ class ModelTrainingStep(AgenticStep):
                 raise ModelRetry(f"The artifacts folder produced by training must be called 'training_artifacts', currently is named {Path(result.path_to_artifacts_dir).name.strip()}")
             if (Path(result.path_to_train_file).resolve().parent / "training_artifacts").resolve() != Path(result.path_to_artifacts_dir).resolve():
                 raise ModelRetry("The artifacts folder produced by training must be a sibling to train.py.")
-            if Path(result.path_to_artifacts_dir).resolve() not in Path(result.path_to_model_file).parents:
+            if Path(result.path_to_artifacts_dir).resolve() not in Path(result.path_to_model_file).resolve().parents:
                 raise ModelRetry(f"Model file ({result.path_to_model_file}) must be inside the artifacts folder ({result.path_to_artifacts_dir})")
             if does_file_contain_iteration_pattern(result.path_to_train_file):
                 raise ModelRetry(f"Train file ({result.path_to_train_file}) contains path containing a forbidden string 'iteration_' or references an iteration folder, which will not accessible during final testing. If you want to re-use a file from a past iteration, copy it into the current working directory and use its path.")
@@ -131,7 +132,7 @@ class ModelTrainingStep(AgenticStep):
         The script must not accept any other parameters.
         """
 
-    def build_deps(self, step_started_at) -> dict[str, object]:
+    def build_deps(self, step_started_at: datetime) -> dict[str, object]:
         data_split = require_step_output(self.config, DataSplitStep.step_id, self.config.current_iteration_dir)
         return {
             "start_time": step_started_at,

--- a/src/agents/steps/model_training.py
+++ b/src/agents/steps/model_training.py
@@ -111,9 +111,9 @@ class ModelTrainingStep(AgenticStep):
           reporter = TrainingReporter()
         - Use reporter.report_epoch(...) whenever your chosen training API naturally exposes epoch summaries or epoch callbacks.
         - You may also use reporter.report_batch(...) for long epochs when your chosen training API already exposes a true batch loop or batch callback and the extra reporting is cheap. Do not invent pseudo-batches or rewrite the training approach just to force batch-level reporting.
-        - When you report a validation metric, report the run's main validation metric: {self.config.val_metric}.
+        - When you report a validation metric, pass val_metric_name="{self.config.val_metric}" and val_metric=<value> to reporter.report_epoch(...).
         - If your chosen library exposes useful callbacks for progress reporting, prefer using those callbacks instead of ad-hoc print statements.
-        - If the chosen training API exposes no real epoch or batch progress hooks, call reporter.report_unavailable("...") once with a concrete reason instead of inventing fake progress.
+        - If the chosen training API exposes no real epoch or batch progress hooks, call reporter.report_unavailable("...") once with a concrete reason, you must then call report_epoch(...) at the end of training to report final metrics.
         - If you implement early stopping and know how many epochs remain before stopping, include early_stopping_patience_remaining in reporter.report_epoch(...).
 """
         return f"""
@@ -189,7 +189,7 @@ class ModelTrainingStep(AgenticStep):
                 training_out.stderr.decode("utf-8", errors="replace"),
             )
             emitted_training_report = any(
-                line.startswith("TRAINING_REPORT:")
+                line.startswith("TRAINING_REPORT")
                 for output in training_outputs
                 for line in output.splitlines()
             )

--- a/src/agents/steps/model_training.py
+++ b/src/agents/steps/model_training.py
@@ -10,6 +10,7 @@ import pandas as pd
 from pydantic import Field
 from pydantic_ai import Agent, ModelRetry, RunContext
 
+import agents.injectables.training_reporter as _training_reporter_module
 from agents.steps.base import AgenticStep, AgenticStepOutput
 from agents.steps.data_split import DataSplitStep
 from runtime.conda_utils import get_shared_environment_path
@@ -46,6 +47,11 @@ class ModelTrainingStep(AgenticStep):
     display_name = "TRAINING"
     output_type = ModelTrainingOutput
 
+    def injected_scripts(self) -> list[Path]:
+        if self.config.disable_training_reporting:
+            return []
+        return [Path(_training_reporter_module.__file__)]
+
     def attach_output_validator(self, agent: Agent[dict, AgenticStepOutput]) -> None:
         @agent.output_validator
         async def validate_training(ctx: RunContext[dict], result: ModelTrainingOutput) -> ModelTrainingOutput:
@@ -59,6 +65,8 @@ class ModelTrainingStep(AgenticStep):
                 raise ModelRetry(f"Model file does not exist at {result.path_to_model_file}")
             workspace_dir = self.config.current_step_dir
             workspace_root = workspace_dir.resolve(strict=False)
+            if Path(result.path_to_train_file).resolve().parent != workspace_root:
+                raise ModelRetry(f"Train file must be created directly in {workspace_dir} as train.py.")
             for candidate_path in [result.path_to_train_file, result.path_to_artifacts_dir, result.path_to_model_file]:
                 if not Path(candidate_path).expanduser().resolve(strict=False).is_relative_to(workspace_root):
                     raise ModelRetry(f"{candidate_path} must stay inside {workspace_dir}.")
@@ -96,14 +104,26 @@ class ModelTrainingStep(AgenticStep):
             return result
 
     def step_prompt(self) -> str:
+        reporting_requirement = "" if self.config.disable_training_reporting else f"""
+        - Always report training status using the helpers package:
+          from helpers.training_reporter import TrainingReporter
+          reporter = TrainingReporter()
+        - Use reporter.report_epoch(...) whenever your chosen training API naturally exposes epoch summaries or epoch callbacks.
+        - You may also use reporter.report_batch(...) for long epochs when your chosen training API already exposes a true batch loop or batch callback and the extra reporting is cheap. Do not invent pseudo-batches or rewrite the training approach just to force batch-level reporting.
+        - When you report a validation metric, report the run's main validation metric: {self.config.val_metric}.
+        - If your chosen library exposes useful callbacks for progress reporting, prefer using those callbacks instead of ad-hoc print statements.
+        - If the chosen training API exposes no real epoch or batch progress hooks, call reporter.report_unavailable("...") once with a concrete reason instead of inventing fake progress.
+        - If you implement early stopping and know how many epochs remain before stopping, include early_stopping_patience_remaining in reporter.report_epoch(...).
+"""
         return f"""
         Your next task: implement training code and train your model.
         Training guidelines:
         - Train until validation performance stops improving, and output the best checkpoint.
         - Save all artifacts needed for inference (model file, tokenizers, etc...).
         - If you failed to implement your intended model, when you call the final_result tool, put into unresolved issues what went wrong.
-        {"If your model can be accelerated by GPU, implement the code to use GPU." if check_gpu_availability() else ""}
-
+        {"- If your model can be accelerated by GPU, implement the code to use GPU." if check_gpu_availability() else ""}
+        {reporting_requirement}
+        - Save the training script directly as train.py in the current step directory, not inside a nested folder.
         The train script should take the following parameters
         --train-data (a path to the training data csv)
         --validation-data (a path to the validation data csv. For example for the purposes of early-stopping. If the training script doesn't need validation data, still include the argument for compatibility and don't use it.)
@@ -158,6 +178,25 @@ class ModelTrainingStep(AgenticStep):
                 raise ModelRetry(
                     self._build_training_retry_message(
                         f"Training script validation failed: model file '{model_file_name}' was not created in the specified artifacts folder.",
+                        returncode=training_out.returncode,
+                        stdout=training_out.stdout,
+                        stderr=training_out.stderr,
+                    )
+                )
+            training_outputs = (
+                training_out.stdout.decode("utf-8", errors="replace"),
+                training_out.stderr.decode("utf-8", errors="replace"),
+            )
+            emitted_training_report = any(
+                line.startswith("TRAINING_REPORT:")
+                for output in training_outputs
+                for line in output.splitlines()
+            )
+            if not self.config.disable_training_reporting and not emitted_training_report:
+                raise ModelRetry(
+                    self._build_training_retry_message(
+                        "Training script validation failed: training script did not emit any TRAINING_REPORT lines during validation. "
+                        "Use TrainingReporter to emit at least one report event, or call reporter.report_unavailable(...) when no intermediate progress is available.",
                         returncode=training_out.returncode,
                         stdout=training_out.stdout,
                         stderr=training_out.stderr,

--- a/src/agents/steps/model_training.py
+++ b/src/agents/steps/model_training.py
@@ -15,6 +15,7 @@ import agents.injectables.training_reporter as _training_reporter_module
 from agents.steps.base import AgenticStep, AgenticStepOutput
 from agents.steps.data_split import DataSplitStep
 from runtime.conda_utils import get_shared_environment_path
+from utils.task_types import TaskTypes
 from runtime.read_write_utils import does_file_contain_iteration_pattern
 from runtime.step_outputs import require_step_output
 from runtime.system_resources import check_gpu_availability
@@ -218,16 +219,16 @@ class ModelTrainingStep(AgenticStep):
 
     def _get_dataset_subset(self, data_path: str, target_col: str) -> pd.DataFrame:
         dataframe = pd.read_csv(data_path)
-        if self.config.task_type == "classification":
+        if self.config.task_type == TaskTypes.CLASSIFICATION:
             samples_per_label = 100
             return dataframe.groupby(target_col, group_keys=False).apply(
                 lambda frame: frame.sample(n=min(len(frame), samples_per_label), random_state=42)
             ).reset_index(drop=True)
-        if self.config.task_type == "regression":
+        if self.config.task_type == TaskTypes.REGRESSION:
             total_samples = min(len(dataframe), 1000)
             return dataframe.sample(n=total_samples, random_state=42).reset_index(drop=True)
         raise ValueError(
-            f"Unknown task type: {self.config.task_type}. Supported types are 'classification' and 'regression'."
+            f"Unknown task type: {self.config.task_type}. Supported types are {TaskTypes}."
         )
 
     def _build_training_retry_message(self, prefix: str, returncode: int, stdout: bytes | str, stderr: bytes | str) -> str:

--- a/src/datasets/create_datasets.py
+++ b/src/datasets/create_datasets.py
@@ -35,6 +35,9 @@ def generate_mirbench_files():
         with open(f"{local_dset_path}/dataset_description.md", "w") as f:
             f.write(dataset_desrciption[dataset_name])
 
+        with open(f"{local_dset_path}/dataset_config.json", "w") as f:
+            json.dump({"task_type": "classification"}, f, indent=4)
+
     for dataset_name, splits in dataset_names_splits.items():
         for split in splits:
             download_path = repo_path/".miRBench"
@@ -78,6 +81,9 @@ def generate_genomic_benchmarks_files():
 
         with open(f"{local_dset_path}/dataset_description.md", "w") as f:
             f.write(dataset_description[dataset_name])
+
+        with open(f"{local_dset_path}/dataset_config.json", "w") as f:
+            json.dump({"task_type": "classification"}, f, indent=4)
 
         for split in ["test","train"]:
             data = []

--- a/src/datasets/dataset_utils.py
+++ b/src/datasets/dataset_utils.py
@@ -2,6 +2,7 @@
 import csv
 import json
 import shutil
+import sys
 import pandas as pd
 from pathlib import Path
 from typing import List, Dict
@@ -10,6 +11,7 @@ from rich.console import Console
 from rich.table import Table
 from rich import box
 from utils.config import Config
+
 
 def count_csv_rows(csv_file: str) -> int:
     """
@@ -179,7 +181,7 @@ def auto_detect_target_col(train_df, interactive=False):
             print(f'INFO: Auto-detected target column: {col}')
             return col
 
-    if interactive:
+    if interactive and sys.stdin.isatty():
         console = Console()
         print(f"\nCould not auto-detect target column. Expected one of {possible_target_cols}")
         cols = train_df.columns.tolist()
@@ -220,18 +222,53 @@ def get_classes_integers(config: Config):
     # Sort by numeric value to get consistent ordering
     return sorted(metadata["label_to_scalar"].values())
         
-def auto_detect_task_type(train_df, target_col) :
-    """Auto-detect task type based on target column values"""
-    target_values = train_df[target_col].dropna()
-    unique_values = target_values.nunique()
-    is_numeric = pd.api.types.is_numeric_dtype(target_values)
-    
-    if is_numeric and unique_values > 10:
-        print(f'INFO: Auto-detected regression task (numeric target with {unique_values} unique values)')
-        return 'regression'
-    
-    print(f'INFO: Auto-detected classification task ({unique_values} unique values)')
-    return 'classification'
+def select_task_type(train_df, target_col, interactive=False):
+    if not interactive or not sys.stdin.isatty():
+        if interactive:
+            print(
+                "Dataset preparation requires task type selection, but stdin is not interactive. "
+                "Prepare this dataset with --task-type classification or --task-type regression."
+            )
+        raise ValueError("Task type is required. Pass --task-type classification or --task-type regression.")
+
+    print_target_column_summary(train_df, target_col)
+    Console().print("[bold red]Action needed:[/bold red] Select the task type for this dataset.")
+
+    while True:
+        choice = input("Select task type ([c]lassification/[r]egression): ").strip().lower()
+        if choice in ("c", "class", "classification"):
+            return "classification"
+        if choice in ("r", "reg", "regression"):
+            return "regression"
+        print("Please enter 'classification' or 'regression'.")
+
+def print_target_column_summary(train_df, target_col):
+    target_values = train_df[target_col]
+    non_null_values = target_values.dropna()
+    unique_values = non_null_values.unique()
+    unique_preview = _format_unique_values_preview(unique_values)
+
+    console = Console()
+    console.print(
+        "\n[bold]Target column summary[/bold]\n"
+        f"- Column: [cyan]{target_col}[/cyan] ({target_values.dtype})\n"
+        f"- Unique non-missing values: {len(unique_values):,}\n"
+        f"- Unique labels: {unique_preview}"
+    )
+
+def _format_unique_values_preview(values, limit=20):
+    preview = _format_preview_values(values[:limit])
+    if len(values) > limit:
+        return f"{preview}, ..."
+    return preview
+
+def _format_preview_values(values):
+    formatted_values = []
+    for value in values:
+        if hasattr(value, "item"):
+            value = value.item()
+        formatted_values.append(repr(value))
+    return ", ".join(formatted_values)
 
 def smart_sort_labels(labels):
     """
@@ -341,7 +378,8 @@ def prepare_dataset(dataset_dir, target_col,
                    positive_class, negative_class, task_type, output_dir, test_sets_output_dir, interactive=False):
     """
     Preprocesses dataset files to a format digestable by the agent code. Stores test set files in a separate directory.
-    If target_col and/or task_type is None, it will be auto-detected and printed out
+    If target_col is None, it will be auto-detected or prompted for in interactive mode.
+    If task_type is None, it will be prompted for in interactive mode.
     If positive_class and negative_class are None, they will be auto-detected for binary classification and printed out
     """
     dataset_dir = Path(dataset_dir)
@@ -361,7 +399,7 @@ def prepare_dataset(dataset_dir, target_col,
     if target_col is None:
         target_col = auto_detect_target_col(train_df, interactive=interactive)
     if task_type is None:
-        task_type = auto_detect_task_type(train_df, target_col)
+        task_type = select_task_type(train_df, target_col, interactive=interactive)
 
     if task_type == 'classification':
         label_map = get_label_to_number_map(

--- a/src/datasets/dataset_utils.py
+++ b/src/datasets/dataset_utils.py
@@ -270,6 +270,20 @@ def _format_preview_values(values):
         formatted_values.append(repr(value))
     return ", ".join(formatted_values)
 
+def validate_single_label_classification(train_df, target_col):
+    target_values = train_df[target_col].dropna()
+    for value in target_values:
+        if isinstance(value, (list, set)):
+            raise ValueError(
+                f"Target column '{target_col}' contains multi-label values (e.g., {value!r}). "
+                "Only single-label classification is supported."
+            )
+        if isinstance(value, str) and value.startswith('[') and value.endswith(']'):
+            raise ValueError(
+                f"Target column '{target_col}' appears to contain multi-label values (e.g., {value!r}). "
+                "Only single-label classification is supported."
+            )
+
 def smart_sort_labels(labels):
     """
     Sort labels with semantic sense:
@@ -402,6 +416,7 @@ def prepare_dataset(dataset_dir, target_col,
         task_type = select_task_type(train_df, target_col, interactive=interactive)
 
     if task_type == 'classification':
+        validate_single_label_classification(train_df, target_col)
         label_map = get_label_to_number_map(
             train_df=train_df,
             test_df=test_df,

--- a/src/datasets/dataset_utils.py
+++ b/src/datasets/dataset_utils.py
@@ -389,6 +389,18 @@ def add_id_column(train_df, validation_df=None, test_df=None):
 
     return train_df, validation_df, test_df
 
+def load_dataset_config(dataset_dir: Path) -> dict:
+    config_path = dataset_dir / "dataset_config.json"
+    if not config_path.exists():
+        return {}
+    config = json.loads(config_path.read_text())
+    if "task_type" in config and config["task_type"] not in TaskTypes:
+        raise ValueError(
+            f"Invalid task_type '{config['task_type']}' in {config_path}. "
+            f"Must be one of: {TaskTypes}"
+        )
+    return config
+
 def prepare_dataset(dataset_dir, target_col,
                    positive_class, negative_class, task_type, output_dir, test_sets_output_dir, interactive=False):
     """
@@ -396,10 +408,21 @@ def prepare_dataset(dataset_dir, target_col,
     If target_col is None, it will be auto-detected or prompted for in interactive mode.
     If task_type is None, it will be prompted for in interactive mode.
     If positive_class and negative_class are None, they will be auto-detected for binary classification and printed out
+    CLI args take precedence over dataset_config.json, which takes precedence over auto-detection.
     """
     dataset_dir = Path(dataset_dir)
     output_dir = Path(output_dir)
     test_sets_output_dir = Path(test_sets_output_dir)
+
+    config = load_dataset_config(dataset_dir)
+    if target_col is None:
+        target_col = config.get("target_col")
+    if task_type is None:
+        task_type = config.get("task_type")
+    if positive_class is None:
+        positive_class = config.get("positive_class")
+    if negative_class is None:
+        negative_class = config.get("negative_class")
 
     train = dataset_dir / 'train.csv'
     test = dataset_dir / 'test.csv' if (dataset_dir / 'test.csv').exists() else None

--- a/src/datasets/dataset_utils.py
+++ b/src/datasets/dataset_utils.py
@@ -11,6 +11,7 @@ from rich.console import Console
 from rich.table import Table
 from rich import box
 from utils.config import Config
+from utils.task_types import TaskTypes
 
 
 def count_csv_rows(csv_file: str) -> int:
@@ -214,7 +215,7 @@ def get_numeric_label_col_from_prepared_dataset(prepared_dataset_dir: Path) -> s
 
 def get_classes_integers(config: Config):
     """Get classes integers from the prepared dataset metadata."""
-    if config.task_type != "classification":
+    if config.task_type != TaskTypes.CLASSIFICATION:
         return None
 
     metadata_path = config.prepared_dataset_dir / "metadata.json"
@@ -236,11 +237,11 @@ def select_task_type(train_df, target_col, interactive=False):
 
     while True:
         choice = input("Select task type ([c]lassification/[r]egression): ").strip().lower()
-        if choice in ("c", "class", "classification"):
-            return "classification"
-        if choice in ("r", "reg", "regression"):
-            return "regression"
-        print("Please enter 'classification' or 'regression'.")
+        if choice in ("c", "class", TaskTypes.CLASSIFICATION):
+            return TaskTypes.CLASSIFICATION
+        if choice in ("r", "reg", TaskTypes.REGRESSION):
+            return TaskTypes.REGRESSION
+        print(f"Please enter '{TaskTypes.CLASSIFICATION}' or '{TaskTypes.REGRESSION}'.")
 
 def print_target_column_summary(train_df, target_col):
     target_values = train_df[target_col]
@@ -415,7 +416,7 @@ def prepare_dataset(dataset_dir, target_col,
     if task_type is None:
         task_type = select_task_type(train_df, target_col, interactive=interactive)
 
-    if task_type == 'classification':
+    if task_type == TaskTypes.CLASSIFICATION:
         validate_single_label_classification(train_df, target_col)
         label_map = get_label_to_number_map(
             train_df=train_df,
@@ -440,7 +441,7 @@ def prepare_dataset(dataset_dir, target_col,
     # Generate prepared split CSV files with numeric labels, plus a labelless held-out test file.
     for split_name, df in dataframes:
         try:
-            if task_type == 'classification':
+            if task_type == TaskTypes.CLASSIFICATION:
                 df['numeric_label'] = df[target_col].map(label_map)
             else:
                 df['numeric_label'] = df[target_col]
@@ -472,7 +473,7 @@ def prepare_dataset(dataset_dir, target_col,
             'test_rows': len(test_df) if test_df is not None else 0,
         }
     }
-    if task_type == 'classification':
+    if task_type == TaskTypes.CLASSIFICATION:
         json_safe_label_map = {str(k): int(v) for k, v in label_map.items()}
         meta['label_to_scalar'] = json_safe_label_map
 

--- a/src/datasets/datasets_interactive.py
+++ b/src/datasets/datasets_interactive.py
@@ -2,7 +2,6 @@ import sys
 from typing import List, Dict, Optional
 from rich.console import Console
 from rich.table import Table
-from rich.progress import Progress, SpinnerColumn, TextColumn
 from utils.user_input import get_user_input_for_int
 from datasets.dataset_utils import prepare_dataset, get_all_datasets_info
 
@@ -100,40 +99,34 @@ def prepare_all_datasets(datasets_dir: str, prepared_datasets_dir: str, prepared
     failed_now = 0
 
     for dataset_info in need_preparation:
-        with Progress(
-            SpinnerColumn(),
-            TextColumn("[progress.description]{task.description}"),
-            console=console
-        ) as progress:
-        
-            task = progress.add_task(f"Preparing {dataset_info['name']}", total=None)
-            try:
-                prepare_dataset(
-                    dataset_dir=dataset_info['path'],
-                    target_col=None, #auto-detected inside
-                    positive_class=None, #auto-detected inside
-                    negative_class=None, #auto-detected inside
-                    task_type=None, #auto-detected inside
-                    output_dir=prepared_datasets_dir,
-                    interactive=True,
-                    test_sets_output_dir=prepared_test_sets_dir
-                )
-                success = True
-            except Exception as e:
-                console.print(f"[red]Error preparing dataset '{dataset_info['name']}': {e}[/red]")
-                success = False
-            
-            if success:
-                progress.update(task, description=f"{dataset_info['name']} prepared successfully")
-                prepared_now += 1
-                dataset_info["status"] = "Prepared"
-                dataset_info["is_prepared"] = True
-                dataset_info["can_prepare"] = False
-                dataset_info["should_prepare"] = False
-            else:
-                progress.update(task, description=f"{dataset_info['name']} preparation failed")
-                failed_now += 1
-                dataset_info["status"] = "Failed"
+        console.print(f"[cyan]Preparing {dataset_info['name']}[/cyan]")
+        try:
+            prepare_dataset(
+                dataset_dir=dataset_info['path'],
+                target_col=None, #auto-detected inside
+                positive_class=None, #auto-detected inside
+                negative_class=None, #auto-detected inside
+                task_type=None,
+                output_dir=prepared_datasets_dir,
+                interactive=True,
+                test_sets_output_dir=prepared_test_sets_dir
+            )
+            success = True
+        except Exception as e:
+            console.print(f"[red]Error preparing dataset '{dataset_info['name']}': {e}[/red]")
+            success = False
+
+        if success:
+            console.print(f"[green]{dataset_info['name']} prepared successfully[/green]")
+            prepared_now += 1
+            dataset_info["status"] = "Prepared"
+            dataset_info["is_prepared"] = True
+            dataset_info["can_prepare"] = False
+            dataset_info["should_prepare"] = False
+        else:
+            console.print(f"[red]{dataset_info['name']} preparation failed[/red]")
+            failed_now += 1
+            dataset_info["status"] = "Failed"
             
     console.print("")
     

--- a/src/prepare_datasets.py
+++ b/src/prepare_datasets.py
@@ -5,6 +5,7 @@ from rich.console import Console
 
 from datasets.dataset_utils import prepare_dataset
 from datasets.datasets_interactive import prepare_all_datasets
+from utils.task_types import TaskTypes
 
 
 def parse_args():
@@ -12,7 +13,7 @@ def parse_args():
     parser.add_argument('--dataset-dir', type=Path, help='Single dataset directory to prepare')
     parser.add_argument('--prepare-all', action='store_true', help='Prepare all datasets in datasets-dir')
     parser.add_argument('--target-col', type=str, default=None, help='Target column name (auto-detected if not provided)')
-    parser.add_argument('--task-type', choices=['classification', 'regression'], default=None, help='Task type (prompted if not provided)')
+    parser.add_argument('--task-type', choices=sorted(TaskTypes), default=None, help='Task type (prompted if not provided)')
     parser.add_argument('--positive-class', help='Value used in the label column for a positive class (affects some binary classification metrics). If not provided, numeric labels are assigned based on the label appearance order in the train csv file.', default=None)
     parser.add_argument('--negative-class', help='Value used in the label column for a negative class (affects some binary classification metrics). If not provided, numeric labels are assigned based on the label appearance order in the train csv file.', default=None)
     parser.add_argument('--datasets-dir', default='./datasets', help='Directory containing raw datasets')

--- a/src/prepare_datasets.py
+++ b/src/prepare_datasets.py
@@ -1,4 +1,5 @@
 import argparse
+import sys
 from pathlib import Path
 from rich.console import Console
 
@@ -7,11 +8,11 @@ from datasets.datasets_interactive import prepare_all_datasets
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(description="Dataset preparation with auto-detection")
+    parser = argparse.ArgumentParser(description="Dataset preparation")
     parser.add_argument('--dataset-dir', type=Path, help='Single dataset directory to prepare')
-    parser.add_argument('--prepare-all', action='store_true', help='Prepare all datasets in datasets-dir and auto-detect their targets and tasks')
+    parser.add_argument('--prepare-all', action='store_true', help='Prepare all datasets in datasets-dir')
     parser.add_argument('--target-col', type=str, default=None, help='Target column name (auto-detected if not provided)')
-    parser.add_argument('--task-type', choices=['classification', 'regression'], default=None, help='Task type (auto-detected if not provided)')
+    parser.add_argument('--task-type', choices=['classification', 'regression'], default=None, help='Task type (prompted if not provided)')
     parser.add_argument('--positive-class', help='Value used in the label column for a positive class (affects some binary classification metrics). If not provided, numeric labels are assigned based on the label appearance order in the train csv file.', default=None)
     parser.add_argument('--negative-class', help='Value used in the label column for a negative class (affects some binary classification metrics). If not provided, numeric labels are assigned based on the label appearance order in the train csv file.', default=None)
     parser.add_argument('--datasets-dir', default='./datasets', help='Directory containing raw datasets')
@@ -33,12 +34,12 @@ def main():
     if args.prepare_all or not args.dataset_dir:
         prepare_all_datasets(datasets_dir, prepared_datasets_dir, prepared_test_sets_dir)
     else:
-        console.print(f'[blue]Preparing dataset "{args.dataset_dir.name}"')# for {task_type} task with target column "{target_col}"[/blue]')
+        console.print(f'[blue]Preparing dataset "{args.dataset_dir.name}"')
         try:
             prepare_dataset(
                 dataset_dir=args.dataset_dir,
                 target_col=args.target_col,
-                positive_class=args.positive_class, #is auto-detected inside - do the same for target/task ?
+                positive_class=args.positive_class,
                 negative_class=args.negative_class,
                 task_type=args.task_type,
                 output_dir=prepared_datasets_dir,
@@ -47,6 +48,7 @@ def main():
             console.print(f"[green]Dataset '{args.dataset_dir.name}' prepared successfully![/green]")
         except Exception as e:
             console.print(f"[red]Dataset '{args.dataset_dir.name}' preparation failed! {e}[/red]")
+            sys.exit(1)
         
 if __name__ == "__main__":
     main()

--- a/src/run_agent.py
+++ b/src/run_agent.py
@@ -35,6 +35,7 @@ async def run_experiment(
     exploration_iterations: int,
     foundation_models_type: str | None = None,
     foundation_models_yaml: str | None = None,
+    disable_training_reporting: bool = False,
 ):
     workspace_dir = Path(workspace_dir)
     prepared_datasets_dir = Path(prepared_datasets_dir)
@@ -65,6 +66,7 @@ async def run_experiment(
         foundation_models_type=foundation_models_type,
         foundation_models_yaml=foundation_models_yaml,
         agent_user=agent_user,
+        disable_training_reporting=disable_training_reporting,
     )
     print_phase("Agentomics run started")
     initialize_run_directories(config)

--- a/src/run_agent_interactive.py
+++ b/src/run_agent_interactive.py
@@ -109,6 +109,12 @@ def parse_args():
         required=True,
         help="Path to a directory containing prepared datasets.",
     )
+    parser.add_argument(
+        "--disable-training-reporting",
+        action="store_true",
+        help="Disable the TrainingReporter helper that emits structured best-effort training updates (enabled by default).",
+    )
+
     # Misc
     parser.add_argument(
         "--root-privileges",
@@ -275,6 +281,7 @@ def main():
             run_python_timeout=args.run_python_timeout,
             foundation_models_type=args.foundation_models_type,
             foundation_models_yaml=args.foundation_models_yaml,
+            disable_training_reporting=args.disable_training_reporting,
         )
     )
     return 0

--- a/src/runtime/evaluate_result.py
+++ b/src/runtime/evaluate_result.py
@@ -5,6 +5,7 @@ import sys
 import pandas as pd
 
 from utils.metrics import get_classification_metrics_functions, get_regression_metrics_functions
+from utils.task_types import TaskTypes
 
 
 def get_metrics(
@@ -25,7 +26,7 @@ def get_metrics(
     if len(merged) != len(test):
         print('WARNING: PREDICTIONS LENGTH DOESNT MATCH TEST DATASET')
 
-    if task_type == "classification":
+    if task_type == TaskTypes.CLASSIFICATION:
         return _get_classification_metrics(
             results=results,
             merged=merged,
@@ -33,13 +34,13 @@ def get_metrics(
             pred_col=pred_col,
             prob_col_prefix=prob_col_prefix,
         )
-    if task_type == "regression":
+    if task_type == TaskTypes.REGRESSION:
         return _get_regression_metrics(
             merged=merged,
             numeric_label_col=numeric_label_col,
             pred_col=pred_col,
         )
-    raise ValueError(f"Unknown task_type: {task_type}. Expected 'classification' or 'regression'.")
+    raise ValueError(f"Unknown task_type: {task_type}. Expected one of {TaskTypes}.")
 
 
 def _get_classification_metrics(results, merged, numeric_label_col: str, pred_col: str, prob_col_prefix: str):
@@ -81,7 +82,7 @@ def main():
     parser.add_argument("-t", "--test", required=True, help="Path to the CSV file with labels.")
     parser.add_argument("--pred-col", default="prediction", help="Name of the prediction column in the results file.")
     parser.add_argument("--numeric-label-col", default="numeric_label", help="Name of the numeric label column in the file.")
-    parser.add_argument("--task-type", choices=["classification", "regression"], required=True, help="Type of task: classification or regression.")
+    parser.add_argument("--task-type", choices=sorted(TaskTypes), required=True, help="Type of task: classification or regression.")
 
     args = parser.parse_args()
 

--- a/src/runtime/generate_final_reports.py
+++ b/src/runtime/generate_final_reports.py
@@ -18,6 +18,7 @@ from agents.steps.validation_evaluation import ValidationEvaluationStep
 from runtime.evaluate_result import get_metrics
 from runtime.step_outputs import load_step_output
 from utils.config import Config
+from utils.task_types import TaskTypes
 from runtime.iteration_reports import write_iteration_report
 from runtime.read_write_utils import get_archived_iterations, load_best_iteration_snapshot_iteration, load_config_from_run_dir_and_reroot
 
@@ -260,13 +261,13 @@ def load_prepared_dataset_meta(prepared_datasets_dir: Path, dataset_name: str) -
         raise SystemExit(f"Failed to parse metadata.json: {meta_path} :: {e}")
 
     task_type = str(d.get("task_type", "")).strip().lower()
-    if task_type not in ("classification", "regression"):
+    if task_type not in TaskTypes:
         raise SystemExit(f"Invalid or missing task_type in metadata.json: {task_type!r}")
     numeric_label_col = d.get("numeric_label_col")
     if not numeric_label_col:
         raise SystemExit("metadata.json missing required key: 'numeric_label_col'")
     label_to_scalar = d.get("label_to_scalar")
-    if task_type == "classification":
+    if task_type == TaskTypes.CLASSIFICATION:
         if not isinstance(label_to_scalar, dict) or not label_to_scalar:
             raise SystemExit("classification metadata.json must include non-empty 'label_to_scalar'")
 
@@ -335,7 +336,7 @@ def merge_labels_and_preds(labeled: pd.DataFrame, preds: pd.DataFrame, meta: Dat
     if y_col not in labeled.columns:
         raise ValueError(f"Label column '{y_col}' not found in labeled CSV. Available: {list(labeled.columns)}")
 
-    if meta.task_type == "regression":
+    if meta.task_type == TaskTypes.REGRESSION:
         pred_col = "prediction"
         if pred_col not in preds.columns:
             raise ValueError(f"Expected regression prediction column '{pred_col}'. Available: {list(preds.columns)}")
@@ -506,7 +507,7 @@ def build_plots_for_split(
     prefix = plots_dir / f"iter_{iteration}_{split.split_name}"
     title_prefix = split.split_name.title()
 
-    if meta.task_type == "classification":
+    if meta.task_type == TaskTypes.CLASSIFICATION:
         return plot_classification(y_true, y_pred, prefix, title_prefix)
     return plot_regression(y_true, y_pred, prefix, title_prefix)
 
@@ -609,7 +610,7 @@ def plots_compare_splits_page_flowables(
         return []
 
     task_type = (task_type or "").strip().lower()
-    if task_type == "classification":
+    if task_type == TaskTypes.CLASSIFICATION:
         row_suffixes = ["_roc", "_pr"]
     else:
         row_suffixes = ["_pred_vs_actual", "_residuals_vs_pred", "_residuals_hist"]
@@ -870,7 +871,7 @@ def main() -> None:
     run_meta = load_run_meta(config)
     dataset_meta = load_prepared_dataset_meta(prepared_datasets, config.dataset)
 
-    if run_meta.task_type in ("classification", "regression") and run_meta.task_type != dataset_meta.task_type:
+    if run_meta.task_type in TaskTypes and run_meta.task_type != dataset_meta.task_type:
         print(f"[WARN] task_type mismatch: config={run_meta.task_type} metadata={dataset_meta.task_type}")
 
     iterations = get_archived_iterations(config)

--- a/src/tools/bash_tool.py
+++ b/src/tools/bash_tool.py
@@ -96,8 +96,7 @@ class BashProcess:
     
     def process_output(self, output: str, command: str) -> str:
         """
-        Uses regex to remove the command from the output.
-        Return only first 5000 output characters.
+        Remove the echoed command and return a concise version of the output.
 
         Args:
             output: a process' output string
@@ -105,10 +104,8 @@ class BashProcess:
         """
         pattern = re.escape(command) + r"\s*\n"
         output = re.sub(pattern, "", output, count=1)
-        output = collapse_repeated_lines(output)
-        if(len(output) > 5000):
-            output = output[:5000]+"\n ... (output truncated, too long)"
-        return output.strip()
+        output = collapse_repeated_lines(output).strip()
+        return concise_output(output)
 
 def create_bash_tool(config: Config):
         bash = BashProcess(

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -77,6 +77,7 @@ class Config:
     run_python_tool_timeout: int = DEFAULT_RUN_PYTHON_TOOL_TIMEOUT
     foundation_models_type: str | None = None
     foundation_models_yaml: str | None = None
+    disable_training_reporting: bool = False
 
     # Optional, default values can not be overwritten through the CLI
     max_steps: int = DEFAULT_MAX_STEPS

--- a/src/utils/metrics.py
+++ b/src/utils/metrics.py
@@ -3,6 +3,8 @@ from scipy.stats import pearsonr, spearmanr
 import numpy as np
 from typing import Optional
 
+from utils.task_types import TaskTypes
+
 
 class Metric:
     """
@@ -130,8 +132,8 @@ def get_regression_metrics_names():
 
 def get_task_to_metrics_names():
     return {
-        "classification": get_classification_metrics_names(),
-        "regression": get_regression_metrics_names(),
+        TaskTypes.CLASSIFICATION: get_classification_metrics_names(),
+        TaskTypes.REGRESSION: get_regression_metrics_names(),
     }
 
 def get_higher_is_better_map():
@@ -143,11 +145,11 @@ def get_higher_is_better_map():
     return {name: metric.higher_is_better for name, metric in all_metrics.items()}
 
 def get_default_val_metric(task_type: str) -> str:
-    if task_type == "classification":
+    if task_type == TaskTypes.CLASSIFICATION:
         return "AUROC"
-    if task_type == "regression":
+    if task_type == TaskTypes.REGRESSION:
         return "MAE"
-    raise ValueError(f"Unknown task_type: {task_type}. Expected 'classification' or 'regression'.")
+    raise ValueError(f"Unknown task_type: {task_type}. Expected one of {TaskTypes}.")
 
 def resolve_val_metric(task_type: str, val_metric: Optional[str] = None) -> str:
     """Resolve a validation metric for a task, applying defaults when omitted."""
@@ -156,7 +158,7 @@ def resolve_val_metric(task_type: str, val_metric: Optional[str] = None) -> str:
 
     allowed = get_task_to_metrics_names().get(task_type)
     if not allowed:
-        raise ValueError(f"Unknown task_type: {task_type}. Expected 'classification' or 'regression'.")
+        raise ValueError(f"Unknown task_type: {task_type}. Expected one of {TaskTypes}.")
     if val_metric not in allowed:
         raise ValueError(
             f"Validation metric '{val_metric}' is invalid for task type '{task_type}'. "

--- a/src/utils/metrics_interactive.py
+++ b/src/utils/metrics_interactive.py
@@ -3,6 +3,7 @@ from rich.columns import Columns
 from rich.console import Console
 
 from utils.metrics import get_classification_metrics_names, get_regression_metrics_names
+from utils.task_types import TaskTypes
 from utils.user_input import get_user_input_for_int
 
 
@@ -36,11 +37,11 @@ def display_metrics_table(task_type=None):
         console.print(Columns(boxes, padding=(0, 1), expand=False))
         return clf_metrics + reg_metrics
 
-    if task_type == "classification":
+    if task_type == TaskTypes.CLASSIFICATION:
         metrics_to_show = get_classification_metrics_names()
         title = "[bold]Metric for Classification[/bold]"
         border_style = "cyan"
-    elif task_type == "regression":
+    elif task_type == TaskTypes.REGRESSION:
         metrics_to_show = get_regression_metrics_names()
         title = "[bold]Metric for Regression[/bold]"
         border_style = "yellow"

--- a/src/utils/printing_utils.py
+++ b/src/utils/printing_utils.py
@@ -30,7 +30,7 @@ def pretty_print(content, width=120, color=None):
     if color:
         content = f"{color}{content}{bcolors.ENDC}"
     if isinstance(content, str):
-        print(textwrap.fill(content, width=width))
+        print("\n".join(textwrap.fill(line, width=width) for line in content.splitlines()))
     else:
         pprint.pprint(content, width=width)
 

--- a/src/utils/printing_utils.py
+++ b/src/utils/printing_utils.py
@@ -77,8 +77,8 @@ def pretty_print_code(code):
 
     print(footer)
 
-def _print_mode() -> str:
-    mode = os.getenv("AGENTOMICS_PRINT_MODE", "summary").strip().lower()
+def _verbosity() -> str:
+    mode = os.getenv("AGENTOMICS_VERBOSITY", "summary").strip().lower()
     return mode if mode in {"summary", "full"} else "summary"
 
 def _args_dict(tool_call_part: ToolCallPart) -> dict:
@@ -136,7 +136,7 @@ def _tool_return_summary(part: ToolReturnPart) -> tuple[str, bool]:
     return "", False
 
 def pretty_print_node(node):
-    mode = _print_mode()
+    mode = _verbosity()
     if mode == "summary":
         if isinstance(node, CallToolsNode):
             for part in node.model_response.parts:

--- a/src/utils/task_types.py
+++ b/src/utils/task_types.py
@@ -1,0 +1,6 @@
+from enum import StrEnum
+
+
+class TaskTypes(StrEnum):
+    CLASSIFICATION = "classification"
+    REGRESSION = "regression"


### PR DESCRIPTION
This PR will:

Generalize task types to a single enum
Update python in preparation conda to support StrEnum
Explicitly inform user multi-label datasets are forbidden
Stop assuming task type from label values
Add support for unprepared dataset configs to specify values like task type
Add prompts for asking task type from the user if not clear
Tests are passing
Note: This PR changes influence the preparation docker image. Reviewer will have to run with --build-images. Before merging, we will have to push the updated preparation docker image to the hub.