### PR TITLE
Add dataset argument when downloading datasets

### DIFF
--- a/scripts/download_example_datasets.sh
+++ b/scripts/download_example_datasets.sh
@@ -3,4 +3,4 @@ REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_DIR" || exit 1
 conda env remove -n agentomics-datasets -y 2>/dev/null || true
 conda env create -f envs/environment_datasets.yaml
-conda run -n agentomics-datasets python src/datasets/create_datasets.py
+conda run -n agentomics-datasets python src/datasets/create_datasets.py "$@"

--- a/src/datasets/create_datasets.py
+++ b/src/datasets/create_datasets.py
@@ -1,98 +1,97 @@
 from pathlib import Path
 import os
-import json
 import pandas as pd
+import argparse
 
-def generate_mirbench_files():
+REPO_PATH = Path(os.path.abspath(os.path.dirname(__file__))).parent.parent
+
+MIRBENCH_DATASETS = {
+    "AGO2_CLASH_Hejret2023": {
+        "splits": ["train", "test"],
+        "description": "The AGO2 Hejret2023 dataset was adapted from [miRBench: novel benchmark datasets for microRNA binding site prediction that mitigate against prevalent microRNA Frequency Class Bias]. This dataset contains microRNA sequences and their corresponding binding sites, as identified via a CLASH (crosslinking, ligation, and sequencing of hybrids) experiment. There are two sequences in this dataset: gene and noncodingRNA. The gene sequences are 50nt fragments including a target site of the noncodingRNA. We expect that the targeting occurs via partial complementarity of the two sequences. Samples with label==1 are target sites retrieved from the CLASH experiment. For each of these positive samples, a negative sample (label==0) is created by matching the same noncodingRNA sequence with a randomly selected gene sequence.",
+    }
+}
+
+# Description pulled from the genomic benchmarks publication text
+GENOMIC_BENCHMARKS_DATASETS = {
+    "human_enhancers_cohn": "The Human enhancers Cohn dataset was adapted from [BioRxiv. 2018:264200]. Enhancers are genomic regulatory functional elements that can be bound by specific DNA binding proteins so as to regulate the transcription of a particular gene. Unlike promoters, enhancers do not need to be in a close proximity to the affected gene, and may be up to several million bases away, making their detection a difficult task.",
+    "drosophila_enhancers_stark": "The Drosophila enhancers Stark dataset was adapted from [Nature. 2014;512(7512):91–5]. These enhancers were experimentally validated and we excluded the weak ones. Original coordinates referred to the dm3 [2007;316(5831):1625–8] assembly of the D. melanogaster genome. We used pyliftoverFootnote 3 tool to map coordinates to the dm6 assembly [Nucleic Acids Res. 2015;43(D1):690–7]. Negative sequences are randomly generated from drosophila genome dm6 to match lengths of positive sequences and to not overlap them.",
+    "human_enhancers_ensembl": "The Human enhancers Ensembl dataset was constructed from Human enhancers from The FANTOM5 project [Nature. 2014;507(7493):455–61] accessed through the Ensembl database [Nucleic Acids Res. 2021;49(D1):884–91]. Negative sequences have been randomly generated from the Human genome GRCh38 to match the lengths of positive sequences and not overlap them.",
+    "human_nontata_promoters": "The Human non-TATA promoters dataset was adapted from [PLoS ONE. 2017;12(2):0171410]. These sequences are of length 251bp: from -200 to +50bp around transcription start site (TSS). To create non-promoters sequences of length 251bp, the authors of the original paper used random fragments of human genes located after first exons.",
+    "human_ocr_ensembl": "The Human ocr Ensembl dataset was constructed from the Ensembl database [Nucleic Acids Res. 2021;49(D1):884–91]. Positive sequences are Human Open Chromatin Regions (OCRs) from The Ensembl Regulatory Build [Genome Biol. 2015;16(1):1–8]. Open chromatin regions are regions of the genome that can be preferentially accessed by DNA regulatory elements because of their open chromatin structure. In the Ensembl Regulatory Build, this label is assigned to open chromatin regions, which were experimentally observed through DNase-seq, but covered by none of the other annotations (enhancer, promoter, gene, TSS, CTCF, etc.). Negative sequences were generated from the Human genome GRCh38 to match the lengths of positive sequences and not overlap them.",
+    "human_ensembl_regulatory": "The Human regulatory Ensembl dataset was constructed from Ensembl database [Nucleic Acids Res. 2021;49(D1):884–91]. This dataset has three classes: enhancer, promoter and open chromatin region from The Ensembl Regulatory Build [Genome Biol. 2015;16(1):1–8]."
+}
+
+CLASS_COL = "target"
+
+
+def generate_mirbench_files(dataset: str | None = None):
     from miRBench.dataset import download_dataset as mirbench_download_dataset
-    repo_path = Path(os.path.abspath(os.path.dirname(__file__))).parent.parent
-    dataset_names_splits = {
-        "AGO2_CLASH_Hejret2023": ["train", "test"],
-    }
 
-    ago2_clash_description = """
-        The AGO2 Hejret2023 dataset was adapted from [miRBench: novel benchmark datasets for microRNA binding site prediction that mitigate against prevalent microRNA Frequency Class Bias]. 
-        This dataset contains microRNA sequences and their corresponding binding sites, as 
-        identified via a CLASH (crosslinking, ligation, and sequencing of hybrids) experiment. 
-        There are two sequences in this dataset: gene and noncodingRNA. 
-        The gene sequences are 50nt fragments including a target site of the noncodingRNA. 
-        We expect that the targeting occurs via partial complementarity of the two sequences.
-        Samples with label==1 are target sites retrieved from the CLASH experiment. 
-        For each of these positive samples, a negative sample (label==0) is created by matching the same 
-        noncodingRNA sequence with a randomly selected gene sequence.
-    """
-    dataset_desrciption = {
-        "AGO2_CLASH_Hejret2023": ago2_clash_description,
-    }
-    dataset_label_to_scalar = {
-        "AGO2_CLASH_Hejret2023": {1:1, 0:0},
-    }
-    class_col = "target"
-    for dataset_name in dataset_names_splits.keys():
-        local_dset_path = repo_path / "datasets" / dataset_name
+    names = [dataset] if dataset is not None else list(MIRBENCH_DATASETS.keys())
+
+    for dataset_name in names:
+        info = MIRBENCH_DATASETS[dataset_name]
+        local_dset_path = REPO_PATH / "datasets" / dataset_name
         os.makedirs(local_dset_path, exist_ok=True)
 
         with open(f"{local_dset_path}/dataset_description.md", "w") as f:
-            f.write(dataset_desrciption[dataset_name])
+            f.write(info["description"])
 
-    for dataset_name, splits in dataset_names_splits.items():
-        for split in splits:
-            download_path = repo_path/".miRBench"
+        for split in info["splits"]:
+            download_path = REPO_PATH / ".miRBench"
             os.makedirs(download_path, exist_ok=True)
-            mirbench_download_dataset(dataset_name, download_path=download_path/'miRBench', split=split)
-            df = pd.read_csv(download_path/'miRBench', sep="\t")
-            df = df.rename(columns={"label": class_col})
-            # Keep original target column - 'numeric_label' will be created during preparation
+            mirbench_download_dataset(dataset_name, download_path=download_path / 'miRBench', split=split)
+            df = pd.read_csv(download_path / 'miRBench', sep="\t")
+            df = df.rename(columns={"label": CLASS_COL})
             df.to_csv(f"{local_dset_path}/{split}.csv", index=False)
 
-def generate_genomic_benchmarks_files():
+
+def generate_genomic_benchmarks_files(dataset: str | None = None):
     from genomic_benchmarks.loc2seq import download_dataset
 
+    names = [dataset] if dataset is not None else list(GENOMIC_BENCHMARKS_DATASETS.keys())
 
-    # Description pulled from the genomic benchmarks publication text
-    dataset_description = {
-        "human_enhancers_cohn": "The Human enhancers Cohn dataset was adapted from [BioRxiv. 2018:264200]. Enhancers are genomic regulatory functional elements that can be bound by specific DNA binding proteins so as to regulate the transcription of a particular gene. Unlike promoters, enhancers do not need to be in a close proximity to the affected gene, and may be up to several million bases away, making their detection a difficult task.",
-        "drosophila_enhancers_stark": "The Drosophila enhancers Stark dataset was adapted from [Nature. 2014;512(7512):91–5]. These enhancers were experimentally validated and we excluded the weak ones. Original coordinates referred to the dm3 [2007;316(5831):1625–8] assembly of the D. melanogaster genome. We used pyliftoverFootnote 3 tool to map coordinates to the dm6 assembly [Nucleic Acids Res. 2015;43(D1):690–7]. Negative sequences are randomly generated from drosophila genome dm6 to match lengths of positive sequences and to not overlap them.",
-        "human_enhancers_ensembl":"The Human enhancers Ensembl dataset was constructed from Human enhancers from The FANTOM5 project [Nature. 2014;507(7493):455–61] accessed through the Ensembl database [Nucleic Acids Res. 2021;49(D1):884–91]. Negative sequences have been randomly generated from the Human genome GRCh38 to match the lengths of positive sequences and not overlap them.",
-        "human_nontata_promoters":"The Human non-TATA promoters dataset was adapted from [PLoS ONE. 2017;12(2):0171410]. These sequences are of length 251bp: from -200 to +50bp around transcription start site (TSS). To create non-promoters sequences of length 251bp, the authors of the original paper used random fragments of human genes located after first exons.",
-        "human_ocr_ensembl":"The Human ocr Ensembl dataset was constructed from the Ensembl database [Nucleic Acids Res. 2021;49(D1):884–91]. Positive sequences are Human Open Chromatin Regions (OCRs) from The Ensembl Regulatory Build [Genome Biol. 2015;16(1):1–8]. Open chromatin regions are regions of the genome that can be preferentially accessed by DNA regulatory elements because of their open chromatin structure. In the Ensembl Regulatory Build, this label is assigned to open chromatin regions, which were experimentally observed through DNase-seq, but covered by none of the other annotations (enhancer, promoter, gene, TSS, CTCF, etc.). Negative sequences were generated from the Human genome GRCh38 to match the lengths of positive sequences and not overlap them.",
-        "human_ensembl_regulatory":"The Human regulatory Ensembl dataset was constructed from Ensembl database [Nucleic Acids Res. 2021;49(D1):884–91]. This dataset has three classes: enhancer, promoter and open chromatin region from The Ensembl Regulatory Build [Genome Biol. 2015;16(1):1–8].",
-    }
-    dataset_label_to_scalar = {
-        "human_enhancers_cohn": {"positive": 1, "negative": 0},
-        "drosophila_enhancers_stark": {"positive": 1, "negative": 0},
-        "human_enhancers_ensembl": {"positive": 1, "negative": 0},
-        "human_nontata_promoters": {"positive": 1, "negative": 0},
-        "human_ocr_ensembl": {"positive": 1, "negative": 0},
-        "human_ensembl_regulatory": {"ocr": 1, "enhancer": 0, "promoter": 2},
-    }
+    for dataset_name in names:
+        download_path = download_dataset(
+            dataset_name,
+            dest_path=REPO_PATH / ".genomic_benchmarks",
+            cache_path=REPO_PATH / ".genomic_benchmarks",
+        )
 
-    for dataset_name in dataset_description.keys():
-        repo_path = Path(os.path.abspath(os.path.dirname(__file__))).parent.parent
-
-        download_path = download_dataset(dataset_name, dest_path=repo_path/".genomic_benchmarks", cache_path=repo_path/".genomic_benchmarks")
-
-        local_dset_path = repo_path / "datasets" / dataset_name
-        class_col = "target"
+        local_dset_path = REPO_PATH / "datasets" / dataset_name
         os.makedirs(local_dset_path, exist_ok=True)
 
         with open(f"{local_dset_path}/dataset_description.md", "w") as f:
-            f.write(dataset_description[dataset_name])
+            f.write(GENOMIC_BENCHMARKS_DATASETS[dataset_name])
 
-        for split in ["test","train"]:
+        for split in ["test", "train"]:
             data = []
-            for label_path in (download_path/split).iterdir():
+            for label_path in (download_path / split).iterdir():
                 label = label_path.stem
                 for sequence_file in label_path.iterdir():
                     seq = sequence_file.read_text().strip()
-                    data.append({"sequence": seq, class_col: label})
+                    data.append({"sequence": seq, CLASS_COL: label})
             df = pd.DataFrame(data)
-            # Keep original target column - 'numeric_label' will be created during preparation
             df.to_csv(f"{local_dset_path}/{split}.csv", index=False)
 
-def generate_dataset_files():
-    generate_genomic_benchmarks_files()
-    generate_mirbench_files()
+def generate_dataset_files(dataset: str | None = None):
+    if dataset is None:
+        generate_genomic_benchmarks_files()
+        generate_mirbench_files()
+        return
+
+    if dataset in GENOMIC_BENCHMARKS_DATASETS:
+        generate_genomic_benchmarks_files(dataset)
+    elif dataset in MIRBENCH_DATASETS:
+        generate_mirbench_files(dataset)
+    else:
+        available = sorted(GENOMIC_BENCHMARKS_DATASETS.keys() | MIRBENCH_DATASETS.keys())
+        raise ValueError(f"Unknown dataset {dataset!r}. Available: {available}")
 
 if __name__ == "__main__":
-    generate_dataset_files()
+    parser = argparse.ArgumentParser(description="Dataset downloader helper script parser")
+    parser.add_argument("--dataset", help="Name of the dataset to download")
+    args = parser.parse_args()
+
+    generate_dataset_files(args.dataset)


### PR DESCRIPTION
This PR will:
- Allow to specify the dataset when using scripts/download_example_datasets.sh
This is done mostly for the agentomics workshop, to speed up the dataset download process