### PR TITLE
perf: parallelize conda-pack environment export

### DIFF
--- a/src/agentomics/runtime/conda_utils.py
+++ b/src/agentomics/runtime/conda_utils.py
@@ -55,6 +55,7 @@ def export_environment_archive(env_path: Path, archive_path: Path) -> None:
             str(Path(sys.executable).parent / "conda-pack"),
             "-p", str(env_path),
             "-o", str(archive_path),
+            "-j", "-1",
             "--force",
             "--quiet",
         ],


### PR DESCRIPTION
This PR will:
- Use all the available cores when exporting environment using conda-pack