### PR TITLE
Add timeout args to docs

### DIFF
--- a/docs/user-guide/forking.md
+++ b/docs/user-guide/forking.md
@@ -55,6 +55,8 @@ Most run options are **optional** when forking — omitting them reuses the valu
 | `--split-allowed-iterations` | Relative increment if provided; inherited if omitted |
 | `--exploration-iterations` | Relative increment if provided; inherited if omitted |
 | `--run-python-timeout` | Inherited if omitted |
+| `--timeout` | Not inherited — no run timeout unless passed (applies only to the forked run's own runtime) |
+| `--split-timeout` | Not inherited — no split timeout unless passed (applies only to the forked run's own runtime) |
 | `--user-prompt` | Inherited if omitted |
 | `--foundation-models-type` | Inherited if omitted |
 | `--tags` | Inherited if omitted |


### PR DESCRIPTION
This PR will:
- Update the docs to make clear that the timeout and split-timeout args are not inherited from the forked run, but instead they need to be specified if needed for the new run