### PR TITLE
fix: forward proxy settings to docker dev build

### DIFF
--- a/docs/developer/proxy-settings.md
+++ b/docs/developer/proxy-settings.md
@@ -10,6 +10,7 @@ Set these variables for proxy access:
 |----------|-------------|---------|
 | `HTTP_PROXY` | HTTP proxy URL | `http://proxy.company.com:8080` |
 | `HTTPS_PROXY` | HTTPS proxy URL | `http://proxy.company.com:8080` |
+| `ALL_PROXY` | Fallback proxy URL for all protocols | `socks5://proxy.company.com:1080` |
 | `NO_PROXY` | Hosts to bypass | `localhost,127.0.0.1,.internal` |
 
 ### Setting Variables
@@ -32,7 +33,7 @@ NO_PROXY=localhost,127.0.0.1
 
 ## Docker Configuration
 
-Docker requires separate proxy configuration.
+Pulling images from a registry is handled by the Docker daemon. If registry pulls also require a proxy, configure the daemon separately from the proxy settings used by image build steps.
 
 ### Configure Docker Daemon
 
@@ -67,15 +68,12 @@ sudo systemctl show --property=Environment docker
 
 ## Building Images with Proxy
 
-Pass proxy settings as build arguments:
+When an Agentomics command is run with `--dev`, the launcher automatically forwards `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, and `NO_PROXY` to the Dockerbuild. Uppercase and lowercase forms are supported.
+
+Proxy values can be exported in the shell or placed in the `.env` file in the repository root. Exported values take precedence over `.env` values:
 
 ```bash
-docker build \
-  --build-arg HTTP_PROXY=$HTTP_PROXY \
-  --build-arg HTTPS_PROXY=$HTTPS_PROXY \
-  --build-arg http_proxy=$http_proxy \
-  --build-arg https_proxy=$https_proxy \
-  -t agentomics .
+agentomics-run --dev --dataset my_dataset
 ```
 
 ## Running with Proxy

--- a/src/agentomics/cli/docker_utils.py
+++ b/src/agentomics/cli/docker_utils.py
@@ -13,6 +13,46 @@ DEFAULT_IMAGE = f"biogemt/agentomics:{get_version()}"
 DEVELOPMENT_IMAGE = "agentomics:dev"
 CONTAINER_PYTHON = "/opt/conda/envs/agentomics-env/bin/python"
 
+PROXY_ENV_VAR_NAMES = (
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "ALL_PROXY",
+    "NO_PROXY"
+)
+
+
+def _resolve_proxy_env_vars() -> dict[str, str]:
+    """Resolve proxy variables from the environment and .env file."""
+
+    env_vars: dict[str, str] = {}
+    env_file_values: dict[str, str] = {}
+    env_file = Path.cwd() / ".env"
+    if env_file.is_file():
+        for line in env_file.read_text().splitlines():
+            line = line.strip()
+            if line and not line.startswith("#") and "=" in line:
+                name, value = line.split("=", 1)
+                env_file_values[name.strip()] = value.strip()
+
+    for upper_name in PROXY_ENV_VAR_NAMES:
+        lower_name = upper_name.lower()
+        value = (
+            os.environ.get(upper_name)
+            or os.environ.get(lower_name)
+            or env_file_values.get(upper_name)
+            or env_file_values.get(lower_name)
+        )
+        if value:
+            env_vars[upper_name] = value
+            env_vars[lower_name] = value
+    return env_vars
+
+def _proxy_build_arguments() -> list[str]:
+    arguments: list[str] = []
+    for name, value in _resolve_proxy_env_vars().items():
+        arguments.extend(["--build-arg", f"{name}={value}"])
+    return arguments
+
 def create_parser(description: str) -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=description,
@@ -50,6 +90,7 @@ def build_development_image() -> str:
         [
             "docker",
             "build",
+            *_proxy_build_arguments(),
             "--build-arg",
             "REPOSITORY_SOURCE=.",
             "-t",


### PR DESCRIPTION
This PR will:
- Parse from current environment and .env file the proxy env vars, and forward them to the docker build command (triggered when --dev is set)

This ensures that the development works for those organizations that work behind a proxy.