### PR TITLE
fix: Fix broken instructions for pypi publishing

### DIFF
--- a/docs/developer/release-administration.md
+++ b/docs/developer/release-administration.md
@@ -171,7 +171,7 @@ Publisher with these exact values:
 | Field | Value |
 | --- | --- |
 | Repository owner | `BioGeMT` |
-| Repository name | `Agentomics-ML` |
+| Repository name | `agentomics-ml` |
 | Workflow filename | `publish-release.yml` |
 | Environment name | `pypi` |
 


### PR DESCRIPTION
This will also serve as a prototype for 1.0.6 automatic release