### PR TITLE
Add automatic evaluation for multiple test splits

### DIFF
--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -20,8 +20,9 @@ cp .env.example .env
 # Edit .env with your values
 ```
 
-The Python launcher forwards exported provider variables and automatically
-passes a `.env` file from the current directory to Docker.
+The Python launchers forward exported variables and automatically pass a
+`.env` file from the current directory to Docker. This applies to both
+`agentomics-run` and `agentomics-inference`.
 
 ## LLM Provider Keys
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -57,13 +57,17 @@ datasets/my_dataset/
 ├── test/               # Optional; hidden from the agent and evaluated afterward
 │   ├── input/
 │   └── labels.csv
+├── test_leftout/       # Optional additional hidden evaluation set
+│   ├── input/
+│   └── labels.csv
 └── dataset_description.md
 ```
 
-The held-out test split is optional. It is not mounted into the agent worker.
-After a successful run, Agentomics starts a separate evaluation container with
-read-only access to the test split, evaluates the best iteration, and includes
-the results in reports. Run training with `--dataset my_dataset`. See
+Held-out test splits are optional. Every top-level directory beginning with
+`test` is withheld from the agent worker. After a successful run, Agentomics
+evaluates the best iteration on each one and records separate output artifacts,
+report sections, and W&B metric namespaces. Run training with
+`--dataset my_dataset`. See
 [Preparing Datasets](../user-guide/datasets.md) for details.
 
 ## Example Datasets

--- a/docs/how-it-works/evaluation.md
+++ b/docs/how-it-works/evaluation.md
@@ -21,15 +21,26 @@ After each iteration:
 3. Compared to previous iterations
 4. Best iteration snapshot updated if improved
 
-## Evaluating on a Held-out Test Set
+## Evaluating on Held-out Test Sets
 
-The agent never sees the held-out `test/` split — it is withheld from the
-agent's mounts. If a dataset includes a co-located `test/` split, `agentomics-run`
-automatically evaluates the best iteration on it **after** the run, in a separate
-read-only evaluation container, and saves the predictions and metrics into the
-best-iteration snapshot (`eval_predictions_test.csv`,
-`eval_predictions_test.metrics.json`). Datasets without a `test/` split simply
-skip this step.
+The agent never sees top-level dataset directories whose names start with
+`test`; they are withheld from the agent's mounts. After a successful run,
+`agentomics-run` automatically evaluates the best iteration on each matching
+split. The conventional `test/` split runs first and additional splits such as
+`test_leftout/` run in alphabetical order.
+
+Each split gets its own best-snapshot artifacts:
+
+```text
+eval_predictions_<split>.csv
+eval_predictions_<split>.numeric_labels.csv
+eval_predictions_<split>.metrics.json
+```
+
+When W&B is configured, metrics are logged to the training run as
+`<split>/<metric>`, for example `test_leftout/AUROC`. A failure on one held-out
+split is reported but does not prevent the remaining splits from running.
+Datasets without a test-prefixed split skip this stage.
 
 To score the finished model on any other labeled set, run inference with
 `--label-col` — metrics are computed by the bundled evaluator and written next to
@@ -161,6 +172,7 @@ Contains:
 If configured, metrics are logged to Weights & Biases:
 
 - Metric plots over iterations
+- Separate final metrics for every test-prefixed split
 - Comparison tables
 - Artifact tracking
 

--- a/docs/reference/workspace-structure.md
+++ b/docs/reference/workspace-structure.md
@@ -35,6 +35,9 @@ datasets/my_dataset/
 ├── test/                   # Optional; hidden from the agent
 │   ├── input/
 │   └── labels.csv
+├── test_leftout/           # Optional additional hidden test split
+│   ├── input/
+│   └── labels.csv
 ├── supplementary/          # Optional: dataset-level source materials
 │   └── README.md           # Optional: describes the supplementary materials
 ├── metadata.json           # Optional if task type is supplied at preparation
@@ -46,8 +49,9 @@ Each unprepared `labels.csv` must include `id` and `label` columns. Your source
 starts, Agentomics copies its public splits into the run workspace and converts
 their labels to `id,numeric_label`. The `input/` interface is recorded at
 preparation time, must match across all splits, and must not be modified during
-a run. The optional source `test/` split is excluded from the agent worker's
-mounts and remains outside the agent-facing prepared data.
+a run. Every source split whose directory name starts with `test` is excluded
+from the agent worker's mounts and remains outside the agent-facing prepared
+data.
 
 The prepared, agent-facing splits are written to the run workspace (never back
 into `datasets/`):
@@ -62,10 +66,10 @@ outputs/<agent_id>/run/shared/splits/split_0/
     └── labels.csv          # id,numeric_label
 ```
 
-After a successful run, Agentomics mounts the optional held-out split read-only
-in a separate evaluation container, runs the best iteration against it, and
-saves its artifacts in the best-iteration snapshot. The source labels remain
-in raw `id,label` form:
+After a successful run, Agentomics evaluates every optional test-prefixed split
+in a separate container, runs the best iteration against it, and saves
+split-specific artifacts in the best-iteration snapshot. The source labels
+remain in raw `id,label` form:
 
 ```text
 datasets/my_dataset/test/
@@ -240,8 +244,8 @@ rm -rf outputs/*
 
 `agentomics-run` launches the container for you. The repository is baked into
 the image; the launcher mounts only the selected dataset's public entries (the
-`test/` split is withheld) and mounts the host workspace at `/workspace` to
-receive the run's output. The agent runs entirely inside the container,
+all test-prefixed splits are withheld) and mounts the host workspace at
+`/workspace` to receive the run's output. The agent runs entirely inside the container,
 isolating execution from the host. See
 [Installation](../getting-started/installation.md).
 

--- a/docs/user-guide/datasets.md
+++ b/docs/user-guide/datasets.md
@@ -18,15 +18,20 @@ datasets/my_dataset/
 ├── test/                   # Optional; held out from the agent
 │   ├── input/
 │   └── labels.csv
+├── test_leftout/           # Optional additional held-out split
+│   ├── input/
+│   └── labels.csv
 ├── supplementary/          # Optional: dataset-level source materials
 ├── metadata.json           # Optional if --task-type is provided
 └── dataset_description.md  # Optional domain context
 ```
 
-The optional `test/` split is stored with the dataset, but is excluded from the
-agent worker's mounts and agent-facing prepared data. After model development,
-Agentomics mounts it read-only in a separate evaluation container, prepares it
-in a temporary directory, and evaluates only the best iteration against it.
+Every top-level directory whose name starts with `test` is a held-out
+evaluation split. These directories are excluded from the agent worker's
+mounts and agent-facing prepared data. After model development, Agentomics
+evaluates the best iteration against each one in a separate container. The
+conventional `test/` split runs first, followed by the remaining names in
+alphabetical order.
 
 ## Split Requirements
 
@@ -104,11 +109,11 @@ be part of the experiment.
 
 The top-level entries in `train/input/` are recorded at dataset preparation
 time and define the split interface. All splits must have matching top-level
-`input/` files and folders: `validation/input/` and `test/input/` are validated
-against `train/input/` during preparation, and the agent cannot add, remove, or
-rename top-level `input/` entries during the split step. Files inside matching
-top-level folders may differ between splits, which supports datasets where each
-split contains different sample files.
+`input/` files and folders: `validation/input/` and every test-prefixed split
+are validated against `train/input/` during preparation, and the agent cannot
+add, remove, or rename top-level `input/` entries during the split step. Files
+inside matching top-level folders may differ between splits, which supports
+datasets where each split contains different sample files.
 
 For per-sample file datasets (images, audio, etc.), place files inside a
 subdirectory rather than directly under `input/`:
@@ -128,11 +133,14 @@ validation/input/cat_03.png          # fails: different top-level files
 If `validation/` is not provided, the agent creates train and validation split
 folders from `train/` during the run.
 
-### test/ Optional
+### test-prefixed splits Optional
 
-The hidden test split is used only for final evaluation. Keep it under
-`datasets/<dataset>/test/`. The run excludes it from the agent-facing prepared
-dataset, then automatically evaluates the best iteration on it after training.
+Hidden test splits are used only for final evaluation. Keep them under the
+dataset directory and start each directory name with `test`, for example
+`test/`, `test_leftout/`, and `test_external_cohort/`. The `test` prefix is
+reserved for this purpose. The run excludes every matching directory from the
+agent-facing prepared dataset, then automatically evaluates the best iteration
+on each one after training.
 
 ### metadata.json Optional
 
@@ -196,7 +204,8 @@ datasets/my_dataset/
 ```
 
 Only these CSV names are auto-detected: `train.csv`, optional `validation.csv`,
-and `test.csv` for hidden test data.
+and `test.csv` for hidden test data. Multiple hidden test sets use the
+folder-based format described above.
 
 For CSV datasets, `metadata.json` should identify the label column and task type:
 
@@ -234,9 +243,8 @@ outputs/<agent_id>/run/shared/splits/split_0/
 ```
 
 The original label values are preserved through `label_to_scalar` in the run
-config. The held-out `test/` split is not part of this prepared data — it is
-excluded from the agent's mounts and prepared separately in a temporary
-directory only for the post-run evaluation.
+config. Held-out test-prefixed splits are not part of this prepared data — they
+are excluded from the agent's mounts and used only for post-run evaluation.
 
 ## Example Datasets
 

--- a/docs/user-guide/inference.md
+++ b/docs/user-guide/inference.md
@@ -38,6 +38,7 @@ agentomics-inference \
 | `--label-col` | Label column in the input **CSV** — when set, metrics are computed against it and written to `<output>.metrics.json`. Ignored for a split folder; there, metrics run only if the folder has a `labels.csv` |
 | `--iteration-dir` | Iteration directory to use, relative to `--agent-dir` (default: `best_iteration_snapshot`) |
 | `--all-iterations` | Run inference for every `run/iteration_N` against `--input` (see below) |
+| `--wandb-prefix` | W&B metric namespace when labels are available (default: input file or directory name) |
 | `--cpu-only` | Run without GPU |
 | `--image` | Docker image to use (default: `biogemt/agentomics:<installed-package-version>`; use this option for an explicit override) |
 | `--help` | Show help message |
@@ -113,6 +114,12 @@ agentomics-inference \
 # -> predictions.csv and predictions.metrics.json
 ```
 
+If `WANDB_API_KEY`, `WANDB_PROJECT_NAME`, and `WANDB_ENTITY` are available and
+the original run has a W&B run ID, those metrics are also appended to that run.
+Use `--wandb-prefix test_external` to log keys such as
+`test_external/AUROC`. Without an explicit prefix, the input file or directory
+name is used. W&B failures warn and do not fail inference.
+
 ## Evaluating Every Iteration
 
 `--all-iterations` runs inference on each `run/iteration_N` snapshot in turn:
@@ -133,7 +140,8 @@ error if every iteration fails.
 Per-iteration predictions are written to `preds/<iteration>_predictions.csv`
 (and `<iteration>_predictions.metrics.json` when `--label-col` is set). Each
 iteration's environment is rebuilt and removed in turn, and a failing iteration
-warns and continues.
+warns and continues. W&B keys include an additional `/iteration_N` namespace
+when `--all-iterations` is used.
 
 ## What's in best_iteration_snapshot
 

--- a/docs/user-guide/outputs.md
+++ b/docs/user-guide/outputs.md
@@ -54,9 +54,12 @@ The most important directory - contains the best-performing iteration's artifact
 | `runtime_info/iteration_metadata.json` | Which iteration produced the snapshot |
 | `runtime_info/environment.yml` | Portable definition of the Conda environment used |
 | `runtime_info/environment.tar.gz` | Packed environment for fast container-local restoration in `full` mode |
-| `eval_predictions_test.csv` | Best-model predictions for the optional test split |
-| `eval_predictions_test.numeric_labels.csv` | Numeric test labels used for metrics |
-| `eval_predictions_test.metrics.json` | Metrics for the optional test split |
+| `eval_predictions_<split>.csv` | Best-model predictions for a test-prefixed split |
+| `eval_predictions_<split>.numeric_labels.csv` | Numeric labels used for that split's metrics |
+| `eval_predictions_<split>.metrics.json` | Metrics for that test-prefixed split |
+
+For example, `test/` produces `eval_predictions_test.*`, while
+`test_leftout/` produces `eval_predictions_test_leftout.*`.
 
 ### Using the Best Model
 
@@ -120,6 +123,7 @@ separate staging area or temporary volume:
 If W&B is configured, you'll also find:
 
 - Experiment tracking at wandb.ai
+- Final held-out metrics under `<split>/<metric>` for every test-prefixed split
 - Agent traces with Weave
 - Metric plots and comparisons
 - Artifact versioning

--- a/src/agentomics/cli/check_dataset.py
+++ b/src/agentomics/cli/check_dataset.py
@@ -58,9 +58,8 @@ def _print_summary(summary: dict, interactive: bool) -> None:
     else:
         console.print("Validation split: not provided (the agent will create one)")
 
-    test_rows = summary.get("test_rows")
-    if test_rows is not None:
-        console.print(f"Test rows: {test_rows}")
+    for split_name, row_count in summary.get("test_splits", {}).items():
+        console.print(f"{split_name} rows: {row_count}")
 
     if "label_to_scalar" in summary:
         console.print(f"Label mapping: {summary['label_to_scalar']}")

--- a/src/agentomics/cli/inference.py
+++ b/src/agentomics/cli/inference.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 from pathlib import Path
 
@@ -38,11 +39,36 @@ def build_parser() -> argparse.ArgumentParser:
         "--all-iterations", action="store_true",
         help="Run every archived iteration",
     )
+    parser.add_argument(
+        "--wandb-prefix",
+        help=(
+            "W&B metric namespace. Defaults to the input file or directory name; "
+            "logging is skipped when W&B is not configured for the run."
+        ),
+    )
     parser.add_argument("--cpu-only", action="store_true", help="Disable GPU access")
     return parser
 
+def _wandb_docker_arguments() -> list[str]:
+    docker_arguments = []
+    env_file = Path.cwd() / ".env"
+    if env_file.is_file():
+        docker_arguments.extend(["--env-file", str(env_file.resolve())])
+    for variable_name in (
+        "WANDB_API_KEY",
+        "WANDB_PROJECT_NAME",
+        "WANDB_ENTITY",
+    ):
+        if variable_name in os.environ:
+            docker_arguments.extend(["-e", variable_name])
+    return docker_arguments
+
 def run_inference_in_docker(arguments: argparse.Namespace) -> None:
     resolve_inference_paths(arguments)
+    wandb_prefix = (
+        getattr(arguments, "wandb_prefix", None)
+        or arguments.input_path.stem
+    )
     container_input = "/inference-input"
     python_arguments = [
         "-m",
@@ -55,6 +81,8 @@ def run_inference_in_docker(arguments: argparse.Namespace) -> None:
         f"/inference-output/{arguments.output.name}",
         "--iteration-dir",
         str(arguments.iteration_dir),
+        "--wandb-prefix",
+        wandb_prefix,
     ]
     if arguments.label_col:
         python_arguments.extend(["--label-col", arguments.label_col])
@@ -72,6 +100,7 @@ def run_inference_in_docker(arguments: argparse.Namespace) -> None:
             f"type=bind,src={arguments.output.parent},dst=/inference-output",
         ],
         python_arguments=python_arguments,
+        docker_arguments=_wandb_docker_arguments(),
     )
 
 def main() -> int:

--- a/src/agentomics/cli/run.py
+++ b/src/agentomics/cli/run.py
@@ -14,7 +14,10 @@ from agentomics.cli.docker_utils import (
 )
 from agentomics.cli.inference import run_inference_in_docker
 from agentomics.cli.run_arguments import add_run_arguments
-from agentomics.datasets.dataset_preparation import prepare_test_dataset
+from agentomics.datasets.dataset_preparation import (
+    discover_test_split_names,
+    prepare_test_dataset,
+)
 from agentomics.datasets.datasets_interactive import (
     get_all_datasets_info,
     interactive_dataset_selection,
@@ -247,8 +250,9 @@ def _run_inference_on_test_input(
     cpu_only: bool,
     workspace_directory: Path,
     test_input: Path,
+    split_name: str,
 ) -> None:
-    print(f"Evaluating the best iteration on {test_input}")
+    print(f"Evaluating the best iteration on {split_name}: {test_input}")
     run_inference_in_docker(
         argparse.Namespace(
             image=image,
@@ -257,12 +261,13 @@ def _run_inference_on_test_input(
             output=(
                 workspace_directory
                 / Config.BEST_ITERATION_SNAPSHOT_DIRNAME
-                / "eval_predictions_test.csv"
+                / f"eval_predictions_{split_name}.csv"
             ),
             label_col=None,
             iteration_dir=Path(Config.BEST_ITERATION_SNAPSHOT_DIRNAME),
             all_iterations=False,
             cpu_only=cpu_only,
+            wandb_prefix=split_name,
         )
     )
 
@@ -273,44 +278,67 @@ def _run_test_evaluation_in_docker(
     workspace_directory: Path,
     dataset_directory: Path,
 ) -> None:
-    test_directory = dataset_directory / "test"
-    if test_directory.is_dir():
-        _run_inference_on_test_input(
-            image, cpu_only, workspace_directory, test_directory
-        )
-        return
-
-    test_csv = dataset_directory / "test.csv"
-    if not test_csv.is_file():
+    split_names = discover_test_split_names(dataset_directory)
+    if not split_names:
         print(
-            f"No test split found at {test_directory} or {test_csv}; "
+            f"No test-prefixed split found in {dataset_directory}; "
             "skipping test evaluation."
         )
         return
 
-    metadata_path = (
-        workspace_directory
-        / "prepared_datasets"
-        / dataset_directory.name
-        / "metadata.json"
-    )
-    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
-    with tempfile.TemporaryDirectory() as temporary_directory:
-        prepared_directory = Path(temporary_directory) / dataset_directory.name
-        prepare_test_dataset(
-            source_dir=dataset_directory,
-            destination_dir=prepared_directory,
-            task_type=metadata["task_type"],
-            input_structure=metadata["input_structure"],
-            label_to_scalar=metadata.get("label_to_scalar"),
-            label_column=metadata.get("label_column"),
-            id_column=metadata.get("id_column"),
-        )
-        _run_inference_on_test_input(
-            image,
-            cpu_only,
-            workspace_directory,
-            prepared_directory / "test",
+    failures = []
+    for split_name in split_names:
+        test_directory = dataset_directory / split_name
+        try:
+            if test_directory.is_dir():
+                _run_inference_on_test_input(
+                    image,
+                    cpu_only,
+                    workspace_directory,
+                    test_directory,
+                    split_name,
+                )
+                continue
+
+            metadata_path = (
+                workspace_directory
+                / "prepared_datasets"
+                / dataset_directory.name
+                / "metadata.json"
+            )
+            metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+            with tempfile.TemporaryDirectory() as temporary_directory:
+                prepared_directory = (
+                    Path(temporary_directory) / dataset_directory.name
+                )
+                prepare_test_dataset(
+                    source_dir=dataset_directory,
+                    destination_dir=prepared_directory,
+                    task_type=metadata["task_type"],
+                    input_structure=metadata["input_structure"],
+                    label_to_scalar=metadata.get("label_to_scalar"),
+                    label_column=metadata.get("label_column"),
+                    id_column=metadata.get("id_column"),
+                    split_name=split_name,
+                )
+                _run_inference_on_test_input(
+                    image,
+                    cpu_only,
+                    workspace_directory,
+                    prepared_directory / split_name,
+                    split_name,
+                )
+        except Exception as error:
+            failures.append(split_name)
+            print(
+                f"Warning: Evaluation failed for {split_name}; continuing: {error}",
+                file=sys.stderr,
+            )
+    if failures:
+        print(
+            f"Test evaluation finished with {len(failures)} failed split(s): "
+            f"{', '.join(failures)}",
+            file=sys.stderr,
         )
 
 

--- a/src/agentomics/datasets/data_contract.py
+++ b/src/agentomics/datasets/data_contract.py
@@ -29,6 +29,9 @@ ALLOWED_PUBLIC_DATASET_ENTRIES = {
 }
 ALLOWED_SPLIT_ENTRIES = {INPUT_DIR_NAME, LABELS_FILE_NAME}
 
+def is_test_split_name(name: str) -> bool:
+    return name.startswith(TEST_SPLIT)
+
 def record_input_dir_structure(input_dir: Path) -> list[str]:
     """
     Returns sorted top-level entries in input_dir. Directories are suffixed with '/'.
@@ -54,12 +57,16 @@ def validate_split_entries(split_path: Path, split_name: str) -> None:
 def validate_public_dataset_entries(dataset_dir: Path) -> None:
     unsupported_entries = sorted(
         item.name for item in dataset_dir.iterdir()
-        if item.name not in ALLOWED_PUBLIC_DATASET_ENTRIES
+        if (
+            item.name not in ALLOWED_PUBLIC_DATASET_ENTRIES
+            and not (item.is_dir() and is_test_split_name(item.name))
+        )
     )
     if unsupported_entries:
         raise ValueError(
             f"Public dataset {dataset_dir.name} has unsupported top-level entries: {unsupported_entries}. "
-            f"Allowed: {sorted(ALLOWED_PUBLIC_DATASET_ENTRIES)}."
+            f"Allowed: {sorted(ALLOWED_PUBLIC_DATASET_ENTRIES)} and directories "
+            f"whose names start with '{TEST_SPLIT}'."
         )
 
 def validate_splits(split_paths: dict[str, Path], expected_input_structure: list[str]) -> None:

--- a/src/agentomics/datasets/dataset_preparation.py
+++ b/src/agentomics/datasets/dataset_preparation.py
@@ -20,6 +20,7 @@ from agentomics.datasets.data_contract import (
     TEST_SPLIT,
     TRAIN_SPLIT,
     VALIDATION_SPLIT,
+    is_test_split_name,
     record_input_dir_structure,
     validate_public_dataset_entries,
     validate_split_entries,
@@ -45,6 +46,21 @@ from agentomics.runtime.filesystem import create_absolute_symlink, find_symlinks
 from agentomics.utils.task_types import TaskTypes
 
 console = Console()
+
+def discover_test_split_names(source_dir: Path) -> list[str]:
+    """Return co-located test split names in deterministic evaluation order."""
+    source_dir = Path(source_dir)
+    split_names = sorted(
+        item.name
+        for item in source_dir.iterdir()
+        if item.is_dir() and is_test_split_name(item.name)
+    )
+    if TEST_SPLIT in split_names:
+        split_names.remove(TEST_SPLIT)
+        split_names.insert(0, TEST_SPLIT)
+    elif is_test_csv_dataset(source_dir):
+        split_names.insert(0, TEST_SPLIT)
+    return split_names
 
 def _reject_symlinks_in_dir(directory: Path) -> None:
     symlinks = find_symlinks_in_dir(directory, include_root=True)
@@ -254,8 +270,8 @@ def check_dataset(source_dir: Path, interactive: bool = False) -> dict:
     Mirrors the preparation a run performs (train/validation, plus the test split
     when present) into a temporary directory that is discarded, so the user's
     dataset is never modified. Returns the prepared train/validation metadata,
-    augmented with ``test_rows`` (the validated test-split row count, or None when
-    no test split is present). Raises ValueError / FileNotFoundError with a
+    augmented with ``test_splits`` (a mapping from every test-prefixed split name
+    to its validated row count). Raises ValueError / FileNotFoundError with a
     descriptive message when the dataset does not satisfy the contract.
     """
     source_dir = Path(source_dir)
@@ -269,22 +285,25 @@ def check_dataset(source_dir: Path, interactive: bool = False) -> dict:
             destination_dir=temporary_root / "prepared",
             interactive=interactive,
         )
-        test_rows = None
-        has_test_split = (source_dir / TEST_SPLIT).is_dir() or is_test_csv_dataset(source_dir)
-        if has_test_split:
+        test_splits = {}
+        for split_name in discover_test_split_names(source_dir):
             test_metadata = prepare_test_dataset(
                 source_dir=source_dir,
-                destination_dir=temporary_root / "prepared_test",
+                destination_dir=temporary_root / f"prepared_{split_name}",
                 task_type=metadata["task_type"],
                 input_structure=metadata["input_structure"],
                 label_to_scalar=metadata.get("label_to_scalar"),
                 label_column=metadata.get("label_column"),
                 id_column=metadata.get("id_column"),
+                split_name=split_name,
             )
-            test_rows = test_metadata["splits"]["test_rows"]
+            test_splits[split_name] = test_metadata["splits"][
+                f"{split_name}_rows"
+            ]
 
     summary = dict(metadata)
-    summary["test_rows"] = test_rows
+    summary["test_splits"] = test_splits
+    summary["test_rows"] = test_splits.get(TEST_SPLIT)
     return summary
 
 
@@ -304,6 +323,7 @@ def prepare_test_dataset(
     label_to_scalar: dict[str, int] | None = None,
     label_column: str | None = None,
     id_column: str | None = None,
+    split_name: str = TEST_SPLIT,
 ) -> dict:
     """Prepare test dataset from source_dir into destination_dir using run metadata.
 
@@ -313,9 +333,17 @@ def prepare_test_dataset(
     """
     source_dir = Path(source_dir)
     destination_dir = Path(destination_dir)
+    if (
+        not is_test_split_name(split_name)
+        or Path(split_name).name != split_name
+    ):
+        raise ValueError(
+            f"Test split name must be a single directory name starting with "
+            f"'{TEST_SPLIT}': {split_name!r}"
+        )
 
     _reject_symlinks_in_dir(source_dir)
-    csv_test_dataset = is_test_csv_dataset(source_dir)
+    csv_test_dataset = split_name == TEST_SPLIT and is_test_csv_dataset(source_dir)
     if csv_test_dataset:
         source_dir = convert_csv_test_dataset_to_standard_raw_dataset(
             source_dir,
@@ -324,33 +352,45 @@ def prepare_test_dataset(
             id_column=id_column,
         )
 
-    test_source = source_dir / TEST_SPLIT
+    test_source = source_dir / split_name
     if not test_source.is_dir():
-        raise FileNotFoundError(f"Required test/ split is missing: {test_source}")
+        raise FileNotFoundError(
+            f"Required {split_name}/ split is missing: {test_source}"
+        )
 
-    validate_split_entries(test_source, TEST_SPLIT)
+    validate_split_entries(test_source, split_name)
 
-    test_labels = load_split_label_dfs({TEST_SPLIT: test_source})
+    test_labels = load_split_label_dfs({split_name: test_source})
 
     if task_type == TaskTypes.CLASSIFICATION:
         if not label_to_scalar:
             raise ValueError("label_to_scalar is required for classification test data preparation")
         validate_single_label_classification(test_labels)
         label_to_scalar = {str(k): int(v) for k, v in label_to_scalar.items()}
-        actual_labels = set(test_labels[TEST_SPLIT][LABEL_COLUMN_NAME].astype(str).unique())
+        actual_labels = set(
+            test_labels[split_name][LABEL_COLUMN_NAME].astype(str).unique()
+        )
         unknown_labels = sorted(actual_labels - set(label_to_scalar))
         if unknown_labels:
             raise ValueError(
-                f"Test split contains labels not present in train: {unknown_labels}. "
+                f"{split_name} split contains labels not present in train: "
+                f"{unknown_labels}. "
                 f"Known labels: {sorted(label_to_scalar)}"
             )
-        numeric_labels = convert_classification_labels(test_labels[TEST_SPLIT], label_to_scalar, TEST_SPLIT)
+        numeric_labels = convert_classification_labels(
+            test_labels[split_name],
+            label_to_scalar,
+            split_name,
+        )
     elif task_type == TaskTypes.REGRESSION:
-        numeric_labels = convert_regression_labels(test_labels[TEST_SPLIT], TEST_SPLIT)
+        numeric_labels = convert_regression_labels(
+            test_labels[split_name],
+            split_name,
+        )
     else:
         raise ValueError(f"Unknown task_type: {task_type}. Expected one of {TaskTypes}.")
 
-    dest_test = destination_dir / TEST_SPLIT
+    dest_test = destination_dir / split_name
     dest_test.mkdir(parents=True, exist_ok=True)
     if csv_test_dataset:
         shutil.copytree(test_source / INPUT_DIR_NAME, dest_test / INPUT_DIR_NAME)
@@ -361,11 +401,11 @@ def prepare_test_dataset(
         )
     numeric_labels.to_csv(dest_test / LABELS_FILE_NAME, index=False)
 
-    validate_splits({TEST_SPLIT: dest_test}, input_structure)
+    validate_splits({split_name: dest_test}, input_structure)
 
     test_metadata = {
         "task_type": task_type,
-        "splits": {"test_rows": len(test_labels[TEST_SPLIT])},
+        "splits": {f"{split_name}_rows": len(test_labels[split_name])},
         "numeric_label_col": NUMERIC_LABEL_COLUMN_NAME,
         "input_structure": input_structure,
         "prepared": True,

--- a/src/agentomics/runtime/generate_final_reports.py
+++ b/src/agentomics/runtime/generate_final_reports.py
@@ -37,11 +37,20 @@ from reportlab.platypus import (
 )
 from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
 
-from agentomics.datasets.data_contract import LABELS_FILE_NAME, NUMERIC_LABEL_COLUMN_NAME, TRAIN_SPLIT, VALIDATION_SPLIT
+from agentomics.datasets.data_contract import (
+    LABELS_FILE_NAME,
+    NUMERIC_LABEL_COLUMN_NAME,
+    TEST_SPLIT,
+    TRAIN_SPLIT,
+    VALIDATION_SPLIT,
+)
 
-TEST_PREDICTIONS_FILENAME = "eval_predictions_test.csv"
-TEST_NUMERIC_LABELS_FILENAME = "eval_predictions_test.numeric_labels.csv"
-TEST_METRICS_FILENAME = "eval_predictions_test.metrics.json"
+TEST_ARTIFACT_PREFIX = "eval_predictions_"
+TEST_ARTIFACT_SUFFIXES = (
+    ".numeric_labels.csv",
+    ".metrics.json",
+    ".csv",
+)
 
 
 # Data models
@@ -263,6 +272,23 @@ def _get_iteration_split_version(config: Config, iter_dir: Path) -> int | None:
     data_split_output = load_step_output(config, "data_split", iter_dir)
     return getattr(data_split_output, "split_version", None)
 
+def discover_test_artifact_split_names(snapshot_dir: Path) -> list[str]:
+    split_names = set()
+    for artifact_path in Path(snapshot_dir).glob(f"{TEST_ARTIFACT_PREFIX}{TEST_SPLIT}*"):
+        artifact_name = artifact_path.name
+        for suffix in TEST_ARTIFACT_SUFFIXES:
+            if artifact_name.endswith(suffix):
+                split_name = artifact_name[
+                    len(TEST_ARTIFACT_PREFIX):-len(suffix)
+                ]
+                if split_name.startswith(TEST_SPLIT):
+                    split_names.add(split_name)
+                break
+    return sorted(
+        split_names,
+        key=lambda split_name: (split_name != TEST_SPLIT, split_name),
+    )
+
 def gather_iteration_inputs(
     config: Config,
     iteration: int,
@@ -290,11 +316,21 @@ def gather_iteration_inputs(
     best_iter = load_best_iteration_snapshot_iteration(config)
     if best_iter is not None and iteration == best_iter:
         snapshot_dir = config.best_iteration_snapshot_dir
-        test_preds = snapshot_dir / TEST_PREDICTIONS_FILENAME
-        test_labeled = snapshot_dir / TEST_NUMERIC_LABELS_FILENAME
-        test_metrics = load_saved_metrics(snapshot_dir / TEST_METRICS_FILENAME)
-        if test_preds.exists() or test_labeled.exists() or bool(test_metrics):
-            splits.append(SplitArtifacts("test", test_labeled, test_preds, test_metrics))
+        for split_name in discover_test_artifact_split_names(snapshot_dir):
+            artifact_stem = f"{TEST_ARTIFACT_PREFIX}{split_name}"
+            test_preds = snapshot_dir / f"{artifact_stem}.csv"
+            test_labeled = snapshot_dir / f"{artifact_stem}.numeric_labels.csv"
+            test_metrics = load_saved_metrics(
+                snapshot_dir / f"{artifact_stem}.metrics.json"
+            )
+            splits.append(
+                SplitArtifacts(
+                    split_name,
+                    test_labeled,
+                    test_preds,
+                    test_metrics,
+                )
+            )
 
     return IterationInputs(iteration=iteration, report_md=report_md, splits=splits)
 
@@ -846,7 +882,11 @@ def main() -> None:
     ensure_dir(out_dir)
     ensure_dir(plots_dir)
     config.markdown_reports_dir.mkdir(parents=True, exist_ok=True)
-    split_order = ["train", "validation", "test"]
+    split_order = [
+        "train",
+        "validation",
+        *discover_test_artifact_split_names(config.best_iteration_snapshot_dir),
+    ]
 
     for it in iterations:
         inp = gather_iteration_inputs(config, it)
@@ -855,7 +895,7 @@ def main() -> None:
             report_metrics = {
                 f"{split.split_name}/{metric_name}": metric_value
                 for split in inp.splits
-                if split.split_name != "test"
+                if not split.split_name.startswith(TEST_SPLIT)
                 for metric_name, metric_value in split.metrics.items()
             }
             test_metrics = next((split.metrics for split in inp.splits if split.split_name == "test"), None)

--- a/src/agentomics/runtime/inference_workflow.py
+++ b/src/agentomics/runtime/inference_workflow.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import sys
@@ -19,6 +20,10 @@ from agentomics.runtime.filesystem import (
     restore_host_ownership,
 )
 from agentomics.runtime.inference_runner import run_inference_script
+from agentomics.runtime.read_write_utils import (
+    load_config_from_run_dir_and_reroot,
+)
+from agentomics.run_logging.env_utils import are_wandb_vars_available
 from agentomics.utils.config import Config
 
 
@@ -59,6 +64,55 @@ def _compute_metrics(agent_dir: Path, input_split: Path, output_path: Path) -> P
     print("Computing metrics...")
     evaluate_predictions(agent_dir, output_path, labels_path, metrics_path)
     return metrics_path
+
+def _log_metrics_to_wandb(
+    agent_dir: Path,
+    metrics_path: Path | None,
+    prefix: str | None,
+) -> bool:
+    if metrics_path is None or not prefix or not are_wandb_vars_available():
+        return False
+
+    wandb_run = None
+    try:
+        from agentomics.run_logging.wandb_setup import resume_wandb_run
+
+        config = load_config_from_run_dir_and_reroot(
+            Path(agent_dir) / Config.RUN_DIRNAME
+        )
+        wandb_run = resume_wandb_run(
+            config,
+            dir=Path(tempfile.gettempdir()) / "agentomics_inference_wandb_logs",
+        )
+        if wandb_run is None:
+            return False
+
+        metrics = json.loads(Path(metrics_path).read_text(encoding="utf-8"))
+        if not isinstance(metrics, dict):
+            raise ValueError(f"Expected JSON object at {metrics_path}")
+        wandb_run.log(
+            {
+                f"{prefix}/{metric_name}": metric_value
+                for metric_name, metric_value in metrics.items()
+            }
+        )
+        print(f"Logged metrics to W&B under prefix '{prefix}'")
+        return True
+    except Exception as error:
+        print(
+            f"Warning: W&B inference logging failed; continuing: {error}",
+            file=sys.stderr,
+        )
+        return False
+    finally:
+        if wandb_run is not None:
+            try:
+                wandb_run.finish()
+            except Exception as error:
+                print(
+                    f"Warning: W&B inference cleanup failed: {error}",
+                    file=sys.stderr,
+                )
 
 def _run_single_inference(arguments: Namespace) -> None:
     iteration_root = resolve_iteration_root(arguments.agent_dir, arguments.iteration_dir)
@@ -103,6 +157,11 @@ def _run_single_inference(arguments: Namespace) -> None:
             )
         print("Inference done")
         metrics_path = _compute_metrics(arguments.agent_dir, input_split, arguments.output)
+        _log_metrics_to_wandb(
+            arguments.agent_dir,
+            metrics_path,
+            getattr(arguments, "wandb_prefix", None),
+        )
         restore_host_ownership(arguments.output)
         if metrics_path is not None:
             restore_host_ownership(metrics_path)
@@ -135,6 +194,10 @@ def _run_all_iterations(arguments: Namespace) -> None:
             iteration_arguments = Namespace(**vars(arguments))
             iteration_arguments.iteration_dir = Path(Config.RUN_DIRNAME) / iteration_name
             iteration_arguments.output = arguments.output.parent / f"{iteration_name}_predictions.csv"
+            if arguments.wandb_prefix:
+                iteration_arguments.wandb_prefix = (
+                    f"{arguments.wandb_prefix}/{iteration_name}"
+                )
             _run_single_inference(iteration_arguments)
             successful_iterations += 1
         except Exception as error:

--- a/test/test_best_iteration_snapshot_and_splits.py
+++ b/test/test_best_iteration_snapshot_and_splits.py
@@ -505,6 +505,34 @@ class TestFinalReportSplitLabels(unittest.TestCase):
         self.assertEqual(snapshot_dir / "eval_predictions_test.csv", test_split.preds_csv)
         self.assertEqual({"ACC": 1.0}, test_split.metrics)
 
+    def test_iteration_inputs_include_multiple_test_artifact_namespaces(self):
+        snapshot_dir = self.config.best_iteration_snapshot_dir
+        (snapshot_dir / Config.RUNTIME_INFO_DIRNAME).mkdir(parents=True, exist_ok=True)
+        (snapshot_dir / Config.RUNTIME_INFO_DIRNAME / Config.ITERATION_METADATA_FILENAME).write_text(
+            json.dumps({"iteration": 0}), encoding="utf-8"
+        )
+        for split_name, accuracy in [
+            ("test_leftout", 0.75),
+            ("test", 1.0),
+        ]:
+            (snapshot_dir / f"eval_predictions_{split_name}.csv").write_text(
+                "id,prediction,probability_1\nt-0,1,0.9\n", encoding="utf-8"
+            )
+            (snapshot_dir / f"eval_predictions_{split_name}.numeric_labels.csv").write_text(
+                "id,numeric_label\nt-0,1\n", encoding="utf-8"
+            )
+            (snapshot_dir / f"eval_predictions_{split_name}.metrics.json").write_text(
+                json.dumps({"ACC": accuracy}), encoding="utf-8"
+            )
+
+        inputs = gather_iteration_inputs(config=self.config, iteration=0)
+
+        test_splits = [
+            split for split in inputs.splits if split.split_name.startswith("test")
+        ]
+        self.assertEqual(["test", "test_leftout"], [split.split_name for split in test_splits])
+        self.assertEqual({"ACC": 0.75}, test_splits[1].metrics)
+
 
 class TestSplitSymlinkHelpers(unittest.TestCase):
 

--- a/test/test_dataset_preparation_publishing.py
+++ b/test/test_dataset_preparation_publishing.py
@@ -9,7 +9,13 @@ SRC_PATH = REPO_ROOT / "src"
 if str(SRC_PATH) not in sys.path:
     sys.path.insert(0, str(SRC_PATH))
 
-from agentomics.datasets.dataset_preparation import check_dataset_prepared, prepare_dataset, prepare_test_dataset
+from agentomics.datasets.dataset_preparation import (
+    check_dataset,
+    check_dataset_prepared,
+    discover_test_split_names,
+    prepare_dataset,
+    prepare_test_dataset,
+)
 
 DATASET_NAME = "publishing_dataset"
 
@@ -85,13 +91,52 @@ class DatasetPreparationPublishingTests(unittest.TestCase):
 
     def test_colocated_test_split_is_allowed_and_ignored_by_training_prep(self):
         write_raw_split(self.dataset_dir, "test")
+        write_raw_split(self.dataset_dir, "test_leftout")
 
         self.prepare()
 
-        # test/ is permitted inside the dataset folder but is not part of the
-        # prepared training output (it is prepared separately at eval time).
+        # test-prefixed folders are permitted inside the dataset folder but are
+        # not part of the prepared training output.
         self.assertTrue(check_dataset_prepared(self.prepared_dir))
         self.assertFalse((self.prepared_dir / "test").exists())
+        self.assertFalse((self.prepared_dir / "test_leftout").exists())
+
+    def test_discovers_all_test_prefixed_split_directories_in_stable_order(self):
+        for split_name in ["test_z", "testing", "test", "test_a"]:
+            write_raw_split(self.dataset_dir, split_name)
+
+        self.assertEqual(
+            ["test", "test_a", "test_z", "testing"],
+            discover_test_split_names(self.dataset_dir),
+        )
+
+    def test_named_test_split_is_prepared_using_training_metadata(self):
+        write_raw_split(self.dataset_dir, "test_leftout")
+        train_metadata = self.prepare()
+
+        test_metadata = prepare_test_dataset(
+            source_dir=self.dataset_dir,
+            destination_dir=self.prepared_test_dir,
+            task_type=train_metadata["task_type"],
+            input_structure=train_metadata["input_structure"],
+            label_to_scalar=train_metadata.get("label_to_scalar"),
+            split_name="test_leftout",
+        )
+
+        labels_path = self.prepared_test_dir / "test_leftout" / "labels.csv"
+        self.assertTrue(labels_path.is_file())
+        self.assertEqual(2, test_metadata["splits"]["test_leftout_rows"])
+
+    def test_dataset_check_validates_and_reports_every_test_split(self):
+        write_raw_split(self.dataset_dir, "test")
+        write_raw_split(self.dataset_dir, "test_leftout")
+
+        summary = check_dataset(self.dataset_dir)
+
+        self.assertEqual(
+            {"test": 2, "test_leftout": 2},
+            summary["test_splits"],
+        )
 
     def test_symlinked_public_dataset_is_rejected_with_actionable_error(self):
         external_file = self.root / "external_reference.txt"

--- a/test/test_inference_wandb_logging.py
+++ b/test/test_inference_wandb_logging.py
@@ -1,0 +1,99 @@
+import json
+import sys
+import types
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import Mock, patch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_PATH = REPO_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+from agentomics.runtime.inference_workflow import _log_metrics_to_wandb
+
+
+class InferenceWandbLoggingTest(unittest.TestCase):
+    def test_metrics_are_logged_under_the_test_split_prefix(self):
+        with TemporaryDirectory() as tmp:
+            agent_dir = Path(tmp)
+            metrics_path = agent_dir / "predictions.metrics.json"
+            metrics_path.write_text(
+                json.dumps({"ACC": 0.75, "F1": 0.8}),
+                encoding="utf-8",
+            )
+            wandb_run = Mock()
+            resume_wandb_run = Mock(return_value=wandb_run)
+            fake_wandb_setup = types.ModuleType(
+                "agentomics.run_logging.wandb_setup"
+            )
+            fake_wandb_setup.resume_wandb_run = resume_wandb_run
+
+            with (
+                patch.dict(
+                    sys.modules,
+                    {"agentomics.run_logging.wandb_setup": fake_wandb_setup},
+                ),
+                patch(
+                    "agentomics.runtime.inference_workflow.are_wandb_vars_available",
+                    return_value=True,
+                ),
+                patch(
+                    "agentomics.runtime.inference_workflow.load_config_from_run_dir_and_reroot",
+                    return_value=Mock(),
+                ),
+            ):
+                logged = _log_metrics_to_wandb(
+                    agent_dir=agent_dir,
+                    metrics_path=metrics_path,
+                    prefix="test_leftout",
+                )
+
+        self.assertTrue(logged)
+        wandb_run.log.assert_called_once_with(
+            {
+                "test_leftout/ACC": 0.75,
+                "test_leftout/F1": 0.8,
+            }
+        )
+        wandb_run.finish.assert_called_once_with()
+
+    def test_logging_failure_does_not_interrupt_inference(self):
+        with TemporaryDirectory() as tmp:
+            agent_dir = Path(tmp)
+            metrics_path = agent_dir / "predictions.metrics.json"
+            metrics_path.write_text(json.dumps({"ACC": 0.75}), encoding="utf-8")
+            fake_wandb_setup = types.ModuleType(
+                "agentomics.run_logging.wandb_setup"
+            )
+            fake_wandb_setup.resume_wandb_run = Mock(
+                side_effect=RuntimeError("network unavailable")
+            )
+
+            with (
+                patch.dict(
+                    sys.modules,
+                    {"agentomics.run_logging.wandb_setup": fake_wandb_setup},
+                ),
+                patch(
+                    "agentomics.runtime.inference_workflow.are_wandb_vars_available",
+                    return_value=True,
+                ),
+                patch(
+                    "agentomics.runtime.inference_workflow.load_config_from_run_dir_and_reroot",
+                    return_value=Mock(),
+                ),
+            ):
+                logged = _log_metrics_to_wandb(
+                    agent_dir=agent_dir,
+                    metrics_path=metrics_path,
+                    prefix="test",
+                )
+
+        self.assertFalse(logged)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_run_launcher_container_contract.py
+++ b/test/test_run_launcher_container_contract.py
@@ -2,6 +2,7 @@ import sys
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import call, patch
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SRC_PATH = REPO_ROOT / "src"
@@ -12,6 +13,7 @@ from agentomics.cli.run import (  # noqa: E402
     CONTAINER_DATASETS_DIRECTORY,
     PUBLIC_DATASET_ENTRY_NAMES,
     _build_dataset_mounts,
+    _run_test_evaluation_in_docker,
 )
 
 RUN_LAUNCHER = REPO_ROOT / "src" / "agentomics" / "cli" / "run.py"
@@ -46,14 +48,14 @@ class RunLauncherSourceContractTest(unittest.TestCase):
     def test_launcher_invokes_container_workflow(self):
         self.assertIn("agentomics.runtime.run_workflow", self.launcher)
 
-    def test_test_evaluation_reuses_inference_on_co_located_split(self):
+    def test_test_evaluation_reuses_inference_on_co_located_splits(self):
         # The old separate hidden-test tree and flag are gone; evaluation runs
-        # the best model on the dataset's own ``test`` split via inference.
+        # the best model on every test-prefixed split via inference.
         self.assertNotIn("test_datasets", self.launcher)
         self.assertNotIn("--test-datasets-dir", self.launcher)
-        self.assertIn('dataset_directory / "test"', self.launcher)
+        self.assertIn("discover_test_split_names", self.launcher)
         self.assertIn("run_inference_in_docker", self.launcher)
-        self.assertIn('"eval_predictions_test.csv"', self.launcher)
+        self.assertIn('f"eval_predictions_{split_name}.csv"', self.launcher)
         self.assertIn("agentomics.runtime.report_workflow", self.launcher)
 
     def test_help_text_has_no_prepared_datasets_user_concept(self):
@@ -94,7 +96,9 @@ class DatasetMountContractTest(unittest.TestCase):
         self.assertNotIn("test", PUBLIC_DATASET_ENTRY_NAMES)
         self.assertNotIn("test.csv", PUBLIC_DATASET_ENTRY_NAMES)
 
-        mounts = self._mounts_for(["train", "validation", "test", "test.csv"])
+        mounts = self._mounts_for(
+            ["train", "validation", "test", "test_leftout", "test.csv"]
+        )
         for mount in mounts:
             self.assertNotIn("/example_dataset/test", mount)
 
@@ -109,6 +113,56 @@ class DatasetMountContractTest(unittest.TestCase):
             with self.assertRaises(ValueError) as raised:
                 _build_dataset_mounts(dataset_dir)
             self.assertIn("symlink", str(raised.exception).lower())
+
+
+class MultipleTestEvaluationContractTest(unittest.TestCase):
+    @patch("agentomics.cli.run._run_inference_on_test_input")
+    def test_all_test_prefixed_directories_are_evaluated_in_stable_order(
+        self,
+        run_inference,
+    ):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            dataset_dir = root / "dataset"
+            workspace_dir = root / "workspace"
+            dataset_dir.mkdir()
+            workspace_dir.mkdir()
+            for split_name in ["test_z", "test", "test_a"]:
+                (dataset_dir / split_name).mkdir()
+
+            _run_test_evaluation_in_docker(
+                image="agentomics:test",
+                cpu_only=True,
+                workspace_directory=workspace_dir,
+                dataset_directory=dataset_dir,
+            )
+
+        self.assertEqual(
+            [
+                call(
+                    "agentomics:test",
+                    True,
+                    workspace_dir,
+                    dataset_dir / "test",
+                    "test",
+                ),
+                call(
+                    "agentomics:test",
+                    True,
+                    workspace_dir,
+                    dataset_dir / "test_a",
+                    "test_a",
+                ),
+                call(
+                    "agentomics:test",
+                    True,
+                    workspace_dir,
+                    dataset_dir / "test_z",
+                    "test_z",
+                ),
+            ],
+            run_inference.call_args_list,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Treat every top-level dataset directory whose name starts with `test` as a hidden held-out split.
- Keep all matching splits outside the training agent's Docker mounts.
- Evaluate the best iteration automatically on `test` first, followed by the remaining matching splits in alphabetical order.
- Write split-specific predictions, numeric labels, and metric files as `eval_predictions_<split>.*` and include them in final reports.
- Append inference metrics to the existing W&B run under `<split>/<metric>` namespaces when W&B is configured.
- Add `agentomics-inference --wandb-prefix`, defaulting to the input file or directory name.
- Update dataset validation, CLI output, and user documentation for the multiple-test contract.

## Why

The current refactored workflow supports only one co-located `test` split. Experiments with many held-out cohorts would otherwise require repeated manual `agentomics-inference` calls and would not consistently attach their metrics to the training W&B run. This restores the focused multiple-test capability from the old #132 design without bringing over its unrelated changes.

## Behavior

A folder layout such as:

```text
datasets/my_dataset/
├── train/
├── validation/
├── test/
├── test_leftout/
└── test_external_cohort/
```

produces independent `test/*`, `test_leftout/*`, and `test_external_cohort/*` W&B metric namespaces and matching best-snapshot artifacts. A failure on one held-out split warns and does not stop the remaining evaluations. The existing single `test.csv` path remains supported; multiple test sets use the folder contract.

## Validation

- 50 relevant unit and integration tests passed inside `biogemt/agentomics:1.0.2`.
- `python -m compileall` and `git diff --check` passed.
- `/SCRATCH/dtzim01/manakov_phact_ag_ready` passed `agentomics-check-dataset` with 2,495,535 train rows and 324,171 test rows.

## Related

W&B run resumption uses the existing logging helper and is designed to compose with the nonblocking W&B initialization changes in #137.