### PR TITLE
Task type selection

### DIFF
--- a/docs/user-guide/datasets.md
+++ b/docs/user-guide/datasets.md
@@ -11,7 +11,8 @@ datasets/my_dataset/
 ├── train.csv              # Required
 ├── validation.csv         # Optional
 ├── test.csv               # Optional
-└── dataset_description.md # Optional
+├── dataset_description.md # Optional
+└── dataset_config.json    # Optional — avoids interactive prompts during dataset preparation
 ```
 
 ## File Requirements
@@ -55,18 +56,32 @@ This dataset contains RNA-seq expression levels from tumor samples.
 - Consider using models that handle high-dimensional data
 ```
 
+## Dataset Config File (Optional)
+
+Add an optional `dataset_config.json` to your dataset folder to avoid interactive prompts during dataset preparation.
+
+**`task_type` is the most important field** — without it you'll be prompted every time you prepare the dataset.
+
+```jsonc
+{
+    "task_type": "classification",   // optional: "classification" or "regression", you will be prompted for this during dataset preparation if omitted
+    "target_col": "label",           // optional: column name to predict, auto-detected if omitted
+    "positive_class": 1,             // optional: value that counts as "positive", only applicable for some binary classification metrics, auto-detected if omitted
+    "negative_class": 0              // optional: value that counts as "negative", only applicable for some binary classification metrics, auto-detected if omitted
+}
+```
+
+Include only the fields you need — at minimum just `task_type`. Values from this file take precedence over auto-detection, but CLI flags (`--task-type`, `--target-col`, etc.) override the config file.
+
 ## Target Column Detection
 
-The agent auto-detects the target column from common names:
+The target column is resolved in this order:
+1. CLI flag (`--target-col`)
+2. `dataset_config.json` (`target_col` field)
+3. Auto-detection from common names: `class`, `target`, `label`, `y`
+4. Interactive prompt (if running interactively)
 
-- `class`
-- `target`
-- `label`
-- `y`
-
-If auto-detection fails, you'll be prompted to select the target column during preparation.
-
-For non-interactive preparation, prepare each dataset individually and pass both `--target-col` and `--task-type` to avoid prompts.
+If all of the above fail, preparation will raise an error.
 
 ## Manual Dataset Preparation
 
@@ -151,8 +166,9 @@ Solution: Add `--target-col your_column_name` to preparation command, or rename 
 
 ### "Task type required"
 
-Solution: Add `--task-type classification` or `--task-type regression`, or run
-dataset preparation interactively and select the task type when prompted.
+Solution (preferred): Add a `dataset_config.json` to your dataset folder with `{"task_type": "classification"}` or `{"task_type": "regression"}`.
+
+Alternative: Pass `--task-type classification` or `--task-type regression` to the preparation command, or run preparation interactively and select when prompted.
 
 ## Next Steps
 

--- a/docs/user-guide/datasets.md
+++ b/docs/user-guide/datasets.md
@@ -66,7 +66,7 @@ The agent auto-detects the target column from common names:
 
 If auto-detection fails, you'll be prompted to select the target column during preparation.
 
-For non-interactive preparation, pass `--target-col` to avoid prompts.
+For non-interactive preparation, prepare each dataset individually and pass both `--target-col` and `--task-type` to avoid prompts.
 
 ## Manual Dataset Preparation
 
@@ -92,7 +92,7 @@ Key options:
 | Option | Description |
 |--------|-------------|
 | `--dataset-dir` | Specific dataset to prepare |
-| `--task-type` | Force `classification` or `regression` |
+| `--task-type` | Specify `classification` or `regression` |
 | `--target-col` | Specify target column name |
 | `--positive-class` | Define positive class for binary classification |
 | `--negative-class` | Define negative class for binary classification |
@@ -135,7 +135,7 @@ Download example datasets:
 ### Regression
 
 - Target column should contain numeric values
-- The agent auto-detects regression when target is continuous
+- Select `regression` during preparation or pass `--task-type regression`
 
 ### Feature Columns
 
@@ -149,9 +149,10 @@ Download example datasets:
 
 Solution: Add `--target-col your_column_name` to preparation command, or rename your target column to `class`, `target`, `label`, or `y`.
 
-### "Task type unclear"
+### "Task type required"
 
-Solution: Add `--task-type classification` or `--task-type regression` to force the task type.
+Solution: Add `--task-type classification` or `--task-type regression`, or run
+dataset preparation interactively and select the task type when prompted.
 
 ## Next Steps
 

--- a/docs/user-guide/datasets.md
+++ b/docs/user-guide/datasets.md
@@ -62,14 +62,21 @@ Add an optional `dataset_config.json` to your dataset folder to avoid interactiv
 
 **`task_type` is the most important field** — without it you'll be prompted every time you prepare the dataset.
 
-```jsonc
+```json
 {
-    "task_type": "classification",   // optional: "classification" or "regression", you will be prompted for this during dataset preparation if omitted
-    "target_col": "label",           // optional: column name to predict, auto-detected if omitted
-    "positive_class": 1,             // optional: value that counts as "positive", only applicable for some binary classification metrics, auto-detected if omitted
-    "negative_class": 0              // optional: value that counts as "negative", only applicable for some binary classification metrics, auto-detected if omitted
+    "task_type": "classification",
+    "target_col": "label",
+    "positive_class": 1,
+    "negative_class": 0
 }
 ```
+
+Fields:
+
+- `task_type` (optional): `"classification"` or `"regression"`; if omitted, you will be prompted during dataset preparation.
+- `target_col` (optional): column name to predict; auto-detected if omitted.
+- `positive_class` (optional): value that counts as "positive"; only applicable for some binary classification metrics, auto-detected if omitted.
+- `negative_class` (optional): value that counts as "negative"; only applicable for some binary classification metrics, auto-detected if omitted.
 
 Include only the fields you need — at minimum just `task_type`. Values from this file take precedence over auto-detection, but CLI flags (`--task-type`, `--target-col`, etc.) override the config file.
 

--- a/envs/environment_prepare.yaml
+++ b/envs/environment_prepare.yaml
@@ -2,7 +2,7 @@ name: agentomics-prepare-env
 channels:
   - conda-forge
 dependencies:
-  - python==3.10
+  - python==3.12
   - pandas==2.3.1
   - pip
   - pip:

--- a/run.sh
+++ b/run.sh
@@ -18,6 +18,7 @@ TIMEOUT_SECS=""
 MODEL_NAME=""
 PREFERRED_PROVIDER=""
 DATASET_NAME=""
+TASK_TYPE=""
 VAL_METRIC=""
 LIST_MODE=false
 FOUNDATION_MODELS_TYPE=""
@@ -46,6 +47,9 @@ Optional Arguments:
                       The LLM model used for generating the iteration plan (e.g., 'openai/gpt-5.4').
                       If not provided, defaults to the same model as --model.
   --provider <name>   When multiple api keys are provided, provider override (e.g., 'openai', 'openrouter').
+  --task-type <classification|regression>
+                      Task type used when preparing a raw dataset selected with --dataset.
+                      If omitted and the dataset config does not define it, preparation prompts in interactive mode.
   --iterations <N>    Number of iterations to run the agent (recommended more than 5).
                       For forked runs, omitting it keeps the source run's total iteration limit.
                       Providing it means N additional iterations from the fork point.
@@ -165,6 +169,11 @@ while [[ $# -gt 0 ]]; do
             require_opt_value "$1" "${2:-}"
             AGENTOMICS_ARGS+=(--dataset "$2")
             DATASET_NAME="$2"
+            shift 2
+            ;;
+        --task-type)
+            require_opt_value "$1" "${2:-}"
+            TASK_TYPE="$2"
             shift 2
             ;;
         --iterations)
@@ -362,10 +371,16 @@ if [ "$LOCAL_MODE" = true ]; then
 
     mkdir -p prepared_datasets
     if [ -n "$EFFECTIVE_DATASET_NAME" ]; then
-        conda run -n agentomics-prepare-env python src/prepare_datasets.py \
-            --dataset-dir "./datasets/${EFFECTIVE_DATASET_NAME}" \
-            --prepared-datasets-dir "$(pwd)/prepared_datasets" \
+        PREPARE_ARGS=(
+            --dataset-dir "./datasets/${EFFECTIVE_DATASET_NAME}"
+            --prepared-datasets-dir "$(pwd)/prepared_datasets"
             --prepared-test-sets-dir "$(pwd)/prepared_test_sets"
+        )
+        if [ -n "$TASK_TYPE" ]; then
+            PREPARE_ARGS+=(--task-type "$TASK_TYPE")
+        fi
+        conda run -n agentomics-prepare-env python src/prepare_datasets.py \
+            ${PREPARE_ARGS[@]+"${PREPARE_ARGS[@]}"}
     else
         conda run -n agentomics-prepare-env python src/prepare_datasets.py --prepare-all \
             --datasets-dir "$(pwd)/datasets" \
@@ -538,6 +553,9 @@ else
     PREPARE_ARGS=()
     if [ -n "$EFFECTIVE_DATASET_NAME" ]; then
         PREPARE_ARGS=(--dataset-dir "./datasets/${EFFECTIVE_DATASET_NAME}")
+        if [ -n "$TASK_TYPE" ]; then
+            PREPARE_ARGS+=(--task-type "$TASK_TYPE")
+        fi
     else
         PREPARE_ARGS=(--prepare-all)
     fi

--- a/run.sh
+++ b/run.sh
@@ -365,8 +365,10 @@ if [ "$LOCAL_MODE" = true ]; then
     echo -e "${RED}Running in local mode - this is only recommended if you run in a non-vulnerable environment!${NOCOLOR}"
     echo "For Docker mode (secure run), re-run without the --local flag."
     
-    if ! conda env list | grep -q "agentomics-prepare-env"; then
+    if ! conda env list | grep -q "^agentomics-prepare-env "; then
         conda env create -f envs/environment_prepare.yaml -q
+    else
+        conda env update -n agentomics-prepare-env -f envs/environment_prepare.yaml -q --prune
     fi
 
     mkdir -p prepared_datasets

--- a/scripts/download_example_datasets.sh
+++ b/scripts/download_example_datasets.sh
@@ -3,4 +3,4 @@ REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_DIR" || exit 1
 conda env remove -n agentomics-datasets -y 2>/dev/null || true
 conda env create -f envs/environment_datasets.yaml
-conda run -n agentomics-datasets python src/datasets/create_datasets.py
+conda run -n agentomics-datasets python src/datasets/create_datasets.py "$@"

--- a/src/agents/prompt_builder.py
+++ b/src/agents/prompt_builder.py
@@ -2,6 +2,7 @@ import json
 
 from runtime.system_resources import check_gpu_availability, get_resources_summary
 from utils.config import Config
+from utils.task_types import TaskTypes
 
 def get_system_prompt(config: Config):
     train_csv_path = config.agent_dataset_dir / "train.csv"
@@ -49,7 +50,7 @@ def get_dataset_knowledge(config: Config):
     dataset_knowledge_path = config.agent_dataset_dir / "dataset_description.md"
     with open(dataset_knowledge_path) as f:
         dataset_knowledge = f.read()
-    if config.task_type == "classification":
+    if config.task_type == TaskTypes.CLASSIFICATION:
         metadata = json.loads((config.prepared_dataset_dir / "metadata.json").read_text())
         dataset_knowledge += f"\n\nLabel mapping: {metadata.get('label_to_scalar', {})}"
     return dataset_knowledge

--- a/src/agents/steps/data_split.py
+++ b/src/agents/steps/data_split.py
@@ -13,6 +13,7 @@ import pandas as pd
 
 from agents.steps.base import AgenticStep, AgenticStepOutput
 from runtime.filesystem import chown_tree_to_root
+from utils.task_types import TaskTypes
 from runtime.read_write_utils import get_last_successful_iteration, load_current_iteration_index, load_iteration_state, update_current_iteration_state
 from runtime.step_outputs import load_step_output
 from run_logging.logging_helpers import log_split_is_allowed
@@ -107,12 +108,12 @@ class DataSplitStep(AgenticStep):
         latest_split_dir = self._get_latest_split_dir()
         current_step_dir = self.config.current_step_dir
 
-        if self.config.task_type == 'classification':
+        if self.config.task_type == TaskTypes.CLASSIFICATION:
             extra_instructions = "Ensure that the validation split contains representative samples from ALL classes."
-        elif self.config.task_type == 'regression':
+        elif self.config.task_type == TaskTypes.REGRESSION:
             extra_instructions = ""
         else:
-            raise ValueError(f"Unknown task type: {self.config.task_type}. Supported types are 'classification' and 'regression'.")
+            raise ValueError(f"Unknown task type: {self.config.task_type}. Supported types are {TaskTypes}.")
 
         if iteration != 0 and latest_split_dir is not None:
             extra_info = f"""

--- a/src/agents/steps/model_inference.py
+++ b/src/agents/steps/model_inference.py
@@ -20,6 +20,7 @@ from runtime.read_write_utils import (
 )
 from runtime.step_outputs import require_step_output
 from datasets.dataset_utils import get_classes_integers
+from utils.task_types import TaskTypes
 from utils.text_processing_utils import collapse_repeated_lines, concise_output
 
 
@@ -48,16 +49,16 @@ class ModelInferenceStep(AgenticStep):
 
     def step_prompt(self) -> str:
         model_training = require_step_output(self.config, ModelTrainingStep.step_id, self.config.current_iteration_dir)
-        if self.config.task_type == "classification":
+        if self.config.task_type == TaskTypes.CLASSIFICATION:
             probability_columns = "\n".join(
                 f"- 'probability_{class_id}': probability for class {class_id} (float)"
                 for class_id in get_classes_integers(self.config)
             )
             output_file_description = f"A csv with columns:\n- 'prediction': the predicted class (int)\n{probability_columns}"
-        elif self.config.task_type == "regression":
+        elif self.config.task_type == TaskTypes.REGRESSION:
             output_file_description = "A csv with a single column 'prediction' containing the predicted continuous values."
         else:
-            raise ValueError(f"Unknown task type: {self.config.task_type}. Supported types are 'classification' and 'regression'.")
+            raise ValueError(f"Unknown task type: {self.config.task_type}. Supported types are {TaskTypes}.")
 
         return f"""
         Your next task: create inference.py file.

--- a/src/agents/steps/model_training.py
+++ b/src/agents/steps/model_training.py
@@ -15,6 +15,7 @@ import agents.injectables.training_reporter as _training_reporter_module
 from agents.steps.base import AgenticStep, AgenticStepOutput
 from agents.steps.data_split import DataSplitStep
 from runtime.conda_utils import get_shared_environment_path
+from utils.task_types import TaskTypes
 from runtime.read_write_utils import does_file_contain_iteration_pattern
 from runtime.step_outputs import require_step_output
 from runtime.system_resources import check_gpu_availability
@@ -218,16 +219,16 @@ class ModelTrainingStep(AgenticStep):
 
     def _get_dataset_subset(self, data_path: str, target_col: str) -> pd.DataFrame:
         dataframe = pd.read_csv(data_path)
-        if self.config.task_type == "classification":
+        if self.config.task_type == TaskTypes.CLASSIFICATION:
             samples_per_label = 100
             return dataframe.groupby(target_col, group_keys=False).apply(
                 lambda frame: frame.sample(n=min(len(frame), samples_per_label), random_state=42)
             ).reset_index(drop=True)
-        if self.config.task_type == "regression":
+        if self.config.task_type == TaskTypes.REGRESSION:
             total_samples = min(len(dataframe), 1000)
             return dataframe.sample(n=total_samples, random_state=42).reset_index(drop=True)
         raise ValueError(
-            f"Unknown task type: {self.config.task_type}. Supported types are 'classification' and 'regression'."
+            f"Unknown task type: {self.config.task_type}. Supported types are {TaskTypes}."
         )
 
     def _build_training_retry_message(self, prefix: str, returncode: int, stdout: bytes | str, stderr: bytes | str) -> str:

--- a/src/datasets/create_datasets.py
+++ b/src/datasets/create_datasets.py
@@ -35,6 +35,9 @@ def generate_mirbench_files():
         with open(f"{local_dset_path}/dataset_description.md", "w") as f:
             f.write(dataset_desrciption[dataset_name])
 
+        with open(f"{local_dset_path}/dataset_config.json", "w") as f:
+            json.dump({"task_type": "classification"}, f, indent=4)
+
     for dataset_name, splits in dataset_names_splits.items():
         for split in splits:
             download_path = repo_path/".miRBench"
@@ -78,6 +81,9 @@ def generate_genomic_benchmarks_files():
 
         with open(f"{local_dset_path}/dataset_description.md", "w") as f:
             f.write(dataset_description[dataset_name])
+
+        with open(f"{local_dset_path}/dataset_config.json", "w") as f:
+            json.dump({"task_type": "classification"}, f, indent=4)
 
         for split in ["test","train"]:
             data = []

--- a/src/datasets/create_datasets.py
+++ b/src/datasets/create_datasets.py
@@ -2,103 +2,103 @@ from pathlib import Path
 import os
 import json
 import pandas as pd
+import argparse
 
-def generate_mirbench_files():
+REPO_PATH = Path(os.path.abspath(os.path.dirname(__file__))).parent.parent
+
+MIRBENCH_DATASETS = {
+    "AGO2_CLASH_Hejret2023": {
+        "splits": ["train", "test"],
+        "description": "The AGO2 Hejret2023 dataset was adapted from [miRBench: novel benchmark datasets for microRNA binding site prediction that mitigate against prevalent microRNA Frequency Class Bias]. This dataset contains microRNA sequences and their corresponding binding sites, as identified via a CLASH (crosslinking, ligation, and sequencing of hybrids) experiment. There are two sequences in this dataset: gene and noncodingRNA. The gene sequences are 50nt fragments including a target site of the noncodingRNA. We expect that the targeting occurs via partial complementarity of the two sequences. Samples with label==1 are target sites retrieved from the CLASH experiment. For each of these positive samples, a negative sample (label==0) is created by matching the same noncodingRNA sequence with a randomly selected gene sequence.",
+    }
+}
+
+# Description pulled from the genomic benchmarks publication text
+GENOMIC_BENCHMARKS_DATASETS = {
+    "human_enhancers_cohn": "The Human enhancers Cohn dataset was adapted from [BioRxiv. 2018:264200]. Enhancers are genomic regulatory functional elements that can be bound by specific DNA binding proteins so as to regulate the transcription of a particular gene. Unlike promoters, enhancers do not need to be in a close proximity to the affected gene, and may be up to several million bases away, making their detection a difficult task.",
+    "drosophila_enhancers_stark": "The Drosophila enhancers Stark dataset was adapted from [Nature. 2014;512(7512):91–5]. These enhancers were experimentally validated and we excluded the weak ones. Original coordinates referred to the dm3 [2007;316(5831):1625–8] assembly of the D. melanogaster genome. We used pyliftoverFootnote 3 tool to map coordinates to the dm6 assembly [Nucleic Acids Res. 2015;43(D1):690–7]. Negative sequences are randomly generated from drosophila genome dm6 to match lengths of positive sequences and to not overlap them.",
+    "human_enhancers_ensembl": "The Human enhancers Ensembl dataset was constructed from Human enhancers from The FANTOM5 project [Nature. 2014;507(7493):455–61] accessed through the Ensembl database [Nucleic Acids Res. 2021;49(D1):884–91]. Negative sequences have been randomly generated from the Human genome GRCh38 to match the lengths of positive sequences and not overlap them.",
+    "human_nontata_promoters": "The Human non-TATA promoters dataset was adapted from [PLoS ONE. 2017;12(2):0171410]. These sequences are of length 251bp: from -200 to +50bp around transcription start site (TSS). To create non-promoters sequences of length 251bp, the authors of the original paper used random fragments of human genes located after first exons.",
+    "human_ocr_ensembl": "The Human ocr Ensembl dataset was constructed from the Ensembl database [Nucleic Acids Res. 2021;49(D1):884–91]. Positive sequences are Human Open Chromatin Regions (OCRs) from The Ensembl Regulatory Build [Genome Biol. 2015;16(1):1–8]. Open chromatin regions are regions of the genome that can be preferentially accessed by DNA regulatory elements because of their open chromatin structure. In the Ensembl Regulatory Build, this label is assigned to open chromatin regions, which were experimentally observed through DNase-seq, but covered by none of the other annotations (enhancer, promoter, gene, TSS, CTCF, etc.). Negative sequences were generated from the Human genome GRCh38 to match the lengths of positive sequences and not overlap them.",
+    "human_ensembl_regulatory": "The Human regulatory Ensembl dataset was constructed from Ensembl database [Nucleic Acids Res. 2021;49(D1):884–91]. This dataset has three classes: enhancer, promoter and open chromatin region from The Ensembl Regulatory Build [Genome Biol. 2015;16(1):1–8]."
+}
+
+CLASS_COL = "target"
+
+
+def generate_mirbench_files(dataset: str | None = None):
     from miRBench.dataset import download_dataset as mirbench_download_dataset
-    repo_path = Path(os.path.abspath(os.path.dirname(__file__))).parent.parent
-    dataset_names_splits = {
-        "AGO2_CLASH_Hejret2023": ["train", "test"],
-    }
 
-    ago2_clash_description = """
-        The AGO2 Hejret2023 dataset was adapted from [miRBench: novel benchmark datasets for microRNA binding site prediction that mitigate against prevalent microRNA Frequency Class Bias]. 
-        This dataset contains microRNA sequences and their corresponding binding sites, as 
-        identified via a CLASH (crosslinking, ligation, and sequencing of hybrids) experiment. 
-        There are two sequences in this dataset: gene and noncodingRNA. 
-        The gene sequences are 50nt fragments including a target site of the noncodingRNA. 
-        We expect that the targeting occurs via partial complementarity of the two sequences.
-        Samples with label==1 are target sites retrieved from the CLASH experiment. 
-        For each of these positive samples, a negative sample (label==0) is created by matching the same 
-        noncodingRNA sequence with a randomly selected gene sequence.
-    """
-    dataset_desrciption = {
-        "AGO2_CLASH_Hejret2023": ago2_clash_description,
-    }
-    dataset_label_to_scalar = {
-        "AGO2_CLASH_Hejret2023": {1:1, 0:0},
-    }
-    class_col = "target"
-    for dataset_name in dataset_names_splits.keys():
-        local_dset_path = repo_path / "datasets" / dataset_name
+    names = [dataset] if dataset is not None else list(MIRBENCH_DATASETS.keys())
+
+    for dataset_name in names:
+        info = MIRBENCH_DATASETS[dataset_name]
+        local_dset_path = REPO_PATH / "datasets" / dataset_name
         os.makedirs(local_dset_path, exist_ok=True)
 
         with open(f"{local_dset_path}/dataset_description.md", "w") as f:
-            f.write(dataset_desrciption[dataset_name])
+            f.write(info["description"])
 
         with open(f"{local_dset_path}/dataset_config.json", "w") as f:
             json.dump({"task_type": "classification"}, f, indent=4)
 
-    for dataset_name, splits in dataset_names_splits.items():
-        for split in splits:
-            download_path = repo_path/".miRBench"
+        for split in info["splits"]:
+            download_path = REPO_PATH / ".miRBench"
             os.makedirs(download_path, exist_ok=True)
-            mirbench_download_dataset(dataset_name, download_path=download_path/'miRBench', split=split)
-            df = pd.read_csv(download_path/'miRBench', sep="\t")
-            df = df.rename(columns={"label": class_col})
-            # Keep original target column - 'numeric_label' will be created during preparation
+            mirbench_download_dataset(dataset_name, download_path=download_path / 'miRBench', split=split)
+            df = pd.read_csv(download_path / 'miRBench', sep="\t")
+            df = df.rename(columns={"label": CLASS_COL})
             df.to_csv(f"{local_dset_path}/{split}.csv", index=False)
 
-def generate_genomic_benchmarks_files():
+
+def generate_genomic_benchmarks_files(dataset: str | None = None):
     from genomic_benchmarks.loc2seq import download_dataset
 
+    names = [dataset] if dataset is not None else list(GENOMIC_BENCHMARKS_DATASETS.keys())
 
-    # Description pulled from the genomic benchmarks publication text
-    dataset_description = {
-        "human_enhancers_cohn": "The Human enhancers Cohn dataset was adapted from [BioRxiv. 2018:264200]. Enhancers are genomic regulatory functional elements that can be bound by specific DNA binding proteins so as to regulate the transcription of a particular gene. Unlike promoters, enhancers do not need to be in a close proximity to the affected gene, and may be up to several million bases away, making their detection a difficult task.",
-        "drosophila_enhancers_stark": "The Drosophila enhancers Stark dataset was adapted from [Nature. 2014;512(7512):91–5]. These enhancers were experimentally validated and we excluded the weak ones. Original coordinates referred to the dm3 [2007;316(5831):1625–8] assembly of the D. melanogaster genome. We used pyliftoverFootnote 3 tool to map coordinates to the dm6 assembly [Nucleic Acids Res. 2015;43(D1):690–7]. Negative sequences are randomly generated from drosophila genome dm6 to match lengths of positive sequences and to not overlap them.",
-        "human_enhancers_ensembl":"The Human enhancers Ensembl dataset was constructed from Human enhancers from The FANTOM5 project [Nature. 2014;507(7493):455–61] accessed through the Ensembl database [Nucleic Acids Res. 2021;49(D1):884–91]. Negative sequences have been randomly generated from the Human genome GRCh38 to match the lengths of positive sequences and not overlap them.",
-        "human_nontata_promoters":"The Human non-TATA promoters dataset was adapted from [PLoS ONE. 2017;12(2):0171410]. These sequences are of length 251bp: from -200 to +50bp around transcription start site (TSS). To create non-promoters sequences of length 251bp, the authors of the original paper used random fragments of human genes located after first exons.",
-        "human_ocr_ensembl":"The Human ocr Ensembl dataset was constructed from the Ensembl database [Nucleic Acids Res. 2021;49(D1):884–91]. Positive sequences are Human Open Chromatin Regions (OCRs) from The Ensembl Regulatory Build [Genome Biol. 2015;16(1):1–8]. Open chromatin regions are regions of the genome that can be preferentially accessed by DNA regulatory elements because of their open chromatin structure. In the Ensembl Regulatory Build, this label is assigned to open chromatin regions, which were experimentally observed through DNase-seq, but covered by none of the other annotations (enhancer, promoter, gene, TSS, CTCF, etc.). Negative sequences were generated from the Human genome GRCh38 to match the lengths of positive sequences and not overlap them.",
-        "human_ensembl_regulatory":"The Human regulatory Ensembl dataset was constructed from Ensembl database [Nucleic Acids Res. 2021;49(D1):884–91]. This dataset has three classes: enhancer, promoter and open chromatin region from The Ensembl Regulatory Build [Genome Biol. 2015;16(1):1–8].",
-    }
-    dataset_label_to_scalar = {
-        "human_enhancers_cohn": {"positive": 1, "negative": 0},
-        "drosophila_enhancers_stark": {"positive": 1, "negative": 0},
-        "human_enhancers_ensembl": {"positive": 1, "negative": 0},
-        "human_nontata_promoters": {"positive": 1, "negative": 0},
-        "human_ocr_ensembl": {"positive": 1, "negative": 0},
-        "human_ensembl_regulatory": {"ocr": 1, "enhancer": 0, "promoter": 2},
-    }
+    for dataset_name in names:
+        download_path = download_dataset(
+            dataset_name,
+            dest_path=REPO_PATH / ".genomic_benchmarks",
+            cache_path=REPO_PATH / ".genomic_benchmarks",
+        )
 
-    for dataset_name in dataset_description.keys():
-        repo_path = Path(os.path.abspath(os.path.dirname(__file__))).parent.parent
-
-        download_path = download_dataset(dataset_name, dest_path=repo_path/".genomic_benchmarks", cache_path=repo_path/".genomic_benchmarks")
-
-        local_dset_path = repo_path / "datasets" / dataset_name
-        class_col = "target"
+        local_dset_path = REPO_PATH / "datasets" / dataset_name
         os.makedirs(local_dset_path, exist_ok=True)
 
         with open(f"{local_dset_path}/dataset_description.md", "w") as f:
-            f.write(dataset_description[dataset_name])
+            f.write(GENOMIC_BENCHMARKS_DATASETS[dataset_name])
 
         with open(f"{local_dset_path}/dataset_config.json", "w") as f:
             json.dump({"task_type": "classification"}, f, indent=4)
 
         for split in ["test","train"]:
             data = []
-            for label_path in (download_path/split).iterdir():
+            for label_path in (download_path / split).iterdir():
                 label = label_path.stem
                 for sequence_file in label_path.iterdir():
                     seq = sequence_file.read_text().strip()
-                    data.append({"sequence": seq, class_col: label})
+                    data.append({"sequence": seq, CLASS_COL: label})
             df = pd.DataFrame(data)
-            # Keep original target column - 'numeric_label' will be created during preparation
             df.to_csv(f"{local_dset_path}/{split}.csv", index=False)
 
-def generate_dataset_files():
-    generate_genomic_benchmarks_files()
-    generate_mirbench_files()
+def generate_dataset_files(dataset: str | None = None):
+    if dataset is None:
+        generate_genomic_benchmarks_files()
+        generate_mirbench_files()
+        return
+
+    if dataset in GENOMIC_BENCHMARKS_DATASETS:
+        generate_genomic_benchmarks_files(dataset)
+    elif dataset in MIRBENCH_DATASETS:
+        generate_mirbench_files(dataset)
+    else:
+        available = sorted(GENOMIC_BENCHMARKS_DATASETS.keys() | MIRBENCH_DATASETS.keys())
+        raise ValueError(f"Unknown dataset {dataset!r}. Available: {available}")
 
 if __name__ == "__main__":
-    generate_dataset_files()
+    parser = argparse.ArgumentParser(description="Dataset downloader helper script parser")
+    parser.add_argument("--dataset", help="Name of the dataset to download")
+    args = parser.parse_args()
+
+    generate_dataset_files(args.dataset)

--- a/src/datasets/dataset_utils.py
+++ b/src/datasets/dataset_utils.py
@@ -2,6 +2,7 @@
 import csv
 import json
 import shutil
+import sys
 import pandas as pd
 from pathlib import Path
 from typing import List, Dict
@@ -10,6 +11,7 @@ from rich.console import Console
 from rich.table import Table
 from rich import box
 from utils.config import Config
+
 
 def count_csv_rows(csv_file: str) -> int:
     """
@@ -179,7 +181,7 @@ def auto_detect_target_col(train_df, interactive=False):
             print(f'INFO: Auto-detected target column: {col}')
             return col
 
-    if interactive:
+    if interactive and sys.stdin.isatty():
         console = Console()
         print(f"\nCould not auto-detect target column. Expected one of {possible_target_cols}")
         cols = train_df.columns.tolist()
@@ -220,18 +222,53 @@ def get_classes_integers(config: Config):
     # Sort by numeric value to get consistent ordering
     return sorted(metadata["label_to_scalar"].values())
         
-def auto_detect_task_type(train_df, target_col) :
-    """Auto-detect task type based on target column values"""
-    target_values = train_df[target_col].dropna()
-    unique_values = target_values.nunique()
-    is_numeric = pd.api.types.is_numeric_dtype(target_values)
-    
-    if is_numeric and unique_values > 10:
-        print(f'INFO: Auto-detected regression task (numeric target with {unique_values} unique values)')
-        return 'regression'
-    
-    print(f'INFO: Auto-detected classification task ({unique_values} unique values)')
-    return 'classification'
+def select_task_type(train_df, target_col, interactive=False):
+    if not interactive or not sys.stdin.isatty():
+        if interactive:
+            print(
+                "Dataset preparation requires task type selection, but stdin is not interactive. "
+                "Prepare this dataset with --task-type classification or --task-type regression."
+            )
+        raise ValueError("Task type is required. Pass --task-type classification or --task-type regression.")
+
+    print_target_column_summary(train_df, target_col)
+    Console().print("[bold red]Action needed:[/bold red] Select the task type for this dataset.")
+
+    while True:
+        choice = input("Select task type ([c]lassification/[r]egression): ").strip().lower()
+        if choice in ("c", "class", "classification"):
+            return "classification"
+        if choice in ("r", "reg", "regression"):
+            return "regression"
+        print("Please enter 'classification' or 'regression'.")
+
+def print_target_column_summary(train_df, target_col):
+    target_values = train_df[target_col]
+    non_null_values = target_values.dropna()
+    unique_values = non_null_values.unique()
+    unique_preview = _format_unique_values_preview(unique_values)
+
+    console = Console()
+    console.print(
+        "\n[bold]Target column summary[/bold]\n"
+        f"- Column: [cyan]{target_col}[/cyan] ({target_values.dtype})\n"
+        f"- Unique non-missing values: {len(unique_values):,}\n"
+        f"- Unique labels: {unique_preview}"
+    )
+
+def _format_unique_values_preview(values, limit=20):
+    preview = _format_preview_values(values[:limit])
+    if len(values) > limit:
+        return f"{preview}, ..."
+    return preview
+
+def _format_preview_values(values):
+    formatted_values = []
+    for value in values:
+        if hasattr(value, "item"):
+            value = value.item()
+        formatted_values.append(repr(value))
+    return ", ".join(formatted_values)
 
 def smart_sort_labels(labels):
     """
@@ -341,7 +378,8 @@ def prepare_dataset(dataset_dir, target_col,
                    positive_class, negative_class, task_type, output_dir, test_sets_output_dir, interactive=False):
     """
     Preprocesses dataset files to a format digestable by the agent code. Stores test set files in a separate directory.
-    If target_col and/or task_type is None, it will be auto-detected and printed out
+    If target_col is None, it will be auto-detected or prompted for in interactive mode.
+    If task_type is None, it will be prompted for in interactive mode.
     If positive_class and negative_class are None, they will be auto-detected for binary classification and printed out
     """
     dataset_dir = Path(dataset_dir)
@@ -361,7 +399,7 @@ def prepare_dataset(dataset_dir, target_col,
     if target_col is None:
         target_col = auto_detect_target_col(train_df, interactive=interactive)
     if task_type is None:
-        task_type = auto_detect_task_type(train_df, target_col)
+        task_type = select_task_type(train_df, target_col, interactive=interactive)
 
     if task_type == 'classification':
         label_map = get_label_to_number_map(

--- a/src/datasets/dataset_utils.py
+++ b/src/datasets/dataset_utils.py
@@ -270,6 +270,20 @@ def _format_preview_values(values):
         formatted_values.append(repr(value))
     return ", ".join(formatted_values)
 
+def validate_single_label_classification(train_df, target_col):
+    target_values = train_df[target_col].dropna()
+    for value in target_values:
+        if isinstance(value, (list, set)):
+            raise ValueError(
+                f"Target column '{target_col}' contains multi-label values (e.g., {value!r}). "
+                "Only single-label classification is supported."
+            )
+        if isinstance(value, str) and value.startswith('[') and value.endswith(']'):
+            raise ValueError(
+                f"Target column '{target_col}' appears to contain multi-label values (e.g., {value!r}). "
+                "Only single-label classification is supported."
+            )
+
 def smart_sort_labels(labels):
     """
     Sort labels with semantic sense:
@@ -402,6 +416,7 @@ def prepare_dataset(dataset_dir, target_col,
         task_type = select_task_type(train_df, target_col, interactive=interactive)
 
     if task_type == 'classification':
+        validate_single_label_classification(train_df, target_col)
         label_map = get_label_to_number_map(
             train_df=train_df,
             test_df=test_df,

--- a/src/datasets/dataset_utils.py
+++ b/src/datasets/dataset_utils.py
@@ -389,6 +389,18 @@ def add_id_column(train_df, validation_df=None, test_df=None):
 
     return train_df, validation_df, test_df
 
+def load_dataset_config(dataset_dir: Path) -> dict:
+    config_path = dataset_dir / "dataset_config.json"
+    if not config_path.exists():
+        return {}
+    config = json.loads(config_path.read_text())
+    if "task_type" in config and config["task_type"] not in TaskTypes:
+        raise ValueError(
+            f"Invalid task_type '{config['task_type']}' in {config_path}. "
+            f"Must be one of: {TaskTypes}"
+        )
+    return config
+
 def prepare_dataset(dataset_dir, target_col,
                    positive_class, negative_class, task_type, output_dir, test_sets_output_dir, interactive=False):
     """
@@ -396,10 +408,21 @@ def prepare_dataset(dataset_dir, target_col,
     If target_col is None, it will be auto-detected or prompted for in interactive mode.
     If task_type is None, it will be prompted for in interactive mode.
     If positive_class and negative_class are None, they will be auto-detected for binary classification and printed out
+    CLI args take precedence over dataset_config.json, which takes precedence over auto-detection.
     """
     dataset_dir = Path(dataset_dir)
     output_dir = Path(output_dir)
     test_sets_output_dir = Path(test_sets_output_dir)
+
+    config = load_dataset_config(dataset_dir)
+    if target_col is None:
+        target_col = config.get("target_col")
+    if task_type is None:
+        task_type = config.get("task_type")
+    if positive_class is None:
+        positive_class = config.get("positive_class")
+    if negative_class is None:
+        negative_class = config.get("negative_class")
 
     train = dataset_dir / 'train.csv'
     test = dataset_dir / 'test.csv' if (dataset_dir / 'test.csv').exists() else None

--- a/src/datasets/dataset_utils.py
+++ b/src/datasets/dataset_utils.py
@@ -11,6 +11,7 @@ from rich.console import Console
 from rich.table import Table
 from rich import box
 from utils.config import Config
+from utils.task_types import TaskTypes
 
 
 def count_csv_rows(csv_file: str) -> int:
@@ -214,7 +215,7 @@ def get_numeric_label_col_from_prepared_dataset(prepared_dataset_dir: Path) -> s
 
 def get_classes_integers(config: Config):
     """Get classes integers from the prepared dataset metadata."""
-    if config.task_type != "classification":
+    if config.task_type != TaskTypes.CLASSIFICATION:
         return None
 
     metadata_path = config.prepared_dataset_dir / "metadata.json"
@@ -236,11 +237,11 @@ def select_task_type(train_df, target_col, interactive=False):
 
     while True:
         choice = input("Select task type ([c]lassification/[r]egression): ").strip().lower()
-        if choice in ("c", "class", "classification"):
-            return "classification"
-        if choice in ("r", "reg", "regression"):
-            return "regression"
-        print("Please enter 'classification' or 'regression'.")
+        if choice in ("c", "class", TaskTypes.CLASSIFICATION):
+            return TaskTypes.CLASSIFICATION
+        if choice in ("r", "reg", TaskTypes.REGRESSION):
+            return TaskTypes.REGRESSION
+        print(f"Please enter '{TaskTypes.CLASSIFICATION}' or '{TaskTypes.REGRESSION}'.")
 
 def print_target_column_summary(train_df, target_col):
     target_values = train_df[target_col]
@@ -415,7 +416,7 @@ def prepare_dataset(dataset_dir, target_col,
     if task_type is None:
         task_type = select_task_type(train_df, target_col, interactive=interactive)
 
-    if task_type == 'classification':
+    if task_type == TaskTypes.CLASSIFICATION:
         validate_single_label_classification(train_df, target_col)
         label_map = get_label_to_number_map(
             train_df=train_df,
@@ -440,7 +441,7 @@ def prepare_dataset(dataset_dir, target_col,
     # Generate prepared split CSV files with numeric labels, plus a labelless held-out test file.
     for split_name, df in dataframes:
         try:
-            if task_type == 'classification':
+            if task_type == TaskTypes.CLASSIFICATION:
                 df['numeric_label'] = df[target_col].map(label_map)
             else:
                 df['numeric_label'] = df[target_col]
@@ -472,7 +473,7 @@ def prepare_dataset(dataset_dir, target_col,
             'test_rows': len(test_df) if test_df is not None else 0,
         }
     }
-    if task_type == 'classification':
+    if task_type == TaskTypes.CLASSIFICATION:
         json_safe_label_map = {str(k): int(v) for k, v in label_map.items()}
         meta['label_to_scalar'] = json_safe_label_map
 

--- a/src/datasets/datasets_interactive.py
+++ b/src/datasets/datasets_interactive.py
@@ -2,7 +2,6 @@ import sys
 from typing import List, Dict, Optional
 from rich.console import Console
 from rich.table import Table
-from rich.progress import Progress, SpinnerColumn, TextColumn
 from utils.user_input import get_user_input_for_int
 from datasets.dataset_utils import prepare_dataset, get_all_datasets_info
 
@@ -100,40 +99,34 @@ def prepare_all_datasets(datasets_dir: str, prepared_datasets_dir: str, prepared
     failed_now = 0
 
     for dataset_info in need_preparation:
-        with Progress(
-            SpinnerColumn(),
-            TextColumn("[progress.description]{task.description}"),
-            console=console
-        ) as progress:
-        
-            task = progress.add_task(f"Preparing {dataset_info['name']}", total=None)
-            try:
-                prepare_dataset(
-                    dataset_dir=dataset_info['path'],
-                    target_col=None, #auto-detected inside
-                    positive_class=None, #auto-detected inside
-                    negative_class=None, #auto-detected inside
-                    task_type=None, #auto-detected inside
-                    output_dir=prepared_datasets_dir,
-                    interactive=True,
-                    test_sets_output_dir=prepared_test_sets_dir
-                )
-                success = True
-            except Exception as e:
-                console.print(f"[red]Error preparing dataset '{dataset_info['name']}': {e}[/red]")
-                success = False
-            
-            if success:
-                progress.update(task, description=f"{dataset_info['name']} prepared successfully")
-                prepared_now += 1
-                dataset_info["status"] = "Prepared"
-                dataset_info["is_prepared"] = True
-                dataset_info["can_prepare"] = False
-                dataset_info["should_prepare"] = False
-            else:
-                progress.update(task, description=f"{dataset_info['name']} preparation failed")
-                failed_now += 1
-                dataset_info["status"] = "Failed"
+        console.print(f"[cyan]Preparing {dataset_info['name']}[/cyan]")
+        try:
+            prepare_dataset(
+                dataset_dir=dataset_info['path'],
+                target_col=None, #auto-detected inside
+                positive_class=None, #auto-detected inside
+                negative_class=None, #auto-detected inside
+                task_type=None,
+                output_dir=prepared_datasets_dir,
+                interactive=True,
+                test_sets_output_dir=prepared_test_sets_dir
+            )
+            success = True
+        except Exception as e:
+            console.print(f"[red]Error preparing dataset '{dataset_info['name']}': {e}[/red]")
+            success = False
+
+        if success:
+            console.print(f"[green]{dataset_info['name']} prepared successfully[/green]")
+            prepared_now += 1
+            dataset_info["status"] = "Prepared"
+            dataset_info["is_prepared"] = True
+            dataset_info["can_prepare"] = False
+            dataset_info["should_prepare"] = False
+        else:
+            console.print(f"[red]{dataset_info['name']} preparation failed[/red]")
+            failed_now += 1
+            dataset_info["status"] = "Failed"
             
     console.print("")
     

--- a/src/prepare_datasets.py
+++ b/src/prepare_datasets.py
@@ -1,4 +1,5 @@
 import argparse
+import sys
 from pathlib import Path
 from rich.console import Console
 
@@ -7,11 +8,11 @@ from datasets.datasets_interactive import prepare_all_datasets
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(description="Dataset preparation with auto-detection")
+    parser = argparse.ArgumentParser(description="Dataset preparation")
     parser.add_argument('--dataset-dir', type=Path, help='Single dataset directory to prepare')
-    parser.add_argument('--prepare-all', action='store_true', help='Prepare all datasets in datasets-dir and auto-detect their targets and tasks')
+    parser.add_argument('--prepare-all', action='store_true', help='Prepare all datasets in datasets-dir')
     parser.add_argument('--target-col', type=str, default=None, help='Target column name (auto-detected if not provided)')
-    parser.add_argument('--task-type', choices=['classification', 'regression'], default=None, help='Task type (auto-detected if not provided)')
+    parser.add_argument('--task-type', choices=['classification', 'regression'], default=None, help='Task type (prompted if not provided)')
     parser.add_argument('--positive-class', help='Value used in the label column for a positive class (affects some binary classification metrics). If not provided, numeric labels are assigned based on the label appearance order in the train csv file.', default=None)
     parser.add_argument('--negative-class', help='Value used in the label column for a negative class (affects some binary classification metrics). If not provided, numeric labels are assigned based on the label appearance order in the train csv file.', default=None)
     parser.add_argument('--datasets-dir', default='./datasets', help='Directory containing raw datasets')
@@ -41,7 +42,7 @@ def main():
             prepare_dataset(
                 dataset_dir=dataset_dir,
                 target_col=args.target_col,
-                positive_class=args.positive_class, #is auto-detected inside - do the same for target/task ?
+                positive_class=args.positive_class,
                 negative_class=args.negative_class,
                 task_type=args.task_type,
                 output_dir=prepared_datasets_dir,
@@ -50,6 +51,7 @@ def main():
             console.print(f"[green]Dataset '{dataset_dir.name}' prepared successfully![/green]")
         except Exception as e:
             console.print(f"[red]Dataset '{dataset_dir.name}' preparation failed! {e}[/red]")
+            sys.exit(1)
         
 if __name__ == "__main__":
     main()

--- a/src/prepare_datasets.py
+++ b/src/prepare_datasets.py
@@ -47,7 +47,8 @@ def main():
                 negative_class=args.negative_class,
                 task_type=args.task_type,
                 output_dir=prepared_datasets_dir,
-                test_sets_output_dir=prepared_test_sets_dir
+                test_sets_output_dir=prepared_test_sets_dir,
+                interactive=sys.stdin.isatty(),
             )
             console.print(f"[green]Dataset '{dataset_dir.name}' prepared successfully![/green]")
         except Exception as e:

--- a/src/prepare_datasets.py
+++ b/src/prepare_datasets.py
@@ -5,6 +5,7 @@ from rich.console import Console
 
 from datasets.dataset_utils import prepare_dataset, check_dataset_prepared
 from datasets.datasets_interactive import prepare_all_datasets
+from utils.task_types import TaskTypes
 
 
 def parse_args():
@@ -12,7 +13,7 @@ def parse_args():
     parser.add_argument('--dataset-dir', type=Path, help='Single dataset directory to prepare')
     parser.add_argument('--prepare-all', action='store_true', help='Prepare all datasets in datasets-dir')
     parser.add_argument('--target-col', type=str, default=None, help='Target column name (auto-detected if not provided)')
-    parser.add_argument('--task-type', choices=['classification', 'regression'], default=None, help='Task type (prompted if not provided)')
+    parser.add_argument('--task-type', choices=sorted(TaskTypes), default=None, help='Task type (prompted if not provided)')
     parser.add_argument('--positive-class', help='Value used in the label column for a positive class (affects some binary classification metrics). If not provided, numeric labels are assigned based on the label appearance order in the train csv file.', default=None)
     parser.add_argument('--negative-class', help='Value used in the label column for a negative class (affects some binary classification metrics). If not provided, numeric labels are assigned based on the label appearance order in the train csv file.', default=None)
     parser.add_argument('--datasets-dir', default='./datasets', help='Directory containing raw datasets')

--- a/src/runtime/evaluate_result.py
+++ b/src/runtime/evaluate_result.py
@@ -5,6 +5,7 @@ import sys
 import pandas as pd
 
 from utils.metrics import get_classification_metrics_functions, get_regression_metrics_functions
+from utils.task_types import TaskTypes
 
 
 def get_metrics(
@@ -25,7 +26,7 @@ def get_metrics(
     if len(merged) != len(test):
         print('WARNING: PREDICTIONS LENGTH DOESNT MATCH TEST DATASET')
 
-    if task_type == "classification":
+    if task_type == TaskTypes.CLASSIFICATION:
         return _get_classification_metrics(
             results=results,
             merged=merged,
@@ -33,13 +34,13 @@ def get_metrics(
             pred_col=pred_col,
             prob_col_prefix=prob_col_prefix,
         )
-    if task_type == "regression":
+    if task_type == TaskTypes.REGRESSION:
         return _get_regression_metrics(
             merged=merged,
             numeric_label_col=numeric_label_col,
             pred_col=pred_col,
         )
-    raise ValueError(f"Unknown task_type: {task_type}. Expected 'classification' or 'regression'.")
+    raise ValueError(f"Unknown task_type: {task_type}. Expected one of {TaskTypes}.")
 
 
 def _get_classification_metrics(results, merged, numeric_label_col: str, pred_col: str, prob_col_prefix: str):
@@ -81,7 +82,7 @@ def main():
     parser.add_argument("-t", "--test", required=True, help="Path to the CSV file with labels.")
     parser.add_argument("--pred-col", default="prediction", help="Name of the prediction column in the results file.")
     parser.add_argument("--numeric-label-col", default="numeric_label", help="Name of the numeric label column in the file.")
-    parser.add_argument("--task-type", choices=["classification", "regression"], required=True, help="Type of task: classification or regression.")
+    parser.add_argument("--task-type", choices=sorted(TaskTypes), required=True, help="Type of task: classification or regression.")
 
     args = parser.parse_args()
 

--- a/src/runtime/generate_final_reports.py
+++ b/src/runtime/generate_final_reports.py
@@ -18,6 +18,7 @@ from agents.steps.validation_evaluation import ValidationEvaluationStep
 from runtime.evaluate_result import get_metrics
 from runtime.step_outputs import load_step_output
 from utils.config import Config
+from utils.task_types import TaskTypes
 from runtime.iteration_reports import write_iteration_report
 from runtime.read_write_utils import get_archived_iterations, load_best_iteration_snapshot_iteration, load_config_from_run_dir_and_reroot
 
@@ -260,13 +261,13 @@ def load_prepared_dataset_meta(prepared_datasets_dir: Path, dataset_name: str) -
         raise SystemExit(f"Failed to parse metadata.json: {meta_path} :: {e}")
 
     task_type = str(d.get("task_type", "")).strip().lower()
-    if task_type not in ("classification", "regression"):
+    if task_type not in TaskTypes:
         raise SystemExit(f"Invalid or missing task_type in metadata.json: {task_type!r}")
     numeric_label_col = d.get("numeric_label_col")
     if not numeric_label_col:
         raise SystemExit("metadata.json missing required key: 'numeric_label_col'")
     label_to_scalar = d.get("label_to_scalar")
-    if task_type == "classification":
+    if task_type == TaskTypes.CLASSIFICATION:
         if not isinstance(label_to_scalar, dict) or not label_to_scalar:
             raise SystemExit("classification metadata.json must include non-empty 'label_to_scalar'")
 
@@ -335,7 +336,7 @@ def merge_labels_and_preds(labeled: pd.DataFrame, preds: pd.DataFrame, meta: Dat
     if y_col not in labeled.columns:
         raise ValueError(f"Label column '{y_col}' not found in labeled CSV. Available: {list(labeled.columns)}")
 
-    if meta.task_type == "regression":
+    if meta.task_type == TaskTypes.REGRESSION:
         pred_col = "prediction"
         if pred_col not in preds.columns:
             raise ValueError(f"Expected regression prediction column '{pred_col}'. Available: {list(preds.columns)}")
@@ -506,7 +507,7 @@ def build_plots_for_split(
     prefix = plots_dir / f"iter_{iteration}_{split.split_name}"
     title_prefix = split.split_name.title()
 
-    if meta.task_type == "classification":
+    if meta.task_type == TaskTypes.CLASSIFICATION:
         return plot_classification(y_true, y_pred, prefix, title_prefix)
     return plot_regression(y_true, y_pred, prefix, title_prefix)
 
@@ -609,7 +610,7 @@ def plots_compare_splits_page_flowables(
         return []
 
     task_type = (task_type or "").strip().lower()
-    if task_type == "classification":
+    if task_type == TaskTypes.CLASSIFICATION:
         row_suffixes = ["_roc", "_pr"]
     else:
         row_suffixes = ["_pred_vs_actual", "_residuals_vs_pred", "_residuals_hist"]
@@ -870,7 +871,7 @@ def main() -> None:
     run_meta = load_run_meta(config)
     dataset_meta = load_prepared_dataset_meta(prepared_datasets, config.dataset)
 
-    if run_meta.task_type in ("classification", "regression") and run_meta.task_type != dataset_meta.task_type:
+    if run_meta.task_type in TaskTypes and run_meta.task_type != dataset_meta.task_type:
         print(f"[WARN] task_type mismatch: config={run_meta.task_type} metadata={dataset_meta.task_type}")
 
     iterations = get_archived_iterations(config)

--- a/src/utils/metrics.py
+++ b/src/utils/metrics.py
@@ -3,6 +3,8 @@ from scipy.stats import pearsonr, spearmanr
 import numpy as np
 from typing import Optional
 
+from utils.task_types import TaskTypes
+
 
 class Metric:
     """
@@ -130,8 +132,8 @@ def get_regression_metrics_names():
 
 def get_task_to_metrics_names():
     return {
-        "classification": get_classification_metrics_names(),
-        "regression": get_regression_metrics_names(),
+        TaskTypes.CLASSIFICATION: get_classification_metrics_names(),
+        TaskTypes.REGRESSION: get_regression_metrics_names(),
     }
 
 def get_higher_is_better_map():
@@ -143,11 +145,11 @@ def get_higher_is_better_map():
     return {name: metric.higher_is_better for name, metric in all_metrics.items()}
 
 def get_default_val_metric(task_type: str) -> str:
-    if task_type == "classification":
+    if task_type == TaskTypes.CLASSIFICATION:
         return "AUROC"
-    if task_type == "regression":
+    if task_type == TaskTypes.REGRESSION:
         return "MAE"
-    raise ValueError(f"Unknown task_type: {task_type}. Expected 'classification' or 'regression'.")
+    raise ValueError(f"Unknown task_type: {task_type}. Expected one of {TaskTypes}.")
 
 def resolve_val_metric(task_type: str, val_metric: Optional[str] = None) -> str:
     """Resolve a validation metric for a task, applying defaults when omitted."""
@@ -156,7 +158,7 @@ def resolve_val_metric(task_type: str, val_metric: Optional[str] = None) -> str:
 
     allowed = get_task_to_metrics_names().get(task_type)
     if not allowed:
-        raise ValueError(f"Unknown task_type: {task_type}. Expected 'classification' or 'regression'.")
+        raise ValueError(f"Unknown task_type: {task_type}. Expected one of {TaskTypes}.")
     if val_metric not in allowed:
         raise ValueError(
             f"Validation metric '{val_metric}' is invalid for task type '{task_type}'. "

--- a/src/utils/metrics_interactive.py
+++ b/src/utils/metrics_interactive.py
@@ -3,6 +3,7 @@ from rich.columns import Columns
 from rich.console import Console
 
 from utils.metrics import get_classification_metrics_names, get_regression_metrics_names
+from utils.task_types import TaskTypes
 from utils.user_input import get_user_input_for_int
 
 
@@ -36,11 +37,11 @@ def display_metrics_table(task_type=None):
         console.print(Columns(boxes, padding=(0, 1), expand=False))
         return clf_metrics + reg_metrics
 
-    if task_type == "classification":
+    if task_type == TaskTypes.CLASSIFICATION:
         metrics_to_show = get_classification_metrics_names()
         title = "[bold]Metric for Classification[/bold]"
         border_style = "cyan"
-    elif task_type == "regression":
+    elif task_type == TaskTypes.REGRESSION:
         metrics_to_show = get_regression_metrics_names()
         title = "[bold]Metric for Regression[/bold]"
         border_style = "yellow"

--- a/src/utils/task_types.py
+++ b/src/utils/task_types.py
@@ -1,0 +1,6 @@
+from enum import StrEnum
+
+
+class TaskTypes(StrEnum):
+    CLASSIFICATION = "classification"
+    REGRESSION = "regression"


### PR DESCRIPTION
This PR will:

- Generalize task types to a single enum
- Update python in preparation conda to support StrEnum
- Explicitly inform user multi-label datasets are forbidden
- Stop assuming task type from label values
- Add support for unprepared dataset configs to specify values like task type
- Add prompts for asking task type from the user if not clear

Tests are passing
Note: This PR changes influence the preparation docker image. Reviewer will have to run with --build-images. Before merging, we will have to push the updated preparation docker image to the hub.