### PR TITLE
Improve image rebuild for development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-
 FROM --platform=$BUILDPLATFORM alpine:3.23.4 AS source
 ARG REPOSITORY_SOURCE=https://github.com/BioGeMT/Agentomics-ML.git#main
 ADD ${REPOSITORY_SOURCE} /repository
@@ -14,10 +13,10 @@ ENV PIP_NO_CACHE_DIR=1
 # Suppress pip version warnings
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1
 
-COPY --from=source /repository/envs/environment.yaml /envs/
+COPY --from=source /repository/envs/environment.yaml /build/
 
 # Create the conda environment with mamba for speed and memory efficiency.
-RUN mamba env create -f /envs/environment.yaml \
+RUN mamba env create -f /build/environment.yaml \
     && mamba clean -afy \
     && rm -rf /tmp/conda-pkgs
 
@@ -26,12 +25,12 @@ RUN conda init bash \
     && echo "conda activate agentomics-env" >> /root/.bashrc
 
 # Setup agent start environment
-COPY --from=source /repository/envs/environment_agent.yaml /envs/
+COPY --from=source /repository/envs/environment_agent.yaml /build/
 ENV START_ENV_PKG=/opt/agent_start_env.tar.gz
 # Preload libgomp on env activation so it claims a static TLS slot before
 # torch's shared libs consume them all. Without this, sklearn (imported via
 # transformers) fails with "cannot allocate memory in static TLS block".
-RUN mamba env create -f /envs/environment_agent.yaml \
+RUN mamba env create -f /build/environment_agent.yaml \
     && mkdir -p /opt/conda/envs/agent_start_env/etc/conda/activate.d \
     && echo 'export LD_PRELOAD=$CONDA_PREFIX/lib/libgomp.so.1' \
        > /opt/conda/envs/agent_start_env/etc/conda/activate.d/preload_libgomp.sh \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
-FROM condaforge/miniforge3:26.3.2-3
 
+FROM --platform=$BUILDPLATFORM alpine:3.23.4 AS source
 ARG REPOSITORY_SOURCE=https://github.com/BioGeMT/Agentomics-ML.git#main
 ADD ${REPOSITORY_SOURCE} /repository
+
+FROM condaforge/miniforge3:26.3.2-3
 
 # Always set -y to conda install commands
 ENV CONDA_ALWAYS_YES=true 
@@ -12,8 +14,10 @@ ENV PIP_NO_CACHE_DIR=1
 # Suppress pip version warnings
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1
 
+COPY --from=source /repository/envs/environment.yaml /envs/
+
 # Create the conda environment with mamba for speed and memory efficiency.
-RUN mamba env create -f /repository/envs/environment.yaml \
+RUN mamba env create -f /envs/environment.yaml \
     && mamba clean -afy \
     && rm -rf /tmp/conda-pkgs
 
@@ -22,11 +26,12 @@ RUN conda init bash \
     && echo "conda activate agentomics-env" >> /root/.bashrc
 
 # Setup agent start environment
+COPY --from=source /repository/envs/environment_agent.yaml /envs/
 ENV START_ENV_PKG=/opt/agent_start_env.tar.gz
 # Preload libgomp on env activation so it claims a static TLS slot before
 # torch's shared libs consume them all. Without this, sklearn (imported via
 # transformers) fails with "cannot allocate memory in static TLS block".
-RUN mamba env create -f /repository/envs/environment_agent.yaml \
+RUN mamba env create -f /envs/environment_agent.yaml \
     && mkdir -p /opt/conda/envs/agent_start_env/etc/conda/activate.d \
     && echo 'export LD_PRELOAD=$CONDA_PREFIX/lib/libgomp.so.1' \
        > /opt/conda/envs/agent_start_env/etc/conda/activate.d/preload_libgomp.sh \
@@ -43,6 +48,8 @@ RUN git config --system --add safe.directory /workspace
 ENV AGENT_USER=agentomics-agent
 ENV PYTHONPATH=/repository/src
 RUN mkdir -p /workspace
+
+COPY --from=source /repository /repository
 
 WORKDIR /repository
 

--- a/docs/developer/releasing.md
+++ b/docs/developer/releasing.md
@@ -45,8 +45,3 @@ against it with `--image` — nothing is pushed to any registry:
 docker build --build-arg REPOSITORY_SOURCE=. -t agentomics:dev .
 agentomics-run --image agentomics:dev --dataset <name>
 ```
-
-The `Dockerfile` copies `envs/` in before creating the conda environments and the
-rest of the sources in after, so rebuilds skip the environments unless `envs/`
-changed. When the code diff touches `envs/`, expect the environments to rebuild
-(a build that skips them would test that code against your old dependencies).

--- a/docs/developer/releasing.md
+++ b/docs/developer/releasing.md
@@ -45,3 +45,8 @@ against it with `--image` — nothing is pushed to any registry:
 docker build --build-arg REPOSITORY_SOURCE=. -t agentomics:dev .
 agentomics-run --image agentomics:dev --dataset <name>
 ```
+
+The `Dockerfile` copies `envs/` in before creating the conda environments and the
+rest of the sources in after, so rebuilds skip the environments unless `envs/`
+changed. When the code diff touches `envs/`, expect the environments to rebuild
+(a build that skips them would test that code against your old dependencies).


### PR DESCRIPTION
This PR will:
- Reorder the Dockerfile so `envs/` is copied in before the conda environments are created and the
  sources after, letting code-only rebuilds reuse the cached environments instead of rebuilding both envs.
- `ADD` is the only instruction that accepts a Git URL and it cannot fetch a subdirectory, so the tree
  is fetched once into a throwaway `alpine` stage and copied out in pieces. 
- Build commands, `REPOSITORY_SOURCE` (Git URL or `.`) and `scripts/release.sh` are unchanged.
- Small additional explanation in docs.
- Rebased main on 30/07