### PR TITLE
Use images

### DIFF
--- a/scripts/bash_helpers.sh
+++ b/scripts/bash_helpers.sh
@@ -87,7 +87,7 @@ load_string_field_from_run_config() {
     local field_line=""
     local field_value=""
 
-    [[ -f "$config_path" ]] || die "Fork source config not found at $config_path"
+    [[ -f "$config_path" ]] || die "Source config not found at $config_path"
 
     field_line="$(grep -m1 -E "^[[:space:]]*\"${field_name}\"[[:space:]]*:" "$config_path" || true)"
     [[ -n "$field_line" ]] || die "${field_name} is missing from $config_path"
@@ -225,11 +225,28 @@ EOF
 }
 
 ensure_agentomics_docker_image() {
+    # Check the existence of the agentomics docker image. Prioritize locally built images, then dockerhub ones
+    local fm_type="$1"
+    local dockerhub_username="$2"
+    local UPPERCASE_FM_TAG
+    UPPERCASE_FM_TAG="$(echo "${fm_type:-NONE}" | tr '[:lower:]' '[:upper:]')"
+    local dockerhub_img="${dockerhub_username}/agentomics:FM-${UPPERCASE_FM_TAG}-latest"
+
     if docker image inspect agentomics_img >/dev/null 2>&1; then
+        AGENTOMICS_IMAGE="agentomics_img"
+        return
+    fi
+    if docker image inspect "$dockerhub_img" >/dev/null 2>&1; then
+        AGENTOMICS_IMAGE="$dockerhub_img"
+        return
+    fi
+    if docker pull "$dockerhub_img" >/dev/null 2>&1; then
+        AGENTOMICS_IMAGE="$dockerhub_img"
         return
     fi
 
-    warn "Docker image 'agentomics_img' not found. Building it now..."
+    warn "Docker image not found locally or on Dockerhub. Building 'agentomics_img'..."
     [[ -f "Dockerfile" ]] || die "Dockerfile not found in repository root; cannot build 'agentomics_img'."
     docker build -t agentomics_img -f Dockerfile .
+    AGENTOMICS_IMAGE="agentomics_img"
 }

--- a/scripts/inference.sh
+++ b/scripts/inference.sh
@@ -7,6 +7,7 @@ source "$SCRIPT_DIR/bash_helpers.sh"
 DOCKER_MODE=true
 CPU_ONLY=false
 REMOVE_CONDA_ENV=false
+DOCKERHUB_USERNAME="biogemt"
 ARGS=()
 
 show_help() {
@@ -141,7 +142,9 @@ if [[ "$DOCKER_MODE" == true ]]; then
     if ! docker info >/dev/null 2>&1; then
         die "Docker is not running or not accessible (start Docker and retry)"
     fi
-    ensure_agentomics_docker_image
+
+    FOUNDATION_MODEL_TYPE="$(load_string_field_from_run_config "$AGENT_DIR" "foundation_models_type")"
+    ensure_agentomics_docker_image "$FOUNDATION_MODEL_TYPE" "$DOCKERHUB_USERNAME"
 
     AGENT_DIR_ABS="$(cd "$(dirname "$AGENT_DIR")" && pwd)/$(basename "$AGENT_DIR")"
     INPUT_PATH_ABS="$(cd "$(dirname "$INPUT_PATH")" && pwd)/$(basename "$INPUT_PATH")"
@@ -161,7 +164,7 @@ if [[ "$DOCKER_MODE" == true ]]; then
             -v "${AGENT_DIR_ABS}/${CODE_PATH}:${CODE_ROOT_IN_CONTAINER}" \
             --entrypoint "" \
             -w "${CODE_ROOT_IN_CONTAINER}" \
-            agentomics_img \
+            "${AGENTOMICS_IMAGE}" \
             bash -c "conda install -n base mamba -c conda-forge -y && mamba env create -f \"${DESCRIPTOR_PATH_IN_CONTAINER}\" -p \"${CODE_ROOT_IN_CONTAINER}/.conda/envs/${AGENT_NAME}_env\""
     fi
 
@@ -170,7 +173,7 @@ if [[ "$DOCKER_MODE" == true ]]; then
         -v "$(dirname "$INPUT_PATH_ABS"):/input_dir" \
         -v "$NORMALIZE_SCRIPT_ABS:/normalize_dataset.py:ro" \
         --entrypoint "" \
-        agentomics_img \
+        "${AGENTOMICS_IMAGE}" \
         python /normalize_dataset.py --input "/input_dir/$(basename "$INPUT_PATH_ABS")")
     if [[ -n "$NORMALIZED_FILENAME" ]]; then
         trap "rm -f \"$(dirname "$INPUT_PATH_ABS")/$NORMALIZED_FILENAME\"" EXIT
@@ -186,7 +189,7 @@ if [[ "$DOCKER_MODE" == true ]]; then
         --entrypoint "" \
         -w "${INFERENCE_WORKDIR_IN_CONTAINER}" \
         -e PATH="${CODE_ROOT_IN_CONTAINER}/.conda/envs/${AGENT_NAME}_env/bin:$PATH" \
-        agentomics_img \
+        "${AGENTOMICS_IMAGE}" \
         python inference.py \
         --input "/input_dir/$(basename "$INPUT_PATH_ABS")" \
         --output "/output_dir/$(basename "$OUTPUT_PATH_ABS")" \
@@ -221,7 +224,7 @@ if [[ "$REMOVE_CONDA_ENV" == true ]]; then
         docker run --rm \
             -v "${AGENT_DIR_ABS}/${CODE_PATH}:${CODE_ROOT_IN_CONTAINER}" \
             --entrypoint "" \
-            agentomics_img \
+            "${AGENTOMICS_IMAGE}" \
             bash -c "rm -rf ${CODE_ROOT_IN_CONTAINER}/.conda/envs/${AGENT_NAME}_env"
     else
         rm -rf "$ENV_PATH"

--- a/scripts/train.sh
+++ b/scripts/train.sh
@@ -5,6 +5,7 @@ source "$SCRIPT_DIR/bash_helpers.sh"
 
 DOCKER_MODE=true
 CPU_ONLY=false
+DOCKERHUB_USERNAME="biogemt"
 ARGS=()
 
 show_help() {
@@ -142,9 +143,10 @@ if [[ "$DOCKER_MODE" == true ]]; then
     if ! docker info >/dev/null 2>&1; then
         die "Docker is not running or not accessible (start Docker and retry)"
     fi
-    if ! docker image inspect agentomics_img >/dev/null 2>&1; then
-        die "Docker image 'agentomics_img' not found. Run ./run.sh once to build it (or build it manually) and retry."
-    fi
+
+    FOUNDATION_MODEL_TYPE="$(load_string_field_from_run_config "$AGENT_DIR" "foundation_models_type")"
+    ensure_agentomics_docker_image "$FOUNDATION_MODEL_TYPE" "$DOCKERHUB_USERNAME"
+
     echo "Running training in Docker..."
     AGENT_DIR_ABS="$(cd "$(dirname "$AGENT_DIR")" && pwd)/$(basename "$AGENT_DIR")"
     TRAIN_DATA_PATH_ABS="$(cd "$(dirname "$TRAIN_DATA_PATH")" && pwd)/$(basename "$TRAIN_DATA_PATH")"
@@ -160,7 +162,7 @@ if [[ "$DOCKER_MODE" == true ]]; then
             -v "${AGENT_DIR_ABS}/best_iteration_snapshot:${CODE_ROOT_IN_CONTAINER}" \
             --entrypoint "" \
             -w "${CODE_ROOT_IN_CONTAINER}" \
-            agentomics_img \
+            "${AGENTOMICS_IMAGE}" \
             bash -c "conda install -n base mamba -c conda-forge -y && mamba env create -f \"${DESCRIPTOR_PATH_IN_CONTAINER}\" -p \"${CODE_ROOT_IN_CONTAINER}/.conda/envs/${AGENT_NAME}_env\""
     fi
     docker run --rm \
@@ -172,7 +174,7 @@ if [[ "$DOCKER_MODE" == true ]]; then
         --entrypoint "" \
         -w "${TRAIN_WORKDIR_IN_CONTAINER}" \
         -e PATH="${CODE_ROOT_IN_CONTAINER}/.conda/envs/${AGENT_NAME}_env/bin:$PATH" \
-        agentomics_img \
+        "${AGENTOMICS_IMAGE}" \
         python train.py \
         --train-data "/train_data_dir/$(basename "$TRAIN_DATA_PATH_ABS")" \
         --validation-data "/validation_data_dir/$(basename "$VALIDATION_DATA_PATH_ABS")" \


### PR DESCRIPTION
This PR will:
- In inference.sh use by default the already existing pulled images (according to the Foundation Model used). If not existing (e.g the user deletes them), it will repull. If built image exists on system (i.e. the user used --build-images), by default that is the first one to be picked up (assuming if user builds images, it wants to use it)
- Same mechanism for train.sh