### PR TITLE
Make W&B startup non-blocking

### DIFF
--- a/src/agentomics/run_logging/logging_helpers.py
+++ b/src/agentomics/run_logging/logging_helpers.py
@@ -1,19 +1,18 @@
 import math
+import os
 from pathlib import Path
 
 import wandb
-from wandb.errors import AuthenticationError, UsageError
 
 from agentomics.utils.metrics import get_task_to_metrics_names
 from agentomics.utils.config import Config
 
 
 def login_to_wandb(api_key):
-    try:
-        wandb.login(key=api_key, anonymous="allow", timeout=5)
-        return True
-    except (AuthenticationError, UsageError):
+    if not api_key:
         return False
+    os.environ["WANDB_API_KEY"] = api_key
+    return True
 
 def is_wandb_active():
     try:

--- a/src/agentomics/run_logging/wandb_setup.py
+++ b/src/agentomics/run_logging/wandb_setup.py
@@ -1,19 +1,24 @@
-import wandb
 import os
 
+os.environ.setdefault("WANDB_ERROR_REPORTING", "false")
+os.environ.setdefault("WANDB_SILENT", "true")
+os.environ.setdefault("WEAVE_LOG_LEVEL", "ERROR")
+
+import wandb
 from wandb.errors import CommError
 from agentomics.run_logging.logging_helpers import login_to_wandb
 from agentomics.utils.config import Config
 import weave
 
 
+def _is_weave_enabled() -> bool:
+    return os.getenv("AGENTOMICS_ENABLE_WEAVE", "").lower() in {"1", "true", "yes", "on"}
+
+
 def setup_logging(config: Config, dir=None):
     api_key = os.getenv("WANDB_API_KEY")
     wandb_project_name = os.getenv("WANDB_PROJECT_NAME")
     wandb_entity = os.getenv("WANDB_ENTITY")
-
-    os.environ.setdefault("WANDB_SILENT", "true")
-    os.environ.setdefault("WEAVE_LOG_LEVEL", "ERROR")
 
     success = login_to_wandb(api_key)
     if not success:
@@ -28,11 +33,18 @@ def setup_logging(config: Config, dir=None):
             config=vars(config),
             name=config.agent_id,
         )
-        if wandb_entity and wandb_project_name:
+        if wandb_entity and wandb_project_name and _is_weave_enabled():
             weave.init(f"{wandb_entity}/{wandb_project_name}")
+        print(
+            f"W&B initialized: entity={wandb_entity}, "
+            f"project={wandb_project_name}, run_id={wandb.run.id}"
+        )
         return wandb.run.id
     except CommError:
         print("W&B initialization failed - skipping experiment logging")
+        return None
+    except Exception as exc:
+        print(f"W&B initialization failed ({type(exc).__name__}): {exc}")
         return None
 
 def resume_wandb_run(config: Config, dir=None):
@@ -60,4 +72,7 @@ def resume_wandb_run(config: Config, dir=None):
         return run
     except CommError:
         print("W&B login failed - cannot resume logging run")
+        return None
+    except Exception as exc:
+        print(f"W&B resume failed ({type(exc).__name__}): {exc}")
         return None


### PR DESCRIPTION
Replaces the explicit W&B login call with environment-based authentication through `WANDB_API_KEY`, allowing current longer API keys to be used unchanged. W&B initialization and resume failures no longer interrupt Agentomics.

Disables Weave tracing by default. Enable it explicitly with `AGENTOMICS_ENABLE_WEAVE=true`