### PR TITLE
multiple test sets

### DIFF
--- a/docs/how-it-works/evaluation.md
+++ b/docs/how-it-works/evaluation.md
@@ -21,15 +21,17 @@ After each iteration:
 3. Compared to previous iterations
 4. Best iteration snapshot updated if improved
 
-## Evaluating on a Held-out Test Set
+## Evaluating on Held-out Test Sets
 
-The agent never sees the held-out `test/` split — it is withheld from the
-agent's mounts. If a dataset includes a co-located `test/` split, `agentomics-run`
-automatically evaluates the best iteration on it **after** the run, in a separate
-read-only evaluation container, and saves the predictions and metrics into the
-best-iteration snapshot (`eval_predictions_test.csv`,
-`eval_predictions_test.metrics.json`). Datasets without a `test/` split simply
-skip this step.
+The agent never sees held-out `test*` splits — they are withheld from the
+agent's mounts. `agentomics-run` automatically evaluates the best iteration on
+every co-located directory whose name starts with `test` **after** the run, in a
+separate read-only evaluation container. Predictions and metrics are saved as
+`eval_predictions_<test_split>.csv` and
+`eval_predictions_<test_split>.metrics.json`, logged to W&B when configured,
+and included in the final PDF report. The flat-dataset `test.csv` format remains
+supported as a single `test` split. Datasets without test data simply skip this
+step.
 
 To score the finished model on any other labeled set, run inference with
 `--label-col` — metrics are computed by the bundled evaluator and written next to

--- a/docs/how-it-works/evaluation.md
+++ b/docs/how-it-works/evaluation.md
@@ -23,8 +23,9 @@ After each iteration:
 
 ## Evaluating on Held-out Test Sets
 
-The agent never sees held-out `test*` splits — they are withheld from the
-agent's mounts. `agentomics-run` automatically evaluates the best iteration on
+The agent never sees held-out test splits—folders whose names start with
+`test`—because they are excluded from the agent's mounts. `agentomics-run`
+automatically evaluates the best iteration on
 every co-located directory whose name starts with `test` **after** the run, in a
 separate read-only evaluation container. Predictions and metrics are saved as
 `eval_predictions_<test_split>.csv` and

--- a/docs/user-guide/datasets.md
+++ b/docs/user-guide/datasets.md
@@ -24,9 +24,10 @@ datasets/my_dataset/
 ```
 
 The optional `test/` split is stored with the dataset, but is excluded from the
-agent worker's mounts and agent-facing prepared data. After model development,
-Agentomics mounts it read-only in a separate evaluation container, prepares it
-in a temporary directory, and evaluates only the best iteration against it.
+agent worker's mounts and agent-facing prepared data. The same applies to every
+top-level directory whose name starts with `test`; Agentomics evaluates the
+best iteration against each one after model development and uses the directory
+name as its W&B metric prefix.
 
 ## Split Requirements
 
@@ -196,7 +197,8 @@ datasets/my_dataset/
 ```
 
 Only these CSV names are auto-detected: `train.csv`, optional `validation.csv`,
-and `test.csv` for hidden test data.
+and `test.csv` for hidden test data. Multiple hidden test sets use the
+folder-based format described above.
 
 For CSV datasets, `metadata.json` should identify the label column and task type:
 

--- a/docs/user-guide/datasets.md
+++ b/docs/user-guide/datasets.md
@@ -24,10 +24,11 @@ datasets/my_dataset/
 ```
 
 The optional `test/` split is stored with the dataset, but is excluded from the
-agent worker's mounts and agent-facing prepared data. The same applies to every
-top-level directory whose name starts with `test`; Agentomics evaluates the
-best iteration against each one after model development and uses the directory
-name as its W&B metric prefix.
+agent worker's mounts and agent-facing prepared data. After model development,
+Agentomics mounts it read-only in a separate evaluation container, prepares it
+in a temporary directory, and evaluates only the best iteration against it.
+Additional top-level directories whose names start with `test` are handled the
+same way and evaluated separately.
 
 ## Split Requirements
 

--- a/docs/user-guide/datasets.md
+++ b/docs/user-guide/datasets.md
@@ -25,8 +25,8 @@ datasets/my_dataset/
 
 The optional `test/` split is stored with the dataset, but is excluded from the
 agent worker's mounts and agent-facing prepared data. After model development,
-Agentomics mounts it read-only in a separate evaluation container, prepares it
-in a temporary directory, and evaluates only the best iteration against it.
+Agentomics mounts it read-only in a separate evaluation container and evaluates
+only the best iteration against it.
 Additional top-level directories whose names start with `test` are handled the
 same way and evaluated separately.
 

--- a/docs/user-guide/outputs.md
+++ b/docs/user-guide/outputs.md
@@ -54,9 +54,9 @@ The most important directory - contains the best-performing iteration's artifact
 | `runtime_info/iteration_metadata.json` | Which iteration produced the snapshot |
 | `runtime_info/environment.yml` | Portable definition of the Conda environment used |
 | `runtime_info/environment.tar.gz` | Packed environment for fast container-local restoration in `full` mode |
-| `eval_predictions_test.csv` | Best-model predictions for the optional test split |
-| `eval_predictions_test.numeric_labels.csv` | Numeric test labels used for metrics |
-| `eval_predictions_test.metrics.json` | Metrics for the optional test split |
+| `eval_predictions_<test_split>.csv` | Best-model predictions for each `test*` split |
+| `eval_predictions_<test_split>.numeric_labels.csv` | Numeric labels used for that split's metrics |
+| `eval_predictions_<test_split>.metrics.json` | Metrics for that split |
 
 ### Using the Best Model
 
@@ -98,7 +98,8 @@ selected iteration's reports and provide stable paths to the final result.
 
 ### PDF Reports
 
-`reports/pdf/iteration_N.pdf` - PDF report per iteration, plus plots in `reports/pdf/plots/`.
+`reports/pdf/iteration_N.pdf` - PDF report per iteration, including metrics and
+plots for every evaluated `test*` split, plus plots in `reports/pdf/plots/`.
 
 ## Metrics
 

--- a/docs/user-guide/outputs.md
+++ b/docs/user-guide/outputs.md
@@ -54,9 +54,13 @@ The most important directory - contains the best-performing iteration's artifact
 | `runtime_info/iteration_metadata.json` | Which iteration produced the snapshot |
 | `runtime_info/environment.yml` | Portable definition of the Conda environment used |
 | `runtime_info/environment.tar.gz` | Packed environment for fast container-local restoration in `full` mode |
-| `eval_predictions_<test_split>.csv` | Best-model predictions for each `test*` split |
-| `eval_predictions_<test_split>.numeric_labels.csv` | Numeric labels used for that split's metrics |
-| `eval_predictions_<test_split>.metrics.json` | Metrics for that split |
+| `eval_predictions_test.csv` | Best-model predictions for the optional test split |
+| `eval_predictions_test.numeric_labels.csv` | Numeric test labels used for metrics |
+| `eval_predictions_test.metrics.json` | Metrics for the optional test split |
+
+Multiple held-out test sets are also supported. Each uses its directory name in
+place of `test` in the filenames above. See
+[Evaluating on Held-out Test Sets](../how-it-works/evaluation.md#evaluating-on-held-out-test-sets).
 
 ### Using the Best Model
 
@@ -99,7 +103,8 @@ selected iteration's reports and provide stable paths to the final result.
 ### PDF Reports
 
 `reports/pdf/iteration_N.pdf` - PDF report per iteration, including metrics and
-plots for every evaluated `test*` split, plus plots in `reports/pdf/plots/`.
+plots for every evaluated held-out test split, plus plots in
+`reports/pdf/plots/`.
 
 ## Metrics
 

--- a/src/agentomics/cli/docker_utils.py
+++ b/src/agentomics/cli/docker_utils.py
@@ -4,6 +4,7 @@ import argparse
 import os
 import shutil
 import subprocess
+from pathlib import Path
 
 from agentomics.utils.versioning import get_version
 
@@ -23,6 +24,16 @@ def create_parser(description: str) -> argparse.ArgumentParser:
         help="Docker image used for the worker",
     )
     return parser
+
+def docker_environment_arguments(*variable_names: str) -> list[str]:
+    docker_arguments: list[str] = []
+    env_file = Path.cwd() / ".env"
+    if env_file.is_file():
+        docker_arguments.extend(["--env-file", str(env_file.resolve())])
+    for variable_name in variable_names:
+        if variable_name in os.environ:
+            docker_arguments.extend(["-e", variable_name])
+    return docker_arguments
 
 def validate_docker_gpu_access(image: str) -> None:
     if shutil.which("docker") is None:

--- a/src/agentomics/cli/inference.py
+++ b/src/agentomics/cli/inference.py
@@ -45,7 +45,6 @@ def build_parser() -> argparse.ArgumentParser:
 
 def run_inference_in_docker(arguments: argparse.Namespace) -> None:
     resolve_inference_paths(arguments)
-    wandb_prefix = getattr(arguments, "wandb_prefix", None)
     container_input = "/inference-input"
     python_arguments = [
         "-m",
@@ -65,8 +64,8 @@ def run_inference_in_docker(arguments: argparse.Namespace) -> None:
         python_arguments.append("--all-iterations")
     if arguments.cpu_only:
         python_arguments.append("--cpu-only")
-    if wandb_prefix:
-        python_arguments.extend(["--wandb-prefix", wandb_prefix])
+    if arguments.wandb_prefix:
+        python_arguments.extend(["--wandb-prefix", arguments.wandb_prefix])
 
     run_python_in_docker(
         image=arguments.image,

--- a/src/agentomics/cli/inference.py
+++ b/src/agentomics/cli/inference.py
@@ -43,9 +43,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--wandb-prefix", help="Metric prefix for W&B logging")
     return parser
 
-def _wandb_docker_arguments(prefix: str | None) -> list[str]:
-    if prefix is None:
-        return []
+def _wandb_docker_arguments() -> list[str]:
     docker_arguments = []
     env_file = Path.cwd() / ".env"
     if env_file.is_file():
@@ -99,7 +97,7 @@ def run_inference_in_docker(arguments: argparse.Namespace) -> None:
             f"type=bind,src={arguments.output.parent},dst=/inference-output",
         ],
         python_arguments=python_arguments,
-        docker_arguments=_wandb_docker_arguments(wandb_prefix),
+        docker_arguments=_wandb_docker_arguments(),
     )
 
 def main() -> int:

--- a/src/agentomics/cli/inference.py
+++ b/src/agentomics/cli/inference.py
@@ -53,6 +53,12 @@ def _wandb_docker_arguments(prefix: str | None) -> list[str]:
         "WANDB_API_KEY",
         "WANDB_PROJECT_NAME",
         "WANDB_ENTITY",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "ALL_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "all_proxy",
     ):
         if variable_name in os.environ:
             docker_arguments.extend(["-e", variable_name])

--- a/src/agentomics/cli/inference.py
+++ b/src/agentomics/cli/inference.py
@@ -10,7 +10,7 @@ from agentomics.cli.docker_utils import (
     run_python_in_docker,
 )
 
-from agentomics.runtime.inference_workflow import resolve_inference_paths
+from agentomics.runtime.filesystem import resolve_inference_paths
 from agentomics.utils.config import Config
 
 def build_parser() -> argparse.ArgumentParser:

--- a/src/agentomics/cli/inference.py
+++ b/src/agentomics/cli/inference.py
@@ -40,6 +40,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="Run every archived iteration",
     )
     parser.add_argument("--cpu-only", action="store_true", help="Disable GPU access")
+    parser.add_argument("--wandb-prefix", help="Metric prefix for W&B logging")
     return parser
 
 def _wandb_docker_arguments(prefix: str | None) -> list[str]:
@@ -62,7 +63,6 @@ def _wandb_docker_arguments(prefix: str | None) -> list[str]:
     ):
         if variable_name in os.environ:
             docker_arguments.extend(["-e", variable_name])
-    docker_arguments.extend(["-e", f"AGENTOMICS_WANDB_PREFIX={prefix}"])
     return docker_arguments
 
 def run_inference_in_docker(arguments: argparse.Namespace) -> None:
@@ -87,6 +87,8 @@ def run_inference_in_docker(arguments: argparse.Namespace) -> None:
         python_arguments.append("--all-iterations")
     if arguments.cpu_only:
         python_arguments.append("--cpu-only")
+    if wandb_prefix:
+        python_arguments.extend(["--wandb-prefix", wandb_prefix])
 
     run_python_in_docker(
         image=arguments.image,

--- a/src/agentomics/cli/inference.py
+++ b/src/agentomics/cli/inference.py
@@ -43,7 +43,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--wandb-prefix", help="Metric prefix for W&B logging")
     return parser
 
-def run_inference_in_docker(arguments: argparse.Namespace) -> None:
+def run_inference_in_docker(arguments: argparse.Namespace) -> int:
     resolve_inference_paths(arguments)
     container_input = "/inference-input"
     python_arguments = [
@@ -67,7 +67,7 @@ def run_inference_in_docker(arguments: argparse.Namespace) -> None:
     if arguments.wandb_prefix:
         python_arguments.extend(["--wandb-prefix", arguments.wandb_prefix])
 
-    run_python_in_docker(
+    return run_python_in_docker(
         image=arguments.image,
         cpu_only=arguments.cpu_only,
         mounts=[
@@ -87,12 +87,12 @@ def run_inference_in_docker(arguments: argparse.Namespace) -> None:
             "https_proxy",
             "all_proxy",
         ),
+        check=False,
     )
 
 def main() -> int:
     arguments = build_parser().parse_args()
-    run_inference_in_docker(arguments)
-    return 0
+    return run_inference_in_docker(arguments)
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/src/agentomics/cli/inference.py
+++ b/src/agentomics/cli/inference.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 from pathlib import Path
 
@@ -41,8 +42,26 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--cpu-only", action="store_true", help="Disable GPU access")
     return parser
 
+def _wandb_docker_arguments(prefix: str | None) -> list[str]:
+    if prefix is None:
+        return []
+    docker_arguments = []
+    env_file = Path.cwd() / ".env"
+    if env_file.is_file():
+        docker_arguments.extend(["--env-file", str(env_file.resolve())])
+    for variable_name in (
+        "WANDB_API_KEY",
+        "WANDB_PROJECT_NAME",
+        "WANDB_ENTITY",
+    ):
+        if variable_name in os.environ:
+            docker_arguments.extend(["-e", variable_name])
+    docker_arguments.extend(["-e", f"AGENTOMICS_WANDB_PREFIX={prefix}"])
+    return docker_arguments
+
 def run_inference_in_docker(arguments: argparse.Namespace) -> None:
     resolve_inference_paths(arguments)
+    wandb_prefix = getattr(arguments, "wandb_prefix", None)
     container_input = "/inference-input"
     python_arguments = [
         "-m",
@@ -72,6 +91,7 @@ def run_inference_in_docker(arguments: argparse.Namespace) -> None:
             f"type=bind,src={arguments.output.parent},dst=/inference-output",
         ],
         python_arguments=python_arguments,
+        docker_arguments=_wandb_docker_arguments(wandb_prefix),
     )
 
 def main() -> int:

--- a/src/agentomics/cli/inference.py
+++ b/src/agentomics/cli/inference.py
@@ -40,7 +40,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="Run every archived iteration",
     )
     parser.add_argument("--cpu-only", action="store_true", help="Disable GPU access")
-    parser.add_argument("--wandb-prefix", help="Metric prefix for W&B logging")
+    parser.add_argument("--wandb-prefix", help="Enable W&B logging with this prefix; valid WANDB_API_KEY, WANDB_PROJECT_NAME, and WANDB_ENTITY are also required")
     return parser
 
 def run_inference_in_docker(arguments: argparse.Namespace) -> int:

--- a/src/agentomics/cli/inference.py
+++ b/src/agentomics/cli/inference.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import argparse
-import os
 import sys
 from pathlib import Path
 
 from agentomics.cli.docker_utils import (
     create_parser,
+    docker_environment_arguments,
     run_python_in_docker,
 )
 
@@ -43,26 +43,6 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--wandb-prefix", help="Metric prefix for W&B logging")
     return parser
 
-def _wandb_docker_arguments() -> list[str]:
-    docker_arguments = []
-    env_file = Path.cwd() / ".env"
-    if env_file.is_file():
-        docker_arguments.extend(["--env-file", str(env_file.resolve())])
-    for variable_name in (
-        "WANDB_API_KEY",
-        "WANDB_PROJECT_NAME",
-        "WANDB_ENTITY",
-        "HTTP_PROXY",
-        "HTTPS_PROXY",
-        "ALL_PROXY",
-        "http_proxy",
-        "https_proxy",
-        "all_proxy",
-    ):
-        if variable_name in os.environ:
-            docker_arguments.extend(["-e", variable_name])
-    return docker_arguments
-
 def run_inference_in_docker(arguments: argparse.Namespace) -> None:
     resolve_inference_paths(arguments)
     wandb_prefix = getattr(arguments, "wandb_prefix", None)
@@ -97,7 +77,17 @@ def run_inference_in_docker(arguments: argparse.Namespace) -> None:
             f"type=bind,src={arguments.output.parent},dst=/inference-output",
         ],
         python_arguments=python_arguments,
-        docker_arguments=_wandb_docker_arguments(),
+        docker_arguments=docker_environment_arguments(
+            "WANDB_API_KEY",
+            "WANDB_PROJECT_NAME",
+            "WANDB_ENTITY",
+            "HTTP_PROXY",
+            "HTTPS_PROXY",
+            "ALL_PROXY",
+            "http_proxy",
+            "https_proxy",
+            "all_proxy",
+        ),
     )
 
 def main() -> int:

--- a/src/agentomics/cli/run.py
+++ b/src/agentomics/cli/run.py
@@ -247,8 +247,9 @@ def _run_inference_on_test_input(
     cpu_only: bool,
     workspace_directory: Path,
     test_input: Path,
+    split_name: str,
 ) -> None:
-    print(f"Evaluating the best iteration on {test_input}")
+    print(f"Evaluating the best iteration on {split_name}: {test_input}")
     run_inference_in_docker(
         argparse.Namespace(
             image=image,
@@ -257,12 +258,13 @@ def _run_inference_on_test_input(
             output=(
                 workspace_directory
                 / Config.BEST_ITERATION_SNAPSHOT_DIRNAME
-                / "eval_predictions_test.csv"
+                / f"eval_predictions_{split_name}.csv"
             ),
             label_col=None,
             iteration_dir=Path(Config.BEST_ITERATION_SNAPSHOT_DIRNAME),
             all_iterations=False,
             cpu_only=cpu_only,
+            wandb_prefix=split_name,
         )
     )
 
@@ -273,13 +275,30 @@ def _run_test_evaluation_in_docker(
     workspace_directory: Path,
     dataset_directory: Path,
 ) -> None:
-    test_directory = dataset_directory / "test"
-    if test_directory.is_dir():
-        _run_inference_on_test_input(
-            image, cpu_only, workspace_directory, test_directory
-        )
+    test_directories = sorted(
+        path
+        for path in dataset_directory.iterdir()
+        if path.is_dir() and path.name.startswith("test")
+    )
+    if test_directories:
+        for test_directory in test_directories:
+            try:
+                _run_inference_on_test_input(
+                    image,
+                    cpu_only,
+                    workspace_directory,
+                    test_directory,
+                    test_directory.name,
+                )
+            except Exception as error:
+                print(
+                    f"Warning: Evaluation failed for {test_directory.name}; "
+                    f"continuing: {error}",
+                    file=sys.stderr,
+                )
         return
 
+    test_directory = dataset_directory / "test"
     test_csv = dataset_directory / "test.csv"
     if not test_csv.is_file():
         print(
@@ -311,6 +330,7 @@ def _run_test_evaluation_in_docker(
             cpu_only,
             workspace_directory,
             prepared_directory / "test",
+            "test",
         )
 
 

--- a/src/agentomics/cli/run.py
+++ b/src/agentomics/cli/run.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -243,9 +242,9 @@ def _run_inference_on_test_input(
     cpu_only: bool,
     workspace_directory: Path,
     test_input: Path,
-) -> None:
+) -> int:
     print(f"Evaluating the best iteration on {test_input.name}: {test_input}")
-    run_inference_in_docker(
+    return run_inference_in_docker(
         argparse.Namespace(
             image=image,
             agent_dir=workspace_directory,
@@ -277,17 +276,16 @@ def _run_test_evaluation_in_docker(
     )
     if test_directories:
         for test_directory in test_directories:
-            try:
-                _run_inference_on_test_input(
-                    image,
-                    cpu_only,
-                    workspace_directory,
-                    test_directory,
-                )
-            except subprocess.CalledProcessError as error:
+            return_code = _run_inference_on_test_input(
+                image,
+                cpu_only,
+                workspace_directory,
+                test_directory,
+            )
+            if return_code != 0:
                 print(
-                    f"Warning: Evaluation failed for {test_directory.name}; "
-                    f"continuing: {error}",
+                    f"Warning: Evaluation failed for {test_directory.name} "
+                    f"with exit code {return_code}; continuing.",
                     file=sys.stderr,
                 )
         return
@@ -315,12 +313,18 @@ def _run_test_evaluation_in_docker(
             label_column=metadata.get("label_column"),
             id_column=metadata.get("id_column"),
         )
-        _run_inference_on_test_input(
+        return_code = _run_inference_on_test_input(
             image,
             cpu_only,
             workspace_directory,
             prepared_directory / "test",
         )
+        if return_code != 0:
+            print(
+                f"Warning: Evaluation failed for test with exit code "
+                f"{return_code}; continuing.",
+                file=sys.stderr,
+            )
 
 
 def _run_reporting_in_docker(

--- a/src/agentomics/cli/run.py
+++ b/src/agentomics/cli/run.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -289,7 +290,7 @@ def _run_test_evaluation_in_docker(
                     workspace_directory,
                     test_directory,
                 )
-            except Exception as error:
+            except subprocess.CalledProcessError as error:
                 print(
                     f"Warning: Evaluation failed for {test_directory.name}; "
                     f"continuing: {error}",

--- a/src/agentomics/cli/run.py
+++ b/src/agentomics/cli/run.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import subprocess
 import sys
 import tempfile
@@ -10,6 +9,7 @@ from pathlib import Path
 
 from agentomics.cli.docker_utils import (
     create_parser,
+    docker_environment_arguments,
     run_python_in_docker,
     validate_docker_gpu_access,
 )
@@ -106,19 +106,13 @@ def _build_container_arguments(arguments: argparse.Namespace) -> list[str]:
     return workflow_arguments
 
 def _docker_environment_arguments(agent_id: str) -> list[str]:
-    docker_arguments: list[str] = []
-    env_file = Path.cwd() / ".env"
-    if env_file.is_file():
-        docker_arguments.extend(["--env-file", str(env_file.resolve())])
-    for variable_name in (
+    docker_arguments = docker_environment_arguments(
         "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "OPENROUTER_API_KEY",
         "PROVISIONING_OPENROUTER_API_KEY", "OLLAMA_BASE_URL",
         "WANDB_API_KEY", "WANDB_PROJECT_NAME", "WANDB_ENTITY",
         "HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY",
         "http_proxy", "https_proxy", "all_proxy", "CUDA_VISIBLE_DEVICES",
-    ):
-        if variable_name in os.environ:
-            docker_arguments.extend(["-e", variable_name])
+    )
     docker_arguments.extend(["-e", f"AGENT_ID={agent_id}"])
     if sys.stdin.isatty() and sys.stdout.isatty():
         docker_arguments.append("-it")

--- a/src/agentomics/cli/run.py
+++ b/src/agentomics/cli/run.py
@@ -247,9 +247,8 @@ def _run_inference_on_test_input(
     cpu_only: bool,
     workspace_directory: Path,
     test_input: Path,
-    split_name: str,
 ) -> None:
-    print(f"Evaluating the best iteration on {split_name}: {test_input}")
+    print(f"Evaluating the best iteration on {test_input.name}: {test_input}")
     run_inference_in_docker(
         argparse.Namespace(
             image=image,
@@ -258,13 +257,13 @@ def _run_inference_on_test_input(
             output=(
                 workspace_directory
                 / Config.BEST_ITERATION_SNAPSHOT_DIRNAME
-                / f"eval_predictions_{split_name}.csv"
+                / f"eval_predictions_{test_input.name}.csv"
             ),
             label_col=None,
             iteration_dir=Path(Config.BEST_ITERATION_SNAPSHOT_DIRNAME),
             all_iterations=False,
             cpu_only=cpu_only,
-            wandb_prefix=split_name,
+            wandb_prefix=test_input.name,
         )
     )
 
@@ -288,7 +287,6 @@ def _run_test_evaluation_in_docker(
                     cpu_only,
                     workspace_directory,
                     test_directory,
-                    test_directory.name,
                 )
             except Exception as error:
                 print(
@@ -330,7 +328,6 @@ def _run_test_evaluation_in_docker(
             cpu_only,
             workspace_directory,
             prepared_directory / "test",
-            "test",
         )
 
 

--- a/src/agentomics/cli/run.py
+++ b/src/agentomics/cli/run.py
@@ -15,7 +15,7 @@ from agentomics.cli.docker_utils import (
 )
 from agentomics.cli.inference import run_inference_in_docker
 from agentomics.cli.run_arguments import add_run_arguments
-from agentomics.datasets.data_contract import TEST_SPLIT
+from agentomics.datasets.data_contract import TEST_SPLIT_PREFIX
 from agentomics.datasets.dataset_preparation import prepare_test_dataset
 from agentomics.datasets.datasets_interactive import (
     get_all_datasets_info,
@@ -279,7 +279,7 @@ def _run_test_evaluation_in_docker(
     test_directories = sorted(
         path
         for path in dataset_directory.iterdir()
-        if path.is_dir() and path.name.startswith(TEST_SPLIT)
+        if path.is_dir() and path.name.startswith(TEST_SPLIT_PREFIX)
     )
     if test_directories:
         for test_directory in test_directories:

--- a/src/agentomics/cli/run.py
+++ b/src/agentomics/cli/run.py
@@ -14,6 +14,7 @@ from agentomics.cli.docker_utils import (
 )
 from agentomics.cli.inference import run_inference_in_docker
 from agentomics.cli.run_arguments import add_run_arguments
+from agentomics.datasets.data_contract import TEST_SPLIT
 from agentomics.datasets.dataset_preparation import prepare_test_dataset
 from agentomics.datasets.datasets_interactive import (
     get_all_datasets_info,
@@ -277,7 +278,7 @@ def _run_test_evaluation_in_docker(
     test_directories = sorted(
         path
         for path in dataset_directory.iterdir()
-        if path.is_dir() and path.name.startswith("test")
+        if path.is_dir() and path.name.startswith(TEST_SPLIT)
     )
     if test_directories:
         for test_directory in test_directories:

--- a/src/agentomics/cli/run.py
+++ b/src/agentomics/cli/run.py
@@ -298,13 +298,9 @@ def _run_test_evaluation_in_docker(
                 )
         return
 
-    test_directory = dataset_directory / "test"
     test_csv = dataset_directory / "test.csv"
     if not test_csv.is_file():
-        print(
-            f"No test split found at {test_directory} or {test_csv}; "
-            "skipping test evaluation."
-        )
+        print(f"No test split found in {dataset_directory}; skipping test evaluation.")
         return
 
     metadata_path = (

--- a/src/agentomics/datasets/create_datasets.py
+++ b/src/agentomics/datasets/create_datasets.py
@@ -14,7 +14,7 @@ from agentomics.datasets.data_contract import (
     LABEL_COLUMN_NAME,
     LABELS_FILE_NAME,
     METADATA_FILE_NAME,
-    TEST_SPLIT,
+    TEST_SPLIT_PREFIX,
     TRAIN_SPLIT,
 )
 
@@ -186,7 +186,7 @@ def generate_breast_cancer_files(_dataset_name: str = "breast_cancer") -> None:
     convert_csv_dataset(
         dataset_dir,
         label_column=LABEL_COLUMN,
-        splits={TRAIN_SPLIT: train_df, TEST_SPLIT: test_df},
+        splits={TRAIN_SPLIT: train_df, TEST_SPLIT_PREFIX: test_df},
         id_column=ID_COLUMN_NAME,
         task_type="classification",
     )
@@ -217,7 +217,7 @@ def generate_digits_images_files(_dataset_name: str = "digits_images") -> None:
 
     split_indices = {
         TRAIN_SPLIT: train_indices,
-        TEST_SPLIT: test_indices,
+        TEST_SPLIT_PREFIX: test_indices,
     }
 
     for split_name, split_idx in split_indices.items():
@@ -264,10 +264,10 @@ def generate_spoken_digits_files(_dataset_name: str = "spoken_digits") -> None:
         raise FileNotFoundError(f"No recordings directory found after extracting {archive_path}")
 
     recordings_dir = recordings_dirs[-1]
-    split_labels = {TRAIN_SPLIT: [], TEST_SPLIT: []}
+    split_labels = {TRAIN_SPLIT: [], TEST_SPLIT_PREFIX: []}
     for wav_path in sorted(recordings_dir.glob("*.wav")):
         label, _speaker, index = wav_path.stem.rsplit("_", 2)
-        split_name = TEST_SPLIT if int(index) < 5 else TRAIN_SPLIT
+        split_name = TEST_SPLIT_PREFIX if int(index) < 5 else TRAIN_SPLIT
         audio_dir = _make_split_dirs(dataset_dir, split_name, "audio")
         destination = audio_dir / wav_path.name
         shutil.copy2(wav_path, destination)

--- a/src/agentomics/datasets/csv_converter.py
+++ b/src/agentomics/datasets/csv_converter.py
@@ -13,7 +13,7 @@ from agentomics.datasets.data_contract import (
     LABELS_FILE_NAME,
     METADATA_FILE_NAME,
     SUPPLEMENTARY_DIR_NAME,
-    TEST_SPLIT,
+    TEST_SPLIT_PREFIX,
     TRAIN_SPLIT,
     VALIDATION_SPLIT,
 )
@@ -24,7 +24,7 @@ CSV_LABEL_COLUMN_METADATA_KEY = "label_column"
 CSV_ID_COLUMN_METADATA_KEY = "id_column"
 TRAIN_CSV_FILE_NAME = f"{TRAIN_SPLIT}.csv"
 VALIDATION_CSV_FILE_NAME = f"{VALIDATION_SPLIT}.csv"
-TEST_CSV_FILE_NAME = f"{TEST_SPLIT}.csv"
+TEST_CSV_FILE_NAME = f"{TEST_SPLIT_PREFIX}.csv"
 CSV_CONVERTED_SOURCE_DIR_NAME = "_csv_converted_source"
 ALLOWED_PUBLIC_CSV_DATASET_ENTRIES = {
     TRAIN_CSV_FILE_NAME,
@@ -46,7 +46,7 @@ def is_public_csv_dataset(source_dir: Path) -> bool:
 
 def is_test_csv_dataset(source_dir: Path) -> bool:
     source_dir = Path(source_dir)
-    return not (source_dir / TEST_SPLIT).exists() and (source_dir / TEST_CSV_FILE_NAME).is_file()
+    return not (source_dir / TEST_SPLIT_PREFIX).exists() and (source_dir / TEST_CSV_FILE_NAME).is_file()
 
 def convert_csv_dataset_to_standard_raw_dataset(
     source_dir: Path,
@@ -107,10 +107,10 @@ def convert_csv_test_dataset_to_standard_raw_dataset(
     converted_source_dir = _converted_source_dir(destination_dir)
     remove_path(converted_source_dir)
     _write_input_and_labels(
-        split_dir=converted_source_dir / TEST_SPLIT,
+        split_dir=converted_source_dir / TEST_SPLIT_PREFIX,
         df=pd.read_csv(source_dir / TEST_CSV_FILE_NAME),
         label_column=str(label_column),
-        id_prefix=TEST_SPLIT,
+        id_prefix=TEST_SPLIT_PREFIX,
         id_column=str(id_column) if id_column is not None else None,
     )
     return converted_source_dir

--- a/src/agentomics/datasets/data_contract.py
+++ b/src/agentomics/datasets/data_contract.py
@@ -4,7 +4,7 @@ import pandas as pd
 
 TRAIN_SPLIT = "train"
 VALIDATION_SPLIT = "validation"
-TEST_SPLIT = "test"
+TEST_SPLIT_PREFIX = "test"
 MINI_TRAIN_SPLIT = "mini_train"
 
 NON_TEST_SPLIT_NAMES = (TRAIN_SPLIT, VALIDATION_SPLIT)
@@ -22,7 +22,7 @@ DATASET_DESCRIPTION_FILE_NAME = "dataset_description.md"
 ALLOWED_PUBLIC_DATASET_ENTRIES = {
     TRAIN_SPLIT,
     VALIDATION_SPLIT,
-    TEST_SPLIT,
+    TEST_SPLIT_PREFIX,
     SUPPLEMENTARY_DIR_NAME,
     METADATA_FILE_NAME,
     DATASET_DESCRIPTION_FILE_NAME,
@@ -56,14 +56,14 @@ def validate_public_dataset_entries(dataset_dir: Path) -> None:
         item.name for item in dataset_dir.iterdir()
         if (
             item.name not in ALLOWED_PUBLIC_DATASET_ENTRIES
-            and not (item.is_dir() and item.name.startswith(TEST_SPLIT))
+            and not (item.is_dir() and item.name.startswith(TEST_SPLIT_PREFIX))
         )
     )
     if unsupported_entries:
         raise ValueError(
             f"Public dataset {dataset_dir.name} has unsupported top-level entries: {unsupported_entries}. "
             f"Allowed: {sorted(ALLOWED_PUBLIC_DATASET_ENTRIES)} and directories "
-            f"whose names start with '{TEST_SPLIT}'."
+            f"whose names start with '{TEST_SPLIT_PREFIX}'."
         )
 
 def validate_splits(split_paths: dict[str, Path], expected_input_structure: list[str]) -> None:

--- a/src/agentomics/datasets/data_contract.py
+++ b/src/agentomics/datasets/data_contract.py
@@ -54,12 +54,16 @@ def validate_split_entries(split_path: Path, split_name: str) -> None:
 def validate_public_dataset_entries(dataset_dir: Path) -> None:
     unsupported_entries = sorted(
         item.name for item in dataset_dir.iterdir()
-        if item.name not in ALLOWED_PUBLIC_DATASET_ENTRIES
+        if (
+            item.name not in ALLOWED_PUBLIC_DATASET_ENTRIES
+            and not (item.is_dir() and item.name.startswith(TEST_SPLIT))
+        )
     )
     if unsupported_entries:
         raise ValueError(
             f"Public dataset {dataset_dir.name} has unsupported top-level entries: {unsupported_entries}. "
-            f"Allowed: {sorted(ALLOWED_PUBLIC_DATASET_ENTRIES)}."
+            f"Allowed: {sorted(ALLOWED_PUBLIC_DATASET_ENTRIES)} and directories "
+            f"whose names start with '{TEST_SPLIT}'."
         )
 
 def validate_splits(split_paths: dict[str, Path], expected_input_structure: list[str]) -> None:

--- a/src/agentomics/datasets/dataset_preparation.py
+++ b/src/agentomics/datasets/dataset_preparation.py
@@ -17,7 +17,7 @@ from agentomics.datasets.data_contract import (
     NON_TEST_SPLIT_NAMES,
     NUMERIC_LABEL_COLUMN_NAME,
     SUPPLEMENTARY_DIR_NAME,
-    TEST_SPLIT,
+    TEST_SPLIT_PREFIX,
     TRAIN_SPLIT,
     VALIDATION_SPLIT,
     record_input_dir_structure,
@@ -270,7 +270,7 @@ def check_dataset(source_dir: Path, interactive: bool = False) -> dict:
             interactive=interactive,
         )
         test_rows = None
-        has_test_split = (source_dir / TEST_SPLIT).is_dir() or is_test_csv_dataset(source_dir)
+        has_test_split = (source_dir / TEST_SPLIT_PREFIX).is_dir() or is_test_csv_dataset(source_dir)
         if has_test_split:
             test_metadata = prepare_test_dataset(
                 source_dir=source_dir,
@@ -324,33 +324,33 @@ def prepare_test_dataset(
             id_column=id_column,
         )
 
-    test_source = source_dir / TEST_SPLIT
+    test_source = source_dir / TEST_SPLIT_PREFIX
     if not test_source.is_dir():
         raise FileNotFoundError(f"Required test/ split is missing: {test_source}")
 
-    validate_split_entries(test_source, TEST_SPLIT)
+    validate_split_entries(test_source, TEST_SPLIT_PREFIX)
 
-    test_labels = load_split_label_dfs({TEST_SPLIT: test_source})
+    test_labels = load_split_label_dfs({TEST_SPLIT_PREFIX: test_source})
 
     if task_type == TaskTypes.CLASSIFICATION:
         if not label_to_scalar:
             raise ValueError("label_to_scalar is required for classification test data preparation")
         validate_single_label_classification(test_labels)
         label_to_scalar = {str(k): int(v) for k, v in label_to_scalar.items()}
-        actual_labels = set(test_labels[TEST_SPLIT][LABEL_COLUMN_NAME].astype(str).unique())
+        actual_labels = set(test_labels[TEST_SPLIT_PREFIX][LABEL_COLUMN_NAME].astype(str).unique())
         unknown_labels = sorted(actual_labels - set(label_to_scalar))
         if unknown_labels:
             raise ValueError(
                 f"Test split contains labels not present in train: {unknown_labels}. "
                 f"Known labels: {sorted(label_to_scalar)}"
             )
-        numeric_labels = convert_classification_labels(test_labels[TEST_SPLIT], label_to_scalar, TEST_SPLIT)
+        numeric_labels = convert_classification_labels(test_labels[TEST_SPLIT_PREFIX], label_to_scalar, TEST_SPLIT_PREFIX)
     elif task_type == TaskTypes.REGRESSION:
-        numeric_labels = convert_regression_labels(test_labels[TEST_SPLIT], TEST_SPLIT)
+        numeric_labels = convert_regression_labels(test_labels[TEST_SPLIT_PREFIX], TEST_SPLIT_PREFIX)
     else:
         raise ValueError(f"Unknown task_type: {task_type}. Expected one of {TaskTypes}.")
 
-    dest_test = destination_dir / TEST_SPLIT
+    dest_test = destination_dir / TEST_SPLIT_PREFIX
     dest_test.mkdir(parents=True, exist_ok=True)
     if csv_test_dataset:
         shutil.copytree(test_source / INPUT_DIR_NAME, dest_test / INPUT_DIR_NAME)
@@ -361,11 +361,11 @@ def prepare_test_dataset(
         )
     numeric_labels.to_csv(dest_test / LABELS_FILE_NAME, index=False)
 
-    validate_splits({TEST_SPLIT: dest_test}, input_structure)
+    validate_splits({TEST_SPLIT_PREFIX: dest_test}, input_structure)
 
     test_metadata = {
         "task_type": task_type,
-        "splits": {"test_rows": len(test_labels[TEST_SPLIT])},
+        "splits": {"test_rows": len(test_labels[TEST_SPLIT_PREFIX])},
         "numeric_label_col": NUMERIC_LABEL_COLUMN_NAME,
         "input_structure": input_structure,
         "prepared": True,

--- a/src/agentomics/runtime/evaluate.py
+++ b/src/agentomics/runtime/evaluate.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 from pathlib import Path
 
 import pandas as pd
@@ -37,6 +36,7 @@ def evaluate_predictions(
     predictions_path: Path,
     labels_path: Path,
     output_path: Path,
+    wandb_prefix: str | None = None,
 ) -> dict:
     config = load_config_from_run_dir_and_reroot(agent_dir / Config.RUN_DIRNAME)
 
@@ -51,12 +51,11 @@ def evaluate_predictions(
     )
 
     output_path.write_text(json.dumps(metrics, indent=2) + "\n", encoding="utf-8")
-    prefix = os.getenv("AGENTOMICS_WANDB_PREFIX")
-    if prefix:
+    if wandb_prefix:
         wandb_run = resume_wandb_run(config)
         if wandb_run is not None:
             wandb_run.log({
-                f"{prefix}/{metric_name}": value
+                f"{wandb_prefix}/{metric_name}": value
                 for metric_name, value in metrics.items()
             })
             wandb_run.finish()

--- a/src/agentomics/runtime/evaluate.py
+++ b/src/agentomics/runtime/evaluate.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import sys
 from pathlib import Path
 
 import pandas as pd
@@ -55,21 +54,18 @@ def evaluate_predictions(
     output_path.write_text(json.dumps(metrics, indent=2) + "\n", encoding="utf-8")
     prefix = os.getenv("AGENTOMICS_WANDB_PREFIX")
     if prefix:
-        try:
-            from agentomics.run_logging.wandb_setup import resume_wandb_run
+        from agentomics.run_logging.wandb_setup import resume_wandb_run
 
-            wandb_run = resume_wandb_run(
-                config,
-                dir=Path(agent_dir) / "logs" / "test_logs",
-            )
-            if wandb_run is not None:
-                wandb_run.log({
-                    f"{prefix}/{metric_name}": value
-                    for metric_name, value in metrics.items()
-                })
-                wandb_run.finish()
-        except Exception as error:
-            print(f"Warning: W&B metric logging failed: {error}", file=sys.stderr)
+        wandb_run = resume_wandb_run(
+            config,
+            dir=Path(agent_dir) / "logs" / "test_logs",
+        )
+        if wandb_run is not None:
+            wandb_run.log({
+                f"{prefix}/{metric_name}": value
+                for metric_name, value in metrics.items()
+            })
+            wandb_run.finish()
     print(json.dumps(metrics, indent=2))
     print(f"Metrics written to {output_path}")
     return metrics

--- a/src/agentomics/runtime/evaluate.py
+++ b/src/agentomics/runtime/evaluate.py
@@ -13,6 +13,7 @@ from agentomics.datasets.data_contract import (
     validate_and_read_labels,
 )
 from agentomics.datasets.label_processing import convert_classification_labels, convert_regression_labels
+from agentomics.run_logging.wandb_setup import resume_wandb_run
 from agentomics.runtime.evaluate_result import get_metrics
 from agentomics.runtime.read_write_utils import load_config_from_run_dir
 from agentomics.utils.config import Config
@@ -54,8 +55,6 @@ def evaluate_predictions(
     output_path.write_text(json.dumps(metrics, indent=2) + "\n", encoding="utf-8")
     prefix = os.getenv("AGENTOMICS_WANDB_PREFIX")
     if prefix:
-        from agentomics.run_logging.wandb_setup import resume_wandb_run
-
         wandb_run = resume_wandb_run(
             config,
             dir=Path(agent_dir) / "logs" / "test_logs",

--- a/src/agentomics/runtime/evaluate.py
+++ b/src/agentomics/runtime/evaluate.py
@@ -15,7 +15,7 @@ from agentomics.datasets.data_contract import (
 from agentomics.datasets.label_processing import convert_classification_labels, convert_regression_labels
 from agentomics.run_logging.wandb_setup import resume_wandb_run
 from agentomics.runtime.evaluate_result import get_metrics
-from agentomics.runtime.read_write_utils import load_config_from_run_dir
+from agentomics.runtime.read_write_utils import load_config_from_run_dir_and_reroot
 from agentomics.utils.config import Config
 from agentomics.utils.task_types import TaskTypes
 
@@ -38,9 +38,7 @@ def evaluate_predictions(
     labels_path: Path,
     output_path: Path,
 ) -> dict:
-    config = load_config_from_run_dir(agent_dir / Config.RUN_DIRNAME)
-    if config is None:
-        raise FileNotFoundError(f"Could not load run config under {agent_dir / Config.RUN_DIRNAME}")
+    config = load_config_from_run_dir_and_reroot(agent_dir / Config.RUN_DIRNAME)
 
     numeric_labels = _read_numeric_labels(labels_path, config)
     numeric_labels_path = predictions_path.parent / f"{predictions_path.stem}.numeric_labels.csv"
@@ -55,10 +53,7 @@ def evaluate_predictions(
     output_path.write_text(json.dumps(metrics, indent=2) + "\n", encoding="utf-8")
     prefix = os.getenv("AGENTOMICS_WANDB_PREFIX")
     if prefix:
-        wandb_run = resume_wandb_run(
-            config,
-            dir=Path(agent_dir) / "logs" / "test_logs",
-        )
+        wandb_run = resume_wandb_run(config)
         if wandb_run is not None:
             wandb_run.log({
                 f"{prefix}/{metric_name}": value

--- a/src/agentomics/runtime/evaluate.py
+++ b/src/agentomics/runtime/evaluate.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import sys
 from pathlib import Path
 
 import pandas as pd
@@ -51,6 +53,23 @@ def evaluate_predictions(
     )
 
     output_path.write_text(json.dumps(metrics, indent=2) + "\n", encoding="utf-8")
+    prefix = os.getenv("AGENTOMICS_WANDB_PREFIX")
+    if prefix:
+        try:
+            from agentomics.run_logging.wandb_setup import resume_wandb_run
+
+            wandb_run = resume_wandb_run(
+                config,
+                dir=Path(agent_dir) / "logs" / "test_logs",
+            )
+            if wandb_run is not None:
+                wandb_run.log({
+                    f"{prefix}/{metric_name}": value
+                    for metric_name, value in metrics.items()
+                })
+                wandb_run.finish()
+        except Exception as error:
+            print(f"Warning: W&B metric logging failed: {error}", file=sys.stderr)
     print(json.dumps(metrics, indent=2))
     print(f"Metrics written to {output_path}")
     return metrics

--- a/src/agentomics/runtime/filesystem.py
+++ b/src/agentomics/runtime/filesystem.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+from argparse import Namespace
 from pathlib import Path
 
 
@@ -25,6 +26,11 @@ def resolve_output_path(path: Path) -> Path:
             f"Output parent directory does not exist: {path.parent}"
         )
     return path.parent.resolve() / path.name
+
+def resolve_inference_paths(arguments: Namespace) -> None:
+    arguments.agent_dir = resolve_existing_directory(arguments.agent_dir)
+    arguments.input_path = resolve_existing_path(arguments.input_path)
+    arguments.output = resolve_output_path(arguments.output)
 
 def require_empty_directory(path: Path) -> None:
     if path.exists() and not path.is_dir():

--- a/src/agentomics/runtime/generate_final_reports.py
+++ b/src/agentomics/runtime/generate_final_reports.py
@@ -285,14 +285,12 @@ def gather_iteration_inputs(
     best_iter = load_best_iteration_snapshot_iteration(config)
     if best_iter is not None and iteration == best_iter:
         snapshot_dir = config.best_iteration_snapshot_dir
-        for test_preds in sorted(snapshot_dir.glob("eval_predictions_test*.csv")):
-            if test_preds.name.endswith(".numeric_labels.csv"):
-                continue
-            split_name = test_preds.stem.removeprefix("eval_predictions_")
-            test_labeled = snapshot_dir / f"{test_preds.stem}.numeric_labels.csv"
-            test_metrics = load_saved_metrics(
-                snapshot_dir / f"{test_preds.stem}.metrics.json"
-            )
+        for test_metrics_path in sorted(snapshot_dir.glob("eval_predictions_test*.metrics.json")):
+            predictions_stem = test_metrics_path.name.removesuffix(".metrics.json")
+            split_name = predictions_stem.removeprefix("eval_predictions_")
+            test_preds = snapshot_dir / f"{predictions_stem}.csv"
+            test_labeled = snapshot_dir / f"{predictions_stem}.numeric_labels.csv"
+            test_metrics = load_saved_metrics(test_metrics_path)
             splits.append(
                 SplitArtifacts(split_name, test_labeled, test_preds, test_metrics)
             )

--- a/src/agentomics/runtime/generate_final_reports.py
+++ b/src/agentomics/runtime/generate_final_reports.py
@@ -39,11 +39,6 @@ from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
 
 from agentomics.datasets.data_contract import LABELS_FILE_NAME, NUMERIC_LABEL_COLUMN_NAME, TRAIN_SPLIT, VALIDATION_SPLIT
 
-TEST_PREDICTIONS_FILENAME = "eval_predictions_test.csv"
-TEST_NUMERIC_LABELS_FILENAME = "eval_predictions_test.numeric_labels.csv"
-TEST_METRICS_FILENAME = "eval_predictions_test.metrics.json"
-
-
 # Data models
 @dataclass(frozen=True)
 class DatasetMeta:
@@ -63,7 +58,7 @@ class RunMeta:
 
 @dataclass
 class SplitArtifacts:
-    split_name: str  # train/validation/test
+    split_name: str  # train/validation/test*
     labeled_csv: Optional[Path]
     preds_csv: Optional[Path]
     metrics: Dict[str, float]
@@ -290,11 +285,17 @@ def gather_iteration_inputs(
     best_iter = load_best_iteration_snapshot_iteration(config)
     if best_iter is not None and iteration == best_iter:
         snapshot_dir = config.best_iteration_snapshot_dir
-        test_preds = snapshot_dir / TEST_PREDICTIONS_FILENAME
-        test_labeled = snapshot_dir / TEST_NUMERIC_LABELS_FILENAME
-        test_metrics = load_saved_metrics(snapshot_dir / TEST_METRICS_FILENAME)
-        if test_preds.exists() or test_labeled.exists() or bool(test_metrics):
-            splits.append(SplitArtifacts("test", test_labeled, test_preds, test_metrics))
+        for test_preds in sorted(snapshot_dir.glob("eval_predictions_test*.csv")):
+            if test_preds.name.endswith(".numeric_labels.csv"):
+                continue
+            split_name = test_preds.stem.removeprefix("eval_predictions_")
+            test_labeled = snapshot_dir / f"{test_preds.stem}.numeric_labels.csv"
+            test_metrics = load_saved_metrics(
+                snapshot_dir / f"{test_preds.stem}.metrics.json"
+            )
+            splits.append(
+                SplitArtifacts(split_name, test_labeled, test_preds, test_metrics)
+            )
 
     return IterationInputs(iteration=iteration, report_md=report_md, splits=splits)
 
@@ -579,6 +580,21 @@ def plots_compare_splits_page_flowables(
     present_splits = [s for s in split_order if plot_groups.get(s)]
     if not present_splits:
         return []
+    if len(present_splits) > 3:
+        flows = []
+        for start in range(0, len(present_splits), 3):
+            if flows:
+                flows.append(PageBreak())
+            flows.extend(
+                plots_compare_splits_page_flowables(
+                    iteration,
+                    task_type,
+                    plot_groups,
+                    present_splits[start : start + 3],
+                    styles,
+                )
+            )
+        return flows
 
     task_type = (task_type or "").strip().lower()
     if task_type == TaskTypes.CLASSIFICATION:
@@ -735,10 +751,18 @@ def metrics_table_flowable(metrics_by_split, split_order, val_metric, styles):
     if not present or not keys:
         return Paragraph("No metrics found.", styles["Muted"])
 
-    data = [["Metric"] + [s.title() for s in present]]
-    for k in keys:
-        row = [k] + [_fmt_metric(metrics_by_split[s].get(k)) for s in present]
-        data.append(row)
+    if len(present) > 3:
+        data = [["Split", "Metric", "Value"]]
+        for split in present:
+            data.extend(
+                [split, metric, _fmt_metric(value)]
+                for metric, value in sorted(metrics_by_split[split].items())
+            )
+    else:
+        data = [["Metric"] + [s.title() for s in present]]
+        for k in keys:
+            row = [k] + [_fmt_metric(metrics_by_split[s].get(k)) for s in present]
+            data.append(row)
 
     tbl = Table(data, hAlign="LEFT")
     ts = TableStyle(
@@ -754,9 +778,23 @@ def metrics_table_flowable(metrics_by_split, split_order, val_metric, styles):
         ]
     )
 
-    if val_metric and val_metric in keys:
-        r = 1 + keys.index(val_metric)
-        ts.add("BACKGROUND", (0, r), (-1, r), colors.Color(1.0, 0.98, 0.90))
+    if val_metric and len(present) > 3:
+        for row_index, row in enumerate(data[1:], start=1):
+            if row[1] == val_metric:
+                ts.add(
+                    "BACKGROUND",
+                    (0, row_index),
+                    (-1, row_index),
+                    colors.Color(1.0, 0.98, 0.90),
+                )
+    elif val_metric and val_metric in keys:
+        row_index = 1 + keys.index(val_metric)
+        ts.add(
+            "BACKGROUND",
+            (0, row_index),
+            (-1, row_index),
+            colors.Color(1.0, 0.98, 0.90),
+        )
 
     tbl.setStyle(ts)
     return tbl
@@ -846,10 +884,9 @@ def main() -> None:
     ensure_dir(out_dir)
     ensure_dir(plots_dir)
     config.markdown_reports_dir.mkdir(parents=True, exist_ok=True)
-    split_order = ["train", "validation", "test"]
-
     for it in iterations:
         inp = gather_iteration_inputs(config, it)
+        split_order = [split.split_name for split in inp.splits]
         report_path = inp.report_md
         if report_path is None:
             report_metrics = {

--- a/src/agentomics/runtime/inference_workflow.py
+++ b/src/agentomics/runtime/inference_workflow.py
@@ -12,20 +12,12 @@ from agentomics.datasets.data_contract import INPUT_DIR_NAME, LABELS_FILE_NAME
 from agentomics.runtime.conda_utils import restore_iteration_environment
 from agentomics.runtime.evaluate import evaluate_predictions
 from agentomics.runtime.filesystem import (
-    resolve_existing_directory,
-    resolve_existing_path,
+    resolve_inference_paths,
     resolve_iteration_root,
-    resolve_output_path,
     restore_host_ownership,
 )
 from agentomics.runtime.inference_runner import run_inference_script
 from agentomics.utils.config import Config
-
-
-def resolve_inference_paths(arguments: Namespace) -> None:
-    arguments.agent_dir = resolve_existing_directory(arguments.agent_dir)
-    arguments.input_path = resolve_existing_path(arguments.input_path)
-    arguments.output = resolve_output_path(arguments.output)
 
 def prepare_inference_input(
     input_path: Path,

--- a/src/agentomics/runtime/inference_workflow.py
+++ b/src/agentomics/runtime/inference_workflow.py
@@ -50,14 +50,14 @@ def prepare_inference_input(
     )
     return output_split_dir
 
-def _compute_metrics(agent_dir: Path, input_split: Path, output_path: Path) -> Path | None:
+def _compute_metrics(agent_dir: Path, input_split: Path, output_path: Path, wandb_prefix: str | None) -> Path | None:
     labels_path = input_split / LABELS_FILE_NAME
     if not labels_path.is_file():
         return None
 
     metrics_path = output_path.with_suffix(".metrics.json")
     print("Computing metrics...")
-    evaluate_predictions(agent_dir, output_path, labels_path, metrics_path)
+    evaluate_predictions(agent_dir, output_path, labels_path, metrics_path, wandb_prefix)
     return metrics_path
 
 def _run_single_inference(arguments: Namespace) -> None:
@@ -102,7 +102,7 @@ def _run_single_inference(arguments: Namespace) -> None:
                 f"Inference completed without creating the prediction output: {arguments.output}"
             )
         print("Inference done")
-        metrics_path = _compute_metrics(arguments.agent_dir, input_split, arguments.output)
+        metrics_path = _compute_metrics(arguments.agent_dir, input_split, arguments.output, arguments.wandb_prefix)
         restore_host_ownership(arguments.output)
         if metrics_path is not None:
             restore_host_ownership(metrics_path)

--- a/test/test_run_launcher_container_contract.py
+++ b/test/test_run_launcher_container_contract.py
@@ -51,7 +51,7 @@ class RunLauncherSourceContractTest(unittest.TestCase):
         # the best model on every test-prefixed split via inference.
         self.assertNotIn("test_datasets", self.launcher)
         self.assertNotIn("--test-datasets-dir", self.launcher)
-        self.assertIn("path.name.startswith(TEST_SPLIT)", self.launcher)
+        self.assertIn("path.name.startswith(TEST_SPLIT_PREFIX)", self.launcher)
         self.assertIn("run_inference_in_docker", self.launcher)
         self.assertIn('f"eval_predictions_{test_input.name}.csv"', self.launcher)
         self.assertIn("agentomics.runtime.report_workflow", self.launcher)

--- a/test/test_run_launcher_container_contract.py
+++ b/test/test_run_launcher_container_contract.py
@@ -51,7 +51,7 @@ class RunLauncherSourceContractTest(unittest.TestCase):
         # the best model on every test-prefixed split via inference.
         self.assertNotIn("test_datasets", self.launcher)
         self.assertNotIn("--test-datasets-dir", self.launcher)
-        self.assertIn('path.name.startswith("test")', self.launcher)
+        self.assertIn("path.name.startswith(TEST_SPLIT)", self.launcher)
         self.assertIn("run_inference_in_docker", self.launcher)
         self.assertIn('f"eval_predictions_{test_input.name}.csv"', self.launcher)
         self.assertIn("agentomics.runtime.report_workflow", self.launcher)

--- a/test/test_run_launcher_container_contract.py
+++ b/test/test_run_launcher_container_contract.py
@@ -53,7 +53,7 @@ class RunLauncherSourceContractTest(unittest.TestCase):
         self.assertNotIn("--test-datasets-dir", self.launcher)
         self.assertIn('path.name.startswith("test")', self.launcher)
         self.assertIn("run_inference_in_docker", self.launcher)
-        self.assertIn('f"eval_predictions_{split_name}.csv"', self.launcher)
+        self.assertIn('f"eval_predictions_{test_input.name}.csv"', self.launcher)
         self.assertIn("agentomics.runtime.report_workflow", self.launcher)
 
     def test_help_text_has_no_prepared_datasets_user_concept(self):

--- a/test/test_run_launcher_container_contract.py
+++ b/test/test_run_launcher_container_contract.py
@@ -46,14 +46,14 @@ class RunLauncherSourceContractTest(unittest.TestCase):
     def test_launcher_invokes_container_workflow(self):
         self.assertIn("agentomics.runtime.run_workflow", self.launcher)
 
-    def test_test_evaluation_reuses_inference_on_co_located_split(self):
+    def test_test_evaluation_reuses_inference_on_co_located_splits(self):
         # The old separate hidden-test tree and flag are gone; evaluation runs
-        # the best model on the dataset's own ``test`` split via inference.
+        # the best model on every test-prefixed split via inference.
         self.assertNotIn("test_datasets", self.launcher)
         self.assertNotIn("--test-datasets-dir", self.launcher)
-        self.assertIn('dataset_directory / "test"', self.launcher)
+        self.assertIn('path.name.startswith("test")', self.launcher)
         self.assertIn("run_inference_in_docker", self.launcher)
-        self.assertIn('"eval_predictions_test.csv"', self.launcher)
+        self.assertIn('f"eval_predictions_{split_name}.csv"', self.launcher)
         self.assertIn("agentomics.runtime.report_workflow", self.launcher)
 
     def test_help_text_has_no_prepared_datasets_user_concept(self):


### PR DESCRIPTION
- Evaluates every top-level dataset directory whose name starts with `test`.
- Saves predictions and metrics separately for each test set.
- Logs metrics to W&B using the test directory name as the namespace, such as `test_1/AUROC`.
- Includes all discovered test sets in the generated PDF report.
- Forwards standard proxy variables to inference containers so W&B logging works in proxied environments.
- Preserves the existing `test.csv` fallback.