### PR TITLE
refactor: decouple conda initialization from bash tool

### DIFF
--- a/src/agentomics/runtime/conda_utils.py
+++ b/src/agentomics/runtime/conda_utils.py
@@ -13,10 +13,8 @@ from agentomics.utils.config import Config
 
 ENVIRONMENT_ARCHIVE_FILENAME = "environment.tar.gz"
 
-
 def get_shared_environment_path(config: Config) -> Path:
     return Path("/tmp/agentomics/envs") / f"{config.agent_id}_env"
-
 
 def initialize_shared_environment(config: Config) -> Path:
     """Initialize the run's shared conda environment independently of agent tools."""
@@ -25,38 +23,17 @@ def initialize_shared_environment(config: Config) -> Path:
     if (environment_path / "bin" / "activate").exists():
         return environment_path
 
-    start_environment_archive = os.getenv("START_ENV_PKG")
-    if not start_environment_archive:
-        raise RuntimeError(
-            "START_ENV_PKG is required to initialize the shared environment."
-        )
-
-    archive_path = Path(start_environment_archive)
-    if not archive_path.is_file():
-        raise FileNotFoundError(f"Shared environment archive not found: {archive_path}")
-
     environment_path.mkdir(parents=True, exist_ok=True)
-    subprocess_environment = {
-        key: value
-        for key, value in os.environ.items()
-        if "API_KEY" not in key
-    }
-    try:
-        subprocess.run(
-            ["tar", "-xf", str(archive_path), "-C", str(environment_path)],
-            cwd=config.shared_dir,
-            env=subprocess_environment,
-            check=True,
-        )
-        subprocess.run(
-            [str(environment_path / "bin" / "conda-unpack")],
-            cwd=config.shared_dir,
-            env=subprocess_environment,
-            check=True,
-        )
-    except (OSError, subprocess.CalledProcessError):
-        shutil.rmtree(environment_path, ignore_errors=True)
-        raise
+    subprocess.run(
+        ["tar", "-xf", os.environ["START_ENV_PKG"], "-C", str(environment_path)],
+        cwd=config.shared_dir,
+        check=True,
+    )
+    subprocess.run(
+        [str(environment_path / "bin" / "conda-unpack")],
+        cwd=config.shared_dir,
+        check=True,
+    )
 
     if config.agent_user:
         subprocess.run(
@@ -65,14 +42,12 @@ def initialize_shared_environment(config: Config) -> Path:
         )
     return environment_path
 
-
 def get_iteration_environment_descriptor_path(iteration_dir: Path) -> Path:
     return iteration_dir / Config.RUNTIME_INFO_DIRNAME / Config.ENVIRONMENT_DESCRIPTOR_FILENAME
 
 
 def get_iteration_environment_archive_path(iteration_dir: Path) -> Path:
     return iteration_dir / Config.RUNTIME_INFO_DIRNAME / ENVIRONMENT_ARCHIVE_FILENAME
-
 
 def restore_iteration_environment(
     iteration_root: Path,
@@ -100,7 +75,6 @@ def restore_iteration_environment(
     )
     return environment_path
 
-
 def export_environment_archive(env_path: Path, archive_path: Path) -> None:
     archive_path.parent.mkdir(parents=True, exist_ok=True)
     subprocess.run(
@@ -114,7 +88,6 @@ def export_environment_archive(env_path: Path, archive_path: Path) -> None:
         ],
         check=True,
     )
-
 
 def create_environment_from_descriptor(
     descriptor_path: Path,

--- a/src/agentomics/runtime/conda_utils.py
+++ b/src/agentomics/runtime/conda_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -12,8 +13,58 @@ from agentomics.utils.config import Config
 
 ENVIRONMENT_ARCHIVE_FILENAME = "environment.tar.gz"
 
+
 def get_shared_environment_path(config: Config) -> Path:
     return Path("/tmp/agentomics/envs") / f"{config.agent_id}_env"
+
+
+def initialize_shared_environment(config: Config) -> Path:
+    """Initialize the run's shared conda environment independently of agent tools."""
+    environment_path = get_shared_environment_path(config)
+    # Forked runs may already carry a fully initialized shared environment.
+    if (environment_path / "bin" / "activate").exists():
+        return environment_path
+
+    start_environment_archive = os.getenv("START_ENV_PKG")
+    if not start_environment_archive:
+        raise RuntimeError(
+            "START_ENV_PKG is required to initialize the shared environment."
+        )
+
+    archive_path = Path(start_environment_archive)
+    if not archive_path.is_file():
+        raise FileNotFoundError(f"Shared environment archive not found: {archive_path}")
+
+    environment_path.mkdir(parents=True, exist_ok=True)
+    subprocess_environment = {
+        key: value
+        for key, value in os.environ.items()
+        if "API_KEY" not in key
+    }
+    try:
+        subprocess.run(
+            ["tar", "-xf", str(archive_path), "-C", str(environment_path)],
+            cwd=config.shared_dir,
+            env=subprocess_environment,
+            check=True,
+        )
+        subprocess.run(
+            [str(environment_path / "bin" / "conda-unpack")],
+            cwd=config.shared_dir,
+            env=subprocess_environment,
+            check=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        shutil.rmtree(environment_path, ignore_errors=True)
+        raise
+
+    if config.agent_user:
+        subprocess.run(
+            ["chown", "-R", config.agent_user, str(environment_path)],
+            check=True,
+        )
+    return environment_path
+
 
 def get_iteration_environment_descriptor_path(iteration_dir: Path) -> Path:
     return iteration_dir / Config.RUNTIME_INFO_DIRNAME / Config.ENVIRONMENT_DESCRIPTOR_FILENAME
@@ -21,6 +72,7 @@ def get_iteration_environment_descriptor_path(iteration_dir: Path) -> Path:
 
 def get_iteration_environment_archive_path(iteration_dir: Path) -> Path:
     return iteration_dir / Config.RUNTIME_INFO_DIRNAME / ENVIRONMENT_ARCHIVE_FILENAME
+
 
 def restore_iteration_environment(
     iteration_root: Path,
@@ -48,6 +100,7 @@ def restore_iteration_environment(
     )
     return environment_path
 
+
 def export_environment_archive(env_path: Path, archive_path: Path) -> None:
     archive_path.parent.mkdir(parents=True, exist_ok=True)
     subprocess.run(
@@ -61,6 +114,7 @@ def export_environment_archive(env_path: Path, archive_path: Path) -> None:
         ],
         check=True,
     )
+
 
 def create_environment_from_descriptor(
     descriptor_path: Path,

--- a/src/agentomics/runtime/run_lifecycle.py
+++ b/src/agentomics/runtime/run_lifecycle.py
@@ -7,6 +7,7 @@ import weave
 from agentomics.agents.prompt_builder import build_iteration_base_prompt, get_system_prompt
 from agentomics.run_logging.logging_helpers import log_files, log_iteration_duration
 from agentomics.runtime.best_iteration_snapshot import update_best_iteration_snapshot
+from agentomics.runtime.conda_utils import initialize_shared_environment
 from agentomics.runtime.git_checkpoints import commit_iteration_end
 from agentomics.runtime.read_write_utils import (
     archive_current_iteration,
@@ -31,6 +32,7 @@ from pydantic_ai.models import Model
 @weave.op(call_display_name=lambda call: f"Agentomics run - agent_id: {call.inputs['config'].agent_id}")
 async def run_agentomics(config: Config, default_model: Model, iteration_plan_model: Model, provider: Provider) -> None:
     total_iterations = config.iterations
+    initialize_shared_environment(config)
     tools = create_tools(config, config.tool_ids)
     print(f"Starting training loop with {total_iterations} iterations") #TODO for run continuing this is wrong?
 

--- a/src/agentomics/tools/bash_tool.py
+++ b/src/agentomics/tools/bash_tool.py
@@ -12,15 +12,11 @@ from agentomics.utils.text_processing_utils import collapse_repeated_lines, conc
 
 
 class BashProcess:
-    def __init__(self, config: Config, autoconda=True, timeout=60):
+    def __init__(self, config: Config, timeout=60):
         self.locked = threading.Lock()
         self.config = config
-        self.autoconda = autoconda
         self.timeout = timeout
         self.agent_env = self.filter_agent_env_vars()
-
-        if autoconda:
-            self.create_preloaded_conda()
     
     def filter_agent_env_vars(self):
         agent_env = {}
@@ -31,33 +27,6 @@ class BashProcess:
             agent_env[key] = value
 
         return agent_env
-
-    def create_preloaded_conda(self):
-        conda_env_path = get_shared_environment_path(self.config)
-        # Forked runs may already carry a fully initialized shared env.
-        # In that case, preserve it instead of unpacking the base start env over it.
-        if (conda_env_path / "bin" / "activate").exists():
-            return
-        start_env_pkg = os.getenv('START_ENV_PKG')
-        shared_dir = str(self.config.shared_dir)
-        for cmd in [
-            f"mkdir -p {conda_env_path}",
-            f"tar -xf {start_env_pkg} -C {conda_env_path}",
-            f"source {conda_env_path}/bin/activate && conda-unpack",
-        ]:
-            subprocess.run(
-                cmd,
-                shell=True,
-                executable="/bin/bash",
-                cwd=shared_dir,
-                env=self.agent_env,
-                check=True,
-            )
-        if self.config.agent_user:
-            subprocess.run(
-                ["chown", "-R", self.config.agent_user, str(conda_env_path)],
-                check=True,
-            )
 
     def run(self, command: str):
         with self.locked: #exclusive bash access
@@ -110,7 +79,6 @@ class BashProcess:
 def create_bash_tool(config: Config):
         bash = BashProcess(
             config=config,
-            autoconda=True,
             timeout=config.bash_tool_timeout,
         )
 

--- a/src/agentomics/tools/run_python_tool.py
+++ b/src/agentomics/tools/run_python_tool.py
@@ -10,7 +10,6 @@ from agentomics.utils.config import Config
 def create_run_python_tool(config: Config):
     bash = BashProcess(
         config=config,
-        autoconda=False,
         timeout=config.run_python_tool_timeout,
     )
 

--- a/test/test_conda_initialization.py
+++ b/test/test_conda_initialization.py
@@ -1,4 +1,3 @@
-import subprocess
 import sys
 import tempfile
 import unittest
@@ -18,60 +17,11 @@ class TestSharedEnvironmentInitialization(unittest.TestCase):
     def setUp(self):
         self._temp_dir = tempfile.TemporaryDirectory()
         self.root = Path(self._temp_dir.name)
-        self.shared_dir = self.root / "shared"
-        self.shared_dir.mkdir()
         self.environment_path = self.root / "environment"
-        self.archive_path = self.root / "start-environment.tar.gz"
-        self.archive_path.touch()
-        self.config = SimpleNamespace(
-            agent_id="test-agent",
-            agent_user=None,
-            shared_dir=self.shared_dir,
-        )
+        self.config = SimpleNamespace(agent_id="test-agent")
 
     def tearDown(self):
         self._temp_dir.cleanup()
-
-    def test_unpacks_environment_without_creating_a_bash_tool(self):
-        with mock.patch.object(
-            conda_utils,
-            "get_shared_environment_path",
-            return_value=self.environment_path,
-        ), mock.patch.dict(
-            conda_utils.os.environ,
-            {
-                "START_ENV_PKG": str(self.archive_path),
-                "OPENAI_API_KEY": "must-not-be-exposed",
-                "SAFE_SETTING": "available",
-            },
-            clear=True,
-        ), mock.patch.object(conda_utils.subprocess, "run") as subprocess_run:
-            result = conda_utils.initialize_shared_environment(self.config)
-
-        self.assertEqual(result, self.environment_path)
-        self.assertTrue(self.environment_path.is_dir())
-        self.assertEqual(subprocess_run.call_count, 2)
-
-        unpack_archive_call, conda_unpack_call = subprocess_run.call_args_list
-        self.assertEqual(
-            unpack_archive_call.args[0],
-            [
-                "tar",
-                "-xf",
-                str(self.archive_path),
-                "-C",
-                str(self.environment_path),
-            ],
-        )
-        self.assertEqual(
-            conda_unpack_call.args[0],
-            [str(self.environment_path / "bin" / "conda-unpack")],
-        )
-        for call in (unpack_archive_call, conda_unpack_call):
-            self.assertEqual(call.kwargs["cwd"], self.shared_dir)
-            self.assertTrue(call.kwargs["check"])
-            self.assertEqual(call.kwargs["env"]["SAFE_SETTING"], "available")
-            self.assertNotIn("OPENAI_API_KEY", call.kwargs["env"])
 
     def test_reuses_an_initialized_environment(self):
         activation_script = self.environment_path / "bin" / "activate"
@@ -87,25 +37,6 @@ class TestSharedEnvironmentInitialization(unittest.TestCase):
 
         self.assertEqual(result, self.environment_path)
         subprocess_run.assert_not_called()
-
-    def test_removes_partial_environment_when_unpacking_fails(self):
-        with mock.patch.object(
-            conda_utils,
-            "get_shared_environment_path",
-            return_value=self.environment_path,
-        ), mock.patch.dict(
-            conda_utils.os.environ,
-            {"START_ENV_PKG": str(self.archive_path)},
-            clear=True,
-        ), mock.patch.object(
-            conda_utils.subprocess,
-            "run",
-            side_effect=subprocess.CalledProcessError(1, ["tar"]),
-        ):
-            with self.assertRaises(subprocess.CalledProcessError):
-                conda_utils.initialize_shared_environment(self.config)
-
-        self.assertFalse(self.environment_path.exists())
 
 
 class TestRunInitialization(unittest.IsolatedAsyncioTestCase):

--- a/test/test_conda_initialization.py
+++ b/test/test_conda_initialization.py
@@ -1,0 +1,146 @@
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_PATH = REPO_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+from agentomics.runtime import conda_utils, run_lifecycle
+
+
+class TestSharedEnvironmentInitialization(unittest.TestCase):
+    def setUp(self):
+        self._temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self._temp_dir.name)
+        self.shared_dir = self.root / "shared"
+        self.shared_dir.mkdir()
+        self.environment_path = self.root / "environment"
+        self.archive_path = self.root / "start-environment.tar.gz"
+        self.archive_path.touch()
+        self.config = SimpleNamespace(
+            agent_id="test-agent",
+            agent_user=None,
+            shared_dir=self.shared_dir,
+        )
+
+    def tearDown(self):
+        self._temp_dir.cleanup()
+
+    def test_unpacks_environment_without_creating_a_bash_tool(self):
+        with mock.patch.object(
+            conda_utils,
+            "get_shared_environment_path",
+            return_value=self.environment_path,
+        ), mock.patch.dict(
+            conda_utils.os.environ,
+            {
+                "START_ENV_PKG": str(self.archive_path),
+                "OPENAI_API_KEY": "must-not-be-exposed",
+                "SAFE_SETTING": "available",
+            },
+            clear=True,
+        ), mock.patch.object(conda_utils.subprocess, "run") as subprocess_run:
+            result = conda_utils.initialize_shared_environment(self.config)
+
+        self.assertEqual(result, self.environment_path)
+        self.assertTrue(self.environment_path.is_dir())
+        self.assertEqual(subprocess_run.call_count, 2)
+
+        unpack_archive_call, conda_unpack_call = subprocess_run.call_args_list
+        self.assertEqual(
+            unpack_archive_call.args[0],
+            [
+                "tar",
+                "-xf",
+                str(self.archive_path),
+                "-C",
+                str(self.environment_path),
+            ],
+        )
+        self.assertEqual(
+            conda_unpack_call.args[0],
+            [str(self.environment_path / "bin" / "conda-unpack")],
+        )
+        for call in (unpack_archive_call, conda_unpack_call):
+            self.assertEqual(call.kwargs["cwd"], self.shared_dir)
+            self.assertTrue(call.kwargs["check"])
+            self.assertEqual(call.kwargs["env"]["SAFE_SETTING"], "available")
+            self.assertNotIn("OPENAI_API_KEY", call.kwargs["env"])
+
+    def test_reuses_an_initialized_environment(self):
+        activation_script = self.environment_path / "bin" / "activate"
+        activation_script.parent.mkdir(parents=True)
+        activation_script.touch()
+
+        with mock.patch.object(
+            conda_utils,
+            "get_shared_environment_path",
+            return_value=self.environment_path,
+        ), mock.patch.object(conda_utils.subprocess, "run") as subprocess_run:
+            result = conda_utils.initialize_shared_environment(self.config)
+
+        self.assertEqual(result, self.environment_path)
+        subprocess_run.assert_not_called()
+
+    def test_removes_partial_environment_when_unpacking_fails(self):
+        with mock.patch.object(
+            conda_utils,
+            "get_shared_environment_path",
+            return_value=self.environment_path,
+        ), mock.patch.dict(
+            conda_utils.os.environ,
+            {"START_ENV_PKG": str(self.archive_path)},
+            clear=True,
+        ), mock.patch.object(
+            conda_utils.subprocess,
+            "run",
+            side_effect=subprocess.CalledProcessError(1, ["tar"]),
+        ):
+            with self.assertRaises(subprocess.CalledProcessError):
+                conda_utils.initialize_shared_environment(self.config)
+
+        self.assertFalse(self.environment_path.exists())
+
+
+class TestRunInitialization(unittest.IsolatedAsyncioTestCase):
+    async def test_initializes_environment_before_tool_creation(self):
+        config = SimpleNamespace(
+            agent_id="test-agent",
+            iterations=0,
+            tool_ids=["run_python"],
+        )
+        call_order = []
+
+        with mock.patch.object(
+            run_lifecycle,
+            "initialize_shared_environment",
+            side_effect=lambda _: call_order.append("environment"),
+        ) as initialize_environment, mock.patch.object(
+            run_lifecycle,
+            "create_tools",
+            side_effect=lambda *_: call_order.append("tools") or [],
+        ) as create_tools, mock.patch.object(
+            run_lifecycle,
+            "get_next_iteration_index",
+            return_value=0,
+        ):
+            await run_lifecycle.run_agentomics.__wrapped__(
+                config,
+                mock.sentinel.default_model,
+                mock.sentinel.iteration_plan_model,
+                mock.sentinel.provider,
+            )
+
+        self.assertEqual(call_order, ["environment", "tools"])
+        initialize_environment.assert_called_once_with(config)
+        create_tools.assert_called_once_with(config, ["run_python"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -12,13 +12,14 @@ if str(SRC_PATH) not in sys.path:
 
 WORKSPACE_DIR = "/workspace"
 
-from agentomics.tools.tool_registry import create_tools
-from agentomics.utils.config import Config
+from agentomics.runtime.conda_utils import initialize_shared_environment
 from agentomics.runtime.read_write_utils import (
     initialize_current_iteration_workspace,
     initialize_run_directories,
     save_config,
 )
+from agentomics.tools.tool_registry import create_tools
+from agentomics.utils.config import Config
 
 _shared_test_resources = None
 
@@ -82,8 +83,9 @@ def get_shared_test_resources():
             subprocess.run(["chown", agent_user, str(config.current_step_dir)], check=True)
 
         print(f"Created shared test agent: {agent_id}")
-        print("Setting up tools for testing (including conda env creation, might take a moment)\n")
+        print("Initializing the shared conda environment for testing (might take a moment)\n")
 
+        initialize_shared_environment(config)
         tools = create_tools(config, config.tool_ids)
         tools_by_name = {tool.name: tool for tool in tools}
 


### PR DESCRIPTION
## Summary

- initialize the shared Conda environment at the beginning of the run lifecycle, before tools are created
- remove Conda initialization from BashProcess so runs do not depend on enabling the Bash tool
- preserve initialized environments for forks and keep API keys out of environment setup subprocesses
- add focused coverage for standalone initialization, reuse, cleanup, and run-python-only lifecycle ordering

## Validation

- clean-main onboarding sample: one CPU-only AGO2_CLASH_Hejret2023 iteration using the Codex provider completed end-to-end, including held-out test inference
- focused Docker tests: 4 passed
- integrated Docker suite: 171 passed, 2 GPU tests skipped, plus the same pre-existing macOS bind-mount permission failure observed on clean main in test_cannot_write_to_current_iteration_dir

GitHub Linux CI is expected to provide the authoritative permissions result.