### PR TITLE
refactor: remove agent_user checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,6 @@ RUN mamba env create -f /build/environment_agent.yaml \
 # The runtime (root) owns the workspace; only current_step_dir is chowned to this user per step.
 RUN useradd -m -s /bin/bash agentomics-agent
 RUN git config --system --add safe.directory /workspace
-ENV AGENT_USER=agentomics-agent
 ENV PYTHONPATH=/repository/src
 RUN mkdir -p /workspace
 

--- a/src/agentomics/agents/steps/base.py
+++ b/src/agentomics/agents/steps/base.py
@@ -74,11 +74,10 @@ class RuntimeStep(ABC):
         iteration = load_current_iteration_index(self.config)
         _console.print(f"[bold purple]ITERATION {iteration} | {self.display_name} STEP[/bold purple]")
         self.config.current_step_dir.mkdir(exist_ok=True)
-        if self.config.agent_user:
-            subprocess.run(
-                ["chown", self.config.agent_user, str(self.config.current_step_dir)],
-                check=True,
-            )
+        subprocess.run(
+            ["chown", self.config.agent_user, str(self.config.current_step_dir)],
+            check=True,
+        )
 
     def on_step_success(self, output: Any) -> None:
         save_step_output(self.config, self.step_id, output)
@@ -101,8 +100,7 @@ class RuntimeStep(ABC):
         rewrite_symlinks_to_absolute(step_dir)
         step_dir.rename(archived_dir)
         self._rewrite_paths_in_step_output(archived_dir, str(step_dir), str(archived_dir))
-        if self.config.agent_user:
-            chown_tree_to_root(archived_dir)
+        chown_tree_to_root(archived_dir)
 
     def _rewrite_paths_in_step_output(self, directory: Path, old: str, new: str) -> None:
         output_file = directory / Config.STEP_OUTPUT_FILENAME

--- a/src/agentomics/agents/steps/base.py
+++ b/src/agentomics/agents/steps/base.py
@@ -75,7 +75,7 @@ class RuntimeStep(ABC):
         _console.print(f"[bold purple]ITERATION {iteration} | {self.display_name} STEP[/bold purple]")
         self.config.current_step_dir.mkdir(exist_ok=True)
         subprocess.run(
-            ["chown", self.config.agent_user, str(self.config.current_step_dir)],
+            ["chown", self.config.AGENT_USER, str(self.config.current_step_dir)],
             check=True,
         )
 

--- a/src/agentomics/agents/steps/data_split.py
+++ b/src/agentomics/agents/steps/data_split.py
@@ -342,8 +342,7 @@ class DataSplitStep(AgenticStep):
         )
 
     def on_step_success(self, output: DataSplitOutput) -> None:
-        if self.config.agent_user:
-            chown_tree_to_root(Path(output.train_path).parent)
+        chown_tree_to_root(Path(output.train_path).parent)
         super().on_step_success(output)
 
     def on_iteration_fail(self, iteration: int) -> None:

--- a/src/agentomics/run_agent.py
+++ b/src/agentomics/run_agent.py
@@ -49,7 +49,6 @@ async def run_experiment(
     split_time_deadline = time.time() + split_timeout if split_timeout is not None else None
 
     agent_id = os.getenv("AGENT_ID")
-    agent_user = os.getenv("AGENT_USER")
     config = Config(
         agent_id=agent_id,
         model_name=model,
@@ -70,7 +69,6 @@ async def run_experiment(
         time_deadline=time_deadline,
         split_time_deadline=split_time_deadline,
         run_python_tool_timeout=run_python_timeout,
-        agent_user=agent_user,
         disable_training_reporting=disable_training_reporting,
         conda_export_mode=conda_export_mode
     )

--- a/src/agentomics/runtime/conda_utils.py
+++ b/src/agentomics/runtime/conda_utils.py
@@ -36,7 +36,7 @@ def initialize_shared_environment(config: Config) -> Path:
     )
 
     subprocess.run(
-        ["chown", "-R", config.agent_user, str(environment_path)],
+        ["chown", "-R", config.AGENT_USER, str(environment_path)],
         check=True,
     )
     return environment_path

--- a/src/agentomics/runtime/conda_utils.py
+++ b/src/agentomics/runtime/conda_utils.py
@@ -35,11 +35,10 @@ def initialize_shared_environment(config: Config) -> Path:
         check=True,
     )
 
-    if config.agent_user:
-        subprocess.run(
-            ["chown", "-R", config.agent_user, str(environment_path)],
-            check=True,
-        )
+    subprocess.run(
+        ["chown", "-R", config.agent_user, str(environment_path)],
+        check=True,
+    )
     return environment_path
 
 def get_iteration_environment_descriptor_path(iteration_dir: Path) -> Path:

--- a/src/agentomics/runtime/read_write_utils.py
+++ b/src/agentomics/runtime/read_write_utils.py
@@ -60,8 +60,7 @@ def load_config_from_run_dir_and_reroot(run_dir: Path) -> Config:
 def initialize_current_iteration_workspace(config: Config) -> None:
     config.current_iteration_dir.mkdir(parents=True, exist_ok=True)
     config.current_iteration_runtime_info_dir.mkdir(exist_ok=True)
-    if config.agent_user:
-        chown_tree_to_root(config.current_iteration_dir)
+    chown_tree_to_root(config.current_iteration_dir)
 
 def archive_current_iteration(config: Config, iteration: int) -> None:
     export_shared_environment_descriptor(config)
@@ -77,8 +76,7 @@ def archive_current_iteration(config: Config, iteration: int) -> None:
     if archived_iteration_dir.exists():
         remove_path(archived_iteration_dir)
     current_iteration_dir.replace(archived_iteration_dir)
-    if config.agent_user:
-        chown_tree_to_root(archived_iteration_dir)
+    chown_tree_to_root(archived_iteration_dir)
 
 def get_archived_iterations(
     config: Config,

--- a/src/agentomics/tools/bash_tool.py
+++ b/src/agentomics/tools/bash_tool.py
@@ -104,8 +104,7 @@ def create_bash_tool(config: Config):
             env_path = get_shared_environment_path(config)
             command_parsed = shlex.quote(command)
             command = f"conda run -p {env_path} --no-capture-output bash -c {command_parsed}"
-            if config.agent_user:
-                command = f"runuser -u {config.agent_user} -- {command}"
+            command = f"runuser -u {config.agent_user} -- {command}"
             out = bash.run(command)
             timer_msg = f"\n[Tool call took {time.time() - start_time:.1f} seconds]"
             return out + timer_msg

--- a/src/agentomics/tools/bash_tool.py
+++ b/src/agentomics/tools/bash_tool.py
@@ -104,7 +104,7 @@ def create_bash_tool(config: Config):
             env_path = get_shared_environment_path(config)
             command_parsed = shlex.quote(command)
             command = f"conda run -p {env_path} --no-capture-output bash -c {command_parsed}"
-            command = f"runuser -u {config.agent_user} -- {command}"
+            command = f"runuser -u {config.AGENT_USER} -- {command}"
             out = bash.run(command)
             timer_msg = f"\n[Tool call took {time.time() - start_time:.1f} seconds]"
             return out + timer_msg

--- a/src/agentomics/tools/run_python_tool.py
+++ b/src/agentomics/tools/run_python_tool.py
@@ -36,7 +36,7 @@ def create_run_python_tool(config: Config):
             command = f"conda run -p {env_path} --no-capture-output python {python_file_path} {args.strip()}"
         else:
             command = f"conda run -p {env_path} --no-capture-output python {python_file_path}"
-        command = f"runuser -u {config.agent_user} -- {command}"
+        command = f"runuser -u {config.AGENT_USER} -- {command}"
         out = bash.run(command)
         timer_msg = f"\n[Tool call took {time.time() - start_time:.1f} seconds]"
         return out + timer_msg

--- a/src/agentomics/tools/run_python_tool.py
+++ b/src/agentomics/tools/run_python_tool.py
@@ -36,8 +36,7 @@ def create_run_python_tool(config: Config):
             command = f"conda run -p {env_path} --no-capture-output python {python_file_path} {args.strip()}"
         else:
             command = f"conda run -p {env_path} --no-capture-output python {python_file_path}"
-        if config.agent_user:
-            command = f"runuser -u {config.agent_user} -- {command}"
+        command = f"runuser -u {config.agent_user} -- {command}"
         out = bash.run(command)
         timer_msg = f"\n[Tool call took {time.time() - start_time:.1f} seconds]"
         return out + timer_msg

--- a/src/agentomics/utils/config.py
+++ b/src/agentomics/utils/config.py
@@ -13,6 +13,7 @@ from agentomics.utils.versioning import get_version
 class Config:
     CONFIG_FILENAME: ClassVar[str] = "config.json"
     RUN_DIRNAME: ClassVar[str] = "run"
+    AGENT_USER: ClassVar[str] = "agentomics-agent"
     SHARED_DIRNAME: ClassVar[str] = "shared"
     RUNTIME_INFO_DIRNAME: ClassVar[str] = "runtime_info"
     BEST_ITERATION_SNAPSHOT_DIRNAME: ClassVar[str] = "best_iteration_snapshot"
@@ -93,7 +94,6 @@ class Config:
     max_tool_retries: int = DEFAULT_MAX_TOOL_RETRIES
     label_to_scalar: dict[str, int] | None = None
     wandb_run_id: str | None = None
-    agent_user: str | None = None
 
     @property
     def run_dir(self) -> Path:

--- a/test/test_agent_permissions.py
+++ b/test/test_agent_permissions.py
@@ -1,6 +1,5 @@
 import os
 import subprocess
-import unittest
 
 from test.test_utils import BaseAgentTest
 from agentomics.runtime.conda_utils import get_shared_environment_path
@@ -85,7 +84,6 @@ class TestAgentPermissions(BaseAgentTest):
             "The co-located test split must not be exposed to the agent",
         )
 
-    @unittest.skipUnless(os.getenv("AGENT_USER"), "Agent user sandboxing only enforced in Docker mode")
     def test_api_key_protection(self):
         """Test that agent cannot access API keys."""
         
@@ -118,14 +116,12 @@ class TestAgentPermissions(BaseAgentTest):
         self.assertNotIn("Command failed", python_result, "Python command should succeed")
         self.assertIn("Matplotlib version:", python_result, "Should successfully import matplotlib")
 
-    @unittest.skipUnless(os.getenv("AGENT_USER"), "Agent user sandboxing only enforced in Docker mode")
     def test_agent_runs_as_restricted_user(self):
         """Test that agent tool subprocesses run as the restricted agent user, not root."""
         result = self.bash_tool.function("whoami")
         expected_user = os.getenv("AGENT_USER")
         self.assertIn(expected_user, result, f"Agent should run as {expected_user}, got: {result}")
 
-    @unittest.skipUnless(os.getenv("AGENT_USER"), "Agent user sandboxing only enforced in Docker mode")
     def test_cannot_write_to_current_iteration_dir(self):
         """Test that the agent cannot create files directly in current_iteration_dir.
         Only current_step_dir (chowned to the agent user) should be writable."""
@@ -134,7 +130,6 @@ class TestAgentPermissions(BaseAgentTest):
         self.assertIn("Permission denied", result,
                       f"Agent must not write directly to current_iteration_dir. Got: {result}")
 
-    @unittest.skipUnless(os.getenv("AGENT_USER"), "Agent user sandboxing only enforced in Docker mode")
     def test_can_write_to_current_step_dir(self):
         """Test that the agent can write inside current_step_dir (its designated workspace)."""
         test_path = self.config.current_step_dir / "sandbox_write_test.txt"

--- a/test/test_agent_permissions.py
+++ b/test/test_agent_permissions.py
@@ -1,4 +1,3 @@
-import os
 import subprocess
 
 from test.test_utils import BaseAgentTest
@@ -119,7 +118,7 @@ class TestAgentPermissions(BaseAgentTest):
     def test_agent_runs_as_restricted_user(self):
         """Test that agent tool subprocesses run as the restricted agent user, not root."""
         result = self.bash_tool.function("whoami")
-        expected_user = os.getenv("AGENT_USER")
+        expected_user = self.config.AGENT_USER
         self.assertIn(expected_user, result, f"Agent should run as {expected_user}, got: {result}")
 
     def test_cannot_write_to_current_iteration_dir(self):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -48,7 +48,6 @@ def get_shared_test_resources():
     global _shared_test_resources
 
     agent_id = os.getenv('AGENT_ID')
-    agent_user = os.getenv('AGENT_USER')
 
     if _shared_test_resources is None:
         workspace_dir = Path(WORKSPACE_DIR).resolve()
@@ -66,7 +65,6 @@ def get_shared_test_resources():
             datasets_dir=str(dataset_dir.parent),
             iterations=5,
             user_prompt="Create the best possible machine learning model that will generalize to new unseen data.",
-            agent_user=agent_user,
         )
 
         initialize_run_directories(config)
@@ -79,7 +77,7 @@ def get_shared_test_resources():
         # Mirror what on_step_start does: create current_step_dir and assign it to
         # agent_user so the agent has a writable working directory during tests.
         config.current_step_dir.mkdir(exist_ok=True)
-        subprocess.run(["chown", agent_user, str(config.current_step_dir)], check=True)
+        subprocess.run(["chown", config.AGENT_USER, str(config.current_step_dir)], check=True)
 
         print(f"Created shared test agent: {agent_id}")
         print("Initializing the shared conda environment for testing (might take a moment)\n")

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -79,8 +79,7 @@ def get_shared_test_resources():
         # Mirror what on_step_start does: create current_step_dir and assign it to
         # agent_user so the agent has a writable working directory during tests.
         config.current_step_dir.mkdir(exist_ok=True)
-        if agent_user:
-            subprocess.run(["chown", agent_user, str(config.current_step_dir)], check=True)
+        subprocess.run(["chown", agent_user, str(config.current_step_dir)], check=True)
 
         print(f"Created shared test agent: {agent_id}")
         print("Initializing the shared conda environment for testing (might take a moment)\n")


### PR DESCRIPTION
This PR will:
- Remove all the check for agent_user

This is done as the local mode is not existing anymore, and we run always in Docker. The agent_user env variable is always defined (in the docker image), therefore all the if branches checking for its existence are useless.